### PR TITLE
Prepare Ceiling 0.43.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Ceiling] 0.43.0 - Unreleased
+## [Ceiling] 0.43.1 - Unreleased
 
 ### Added
 - Add a persistent, taskbar-adjacent capacity strip with provider-aware usage lanes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexbar"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "codexbar-desktop-tauri"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "chrono",
  "codexbar",

--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop-tauri",
   "private": true,
-  "version": "0.43.0",
+  "version": "0.43.1",
   "packageManager": "pnpm@10.18.1",
   "type": "module",
   "scripts": {

--- a/apps/desktop-tauri/src-tauri/Cargo.toml
+++ b/apps/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexbar-desktop-tauri"
-version = "0.43.0"
+version = "0.43.1"
 edition = "2024"
 publish = false
 

--- a/apps/desktop-tauri/src-tauri/tauri.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ceiling",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "identifier": "io.github.tsouth89.ceiling",
   "build": {
     "beforeDevCommand": "pnpm run dev",

--- a/docs/release/ci-cd.md
+++ b/docs/release/ci-cd.md
@@ -12,14 +12,14 @@ that covers the change:
 ```powershell
 powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1
 powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -Format -Clippy
-powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -All -Version 0.43.0
+powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -All -Version 0.43.1
 ```
 
 ## Signed release flow
 
 1. Merge the release PR into protected `main` after all required checks pass.
 2. Create and push an annotated tag that exactly matches the repository version,
-   for example `v0.43.0`.
+   for example `v0.43.1`.
 3. The `Signed Windows Release` workflow builds, signs, verifies, smoke-tests,
    and uploads four assets to a draft GitHub release.
 4. Review the draft notes and manually test the downloaded installer and
@@ -39,11 +39,11 @@ subject, so there is no client secret or certificate private key in GitHub.
 The signed workflow deliberately separates compilation from packaging:
 
 ```powershell
-.\scripts\windows-release-build.ps1 -Ref v0.43.0 -BuildOnly
+.\scripts\windows-release-build.ps1 -Ref v0.43.1 -BuildOnly
 # Sign ceiling.exe and codexbar-cli.exe.
-.\scripts\windows-release-build.ps1 -Ref v0.43.0 -PackageOnly
-# Sign Ceiling-0.43.0-Setup.exe.
-.\scripts\finalize-windows-release.ps1 -Version 0.43.0
+.\scripts\windows-release-build.ps1 -Ref v0.43.1 -PackageOnly
+# Sign Ceiling-0.43.1-Setup.exe.
+.\scripts\finalize-windows-release.ps1 -Version 0.43.1
 ```
 
 `-BuildOnly` prevents unsigned binaries from being packaged. `-PackageOnly`

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexbar"
-version = "0.43.0"
+version = "0.43.1"
 edition = "2024"
 authors = ["Ceiling Contributors"]
 description = "Local-first Windows companion for monitoring AI capacity and reset times"


### PR DESCRIPTION
## Summary
- bump Ceiling release metadata from 0.43.0 to 0.43.1
- update the changelog and release-command examples
- preserve the immutable failed v0.43.0 tag while preparing the corrected first draft release

## Validation
- Cargo metadata for both Rust packages
- JSON parsing for Tauri and frontend package versions
- cross-file version consistency check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application and package version to **0.43.1**.
  * Updated the changelog and release documentation with the new version information.
  * Aligned desktop release configuration and documented build, packaging, signing, and finalization steps with version **0.43.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->