### PR TITLE
Fix signed release packaging

### DIFF
--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -378,6 +378,10 @@ try {
     Copy-Item $sourceCliExe $releaseExe -Force
     } else {
         Write-Host "Reusing signed binaries from $releaseBinDir"
+        # Signing changes the canonical desktop executable after BuildOnly has
+        # created the compatibility copy. Keep both installer inputs identical
+        # by refreshing the legacy name from the signed canonical binary.
+        Copy-Item $desktopExe $legacyDesktopExe -Force
     }
 
     $verifyExecutablesScript = Join-Path $SourceDir "scripts\verify-windows-executables.ps1"


### PR DESCRIPTION
## Summary
- refresh the legacy desktop executable from the signed canonical binary during package-only release runs
- keep installer inputs byte-identical after Azure signing

## Validation
- PowerShell parser check
- git diff --check
- failed release run confirmed signing succeeded and packaging failed only on the stale compatibility copy

Fixes the v0.43.0 draft-release packaging failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows release packages now consistently use the latest signed desktop executable when reusing existing binaries.
  * Prevented stale executable files from being included in installers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->