### PR TITLE
Fix release page image hosting

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -10,7 +10,11 @@
     />
     <meta name="theme-color" content="#050607" />
     <link rel="canonical" href="https://ceiling.win/" />
-    <link rel="icon" href="/favicon.png" type="image/png" />
+    <link
+      rel="icon"
+      href="https://raw.githubusercontent.com/tsouth89/ceiling/main/site/favicon.png"
+      type="image/png"
+    />
 
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Ceiling — Stay below the ceiling." />
@@ -19,14 +23,20 @@
       content="AI usage in one quiet, local-first Windows app."
     />
     <meta property="og:url" content="https://ceiling.win/" />
-    <meta property="og:image" content="https://ceiling.win/ceiling-ui.png" />
+    <meta
+      property="og:image"
+      content="https://raw.githubusercontent.com/tsouth89/ceiling/main/site/ceiling-ui.png"
+    />
     <meta property="og:image:width" content="659" />
     <meta property="og:image:height" content="821" />
     <meta property="og:image:alt" content="Ceiling's floating capacity bar and usage overview" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Ceiling — Stay below the ceiling." />
     <meta name="twitter:description" content="AI usage in one quiet Windows app." />
-    <meta name="twitter:image" content="https://ceiling.win/ceiling-ui.png" />
+    <meta
+      name="twitter:image"
+      content="https://raw.githubusercontent.com/tsouth89/ceiling/main/site/ceiling-ui.png"
+    />
 
     <style>
       :root {
@@ -336,7 +346,10 @@
     <div class="page">
       <header class="topbar">
         <a class="brand" href="/" aria-label="Ceiling home">
-          <img src="/favicon.png" alt="" />
+          <img
+            src="https://raw.githubusercontent.com/tsouth89/ceiling/main/site/favicon.png"
+            alt=""
+          />
           <span>Ceiling</span>
         </a>
         <a class="github" href="https://github.com/tsouth89/ceiling">GitHub</a>
@@ -362,7 +375,7 @@
         <section class="product" aria-label="Ceiling interface preview">
           <div class="floatbar">
             <img
-              src="/ceiling-floatbar.png"
+              src="https://raw.githubusercontent.com/tsouth89/ceiling/main/site/ceiling-floatbar.png"
               width="406"
               height="38"
               alt="Ceiling's floating capacity bar showing Claude, Cursor, and Codex usage"
@@ -372,7 +385,7 @@
           <div class="dashboard-frame">
             <div class="dashboard-inner">
               <img
-                src="/ceiling-dashboard.png"
+                src="https://raw.githubusercontent.com/tsouth89/ceiling/main/site/ceiling-dashboard.png"
                 width="577"
                 height="689"
                 alt="Ceiling's Windows dashboard showing Codex, Claude, and Cursor usage"


### PR DESCRIPTION
## Summary
- serve release-page images from the repository's public raw asset URLs
- avoid broken image requests from the current Cloudflare worker route

## Validation
- verified every referenced image returns HTTP 200 with an image content type
- ran `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated favicon, social preview images, and hero section visuals to load reliably from hosted image URLs.
  * Improved image availability when viewing or sharing the site across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->