### PR TITLE
Support mixed-monitor taskbars

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/floatbar/taskbar.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/taskbar.rs
@@ -8,7 +8,9 @@ const OBSTACLE_CLEARANCE: i32 = 6;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskbarLayout {
     pub bounds: Rect,
+    pub monitor_bounds: Rect,
     pub obstacles: Vec<Rect>,
+    pub primary: bool,
 }
 
 impl TaskbarLayout {
@@ -41,135 +43,159 @@ impl TaskbarLayout {
     }
 }
 
+pub fn primary_layout(layouts: &[TaskbarLayout]) -> Option<&TaskbarLayout> {
+    layouts
+        .iter()
+        .find(|layout| layout.primary)
+        .or_else(|| layouts.first())
+}
+
+/// Choose the taskbar belonging to the monitor containing `point`.
+///
+/// Windows' virtual screen coordinates may be negative and monitors may have
+/// unrelated physical sizes or DPI scales. Monitor rectangles from Win32 are
+/// therefore compared directly without converting through logical pixels.
+pub fn select_for_point(layouts: &[TaskbarLayout], point: Point) -> Option<&TaskbarLayout> {
+    layouts
+        .iter()
+        .find(|layout| contains(layout.monitor_bounds, point))
+        .or_else(|| {
+            layouts
+                .iter()
+                .min_by_key(|layout| distance_squared(layout.monitor_bounds, point))
+        })
+}
+
+fn contains(rect: Rect, point: Point) -> bool {
+    point.x >= rect.left && point.x < rect.right && point.y >= rect.top && point.y < rect.bottom
+}
+
+fn distance_squared(rect: Rect, point: Point) -> i64 {
+    let dx = if point.x < rect.left {
+        i64::from(rect.left) - i64::from(point.x)
+    } else if point.x >= rect.right {
+        i64::from(point.x) - i64::from(rect.right.saturating_sub(1))
+    } else {
+        0
+    };
+    let dy = if point.y < rect.top {
+        i64::from(rect.top) - i64::from(point.y)
+    } else if point.y >= rect.bottom {
+        i64::from(point.y) - i64::from(rect.bottom.saturating_sub(1))
+    } else {
+        0
+    };
+    dx.saturating_mul(dx).saturating_add(dy.saturating_mul(dy))
+}
+
 #[cfg(not(windows))]
-pub fn discover() -> Option<TaskbarLayout> {
-    None
+pub fn discover_all() -> Vec<TaskbarLayout> {
+    Vec::new()
 }
 
 #[cfg(windows)]
-pub fn discover() -> Option<TaskbarLayout> {
-    use std::ffi::c_void;
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct WinRect {
+    left: i32,
+    top: i32,
+    right: i32,
+    bottom: i32,
+}
 
-    #[repr(C)]
-    #[derive(Clone, Copy)]
-    struct WinRect {
-        left: i32,
-        top: i32,
-        right: i32,
-        bottom: i32,
-    }
-
-    impl From<WinRect> for Rect {
-        fn from(value: WinRect) -> Self {
-            Self {
-                left: value.left,
-                top: value.top,
-                right: value.right,
-                bottom: value.bottom,
-            }
+#[cfg(windows)]
+impl From<WinRect> for Rect {
+    fn from(value: WinRect) -> Self {
+        Self {
+            left: value.left,
+            top: value.top,
+            right: value.right,
+            bottom: value.bottom,
         }
     }
+}
 
-    struct EnumContext {
-        taskbar: Rect,
-        obstacles: Vec<Rect>,
-    }
+#[cfg(windows)]
+struct ChildEnumContext {
+    taskbar: Rect,
+    obstacles: Vec<Rect>,
+}
 
-    unsafe extern "system" fn collect_child(hwnd: isize, lparam: isize) -> i32 {
+#[cfg(windows)]
+struct TaskbarEnumContext {
+    layouts: Vec<TaskbarLayout>,
+}
+
+#[cfg(windows)]
+pub fn discover_all() -> Vec<TaskbarLayout> {
+    unsafe extern "system" fn collect_taskbar(hwnd: isize, lparam: isize) -> i32 {
         unsafe {
-            if IsWindowVisible(hwnd) == 0 {
+            let Some(class_name) = window_class(hwnd) else {
+                return 1;
+            };
+            let primary = class_name == "Shell_TrayWnd";
+            if !primary && class_name != "Shell_SecondaryTrayWnd" {
                 return 1;
             }
-            let context = &mut *(lparam as *mut EnumContext);
-            let mut raw = WinRect {
-                left: 0,
-                top: 0,
-                right: 0,
-                bottom: 0,
-            };
-            if GetWindowRect(hwnd, (&mut raw as *mut WinRect).cast()) == 0 {
-                return 1;
-            }
-            let rect = Rect::from(raw);
-            let width = rect.width();
-            let height = rect.height();
-            let horizontal = context.taskbar.width() >= context.taskbar.height();
-            let taskbar_major = if horizontal {
-                context.taskbar.width()
-            } else {
-                context.taskbar.height()
-            };
-            let rect_major = if horizontal { width } else { height };
-            let rect_cross = if horizontal { height } else { width };
-            let taskbar_cross = if horizontal {
-                context.taskbar.height()
-            } else {
-                context.taskbar.width()
-            };
 
-            // Ignore invalid rectangles and shell composition containers that
-            // span almost the complete taskbar. Smaller visible children are
-            // useful obstacle hints on both classic and modern taskbars.
-            if width > 0
-                && height > 0
-                && rect_major < taskbar_major.saturating_mul(3) / 4
-                && rect_cross <= taskbar_cross.saturating_mul(2)
-                && rect.left < context.taskbar.right
-                && rect.right > context.taskbar.left
-                && rect.top < context.taskbar.bottom
-                && rect.bottom > context.taskbar.top
-            {
-                context.obstacles.push(rect);
+            let context = &mut *(lparam as *mut TaskbarEnumContext);
+            if let Some(layout) = layout_for_taskbar(hwnd, primary) {
+                context.layouts.push(layout);
             }
             1
         }
     }
 
     unsafe {
-        let shell_class = wide("Shell_TrayWnd");
-        let tray_class = wide("TrayNotifyWnd");
-        let shell = FindWindowW(shell_class.as_ptr(), std::ptr::null());
-        if shell == 0 {
-            return None;
-        }
-        let tray = FindWindowExW(shell, 0, tray_class.as_ptr(), std::ptr::null());
-
-        let mut shell_rect = WinRect {
-            left: 0,
-            top: 0,
-            right: 0,
-            bottom: 0,
+        let mut context = TaskbarEnumContext {
+            layouts: Vec::new(),
         };
-        if GetWindowRect(shell, (&mut shell_rect as *mut WinRect).cast()) == 0 {
-            return None;
-        }
-        let bounds = Rect::from(shell_rect);
+        EnumWindows(
+            Some(collect_taskbar),
+            (&mut context as *mut TaskbarEnumContext).cast::<std::ffi::c_void>() as isize,
+        );
+        context.layouts.sort_by_key(|layout| {
+            (
+                !layout.primary,
+                layout.monitor_bounds.left,
+                layout.monitor_bounds.top,
+                layout.bounds.left,
+                layout.bounds.top,
+            )
+        });
+        context.layouts.dedup_by(|left, right| {
+            left.monitor_bounds == right.monitor_bounds && left.bounds == right.bounds
+        });
+        context.layouts
+    }
+}
+
+#[cfg(windows)]
+unsafe fn layout_for_taskbar(hwnd: isize, primary: bool) -> Option<TaskbarLayout> {
+    unsafe {
+        let bounds = window_rect(hwnd)?;
         if bounds.width() <= 0 || bounds.height() <= 0 {
             return None;
         }
 
-        let mut context = EnumContext {
+        let monitor_bounds = monitor_rect(hwnd).unwrap_or(bounds);
+        let mut context = ChildEnumContext {
             taskbar: bounds,
             obstacles: Vec::new(),
         };
         EnumChildWindows(
-            shell,
+            hwnd,
             Some(collect_child),
-            (&mut context as *mut EnumContext).cast::<c_void>() as isize,
+            (&mut context as *mut ChildEnumContext).cast::<std::ffi::c_void>() as isize,
         );
 
-        // Always reserve the notification area even if child enumeration was
-        // restricted by a shell replacement.
-        if tray != 0 {
-            let mut tray_rect = WinRect {
-                left: 0,
-                top: 0,
-                right: 0,
-                bottom: 0,
-            };
-            if GetWindowRect(tray, (&mut tray_rect as *mut WinRect).cast()) != 0 {
-                context.obstacles.push(Rect::from(tray_rect));
-            }
+        // Reserve the notification area when this taskbar exposes one. Some
+        // Windows versions omit TrayNotifyWnd from secondary taskbars; child
+        // enumeration still captures the controls that are actually present.
+        let tray_class = wide("TrayNotifyWnd");
+        let tray = FindWindowExW(hwnd, 0, tray_class.as_ptr(), std::ptr::null());
+        if let Some(tray_rect) = window_rect(tray) {
+            context.obstacles.push(tray_rect);
         }
 
         context
@@ -178,9 +204,94 @@ pub fn discover() -> Option<TaskbarLayout> {
         context.obstacles.dedup();
         Some(TaskbarLayout {
             bounds,
+            monitor_bounds,
             obstacles: context.obstacles,
+            primary,
         })
     }
+}
+
+#[cfg(windows)]
+unsafe extern "system" fn collect_child(hwnd: isize, lparam: isize) -> i32 {
+    unsafe {
+        if IsWindowVisible(hwnd) == 0 {
+            return 1;
+        }
+        let context = &mut *(lparam as *mut ChildEnumContext);
+        let Some(rect) = window_rect(hwnd) else {
+            return 1;
+        };
+        let width = rect.width();
+        let height = rect.height();
+        let horizontal = context.taskbar.width() >= context.taskbar.height();
+        let taskbar_major = if horizontal {
+            context.taskbar.width()
+        } else {
+            context.taskbar.height()
+        };
+        let rect_major = if horizontal { width } else { height };
+        let rect_cross = if horizontal { height } else { width };
+        let taskbar_cross = if horizontal {
+            context.taskbar.height()
+        } else {
+            context.taskbar.width()
+        };
+
+        // Ignore invalid rectangles and shell composition containers that
+        // span almost the complete taskbar. Smaller visible children are
+        // useful obstacle hints on both classic and modern taskbars.
+        if width > 0
+            && height > 0
+            && rect_major < taskbar_major.saturating_mul(3) / 4
+            && rect_cross <= taskbar_cross.saturating_mul(2)
+            && rect.left < context.taskbar.right
+            && rect.right > context.taskbar.left
+            && rect.top < context.taskbar.bottom
+            && rect.bottom > context.taskbar.top
+        {
+            context.obstacles.push(rect);
+        }
+        1
+    }
+}
+
+#[cfg(windows)]
+unsafe fn window_rect(hwnd: isize) -> Option<Rect> {
+    if hwnd == 0 {
+        return None;
+    }
+    let mut raw = WinRect {
+        left: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+    };
+    (unsafe { GetWindowRect(hwnd, (&mut raw as *mut WinRect).cast()) } != 0)
+        .then_some(Rect::from(raw))
+}
+
+#[cfg(windows)]
+unsafe fn monitor_rect(hwnd: isize) -> Option<Rect> {
+    let (left, top, right, bottom) = crate::shell::dwm::monitor_bounds_for_window(hwnd)?;
+    Some(Rect {
+        left,
+        top,
+        right,
+        bottom,
+    })
+}
+
+#[cfg(windows)]
+unsafe fn window_class(hwnd: isize) -> Option<String> {
+    let mut class_name = [0_u16; 64];
+    let length = unsafe {
+        GetClassNameW(
+            hwnd,
+            class_name.as_mut_ptr(),
+            class_name.len().try_into().ok()?,
+        )
+    };
+    (length > 0).then(|| String::from_utf16_lossy(&class_name[..length as usize]))
 }
 
 #[cfg(windows)]
@@ -191,7 +302,10 @@ fn wide(value: &str) -> Vec<u16> {
 #[cfg(windows)]
 #[link(name = "user32")]
 unsafe extern "system" {
-    fn FindWindowW(class_name: *const u16, window_name: *const u16) -> isize;
+    fn EnumWindows(
+        callback: Option<unsafe extern "system" fn(isize, isize) -> i32>,
+        lparam: isize,
+    ) -> i32;
     fn FindWindowExW(
         parent: isize,
         child_after: isize,
@@ -199,10 +313,188 @@ unsafe extern "system" {
         window_name: *const u16,
     ) -> isize;
     fn GetWindowRect(hwnd: isize, rect: *mut std::ffi::c_void) -> i32;
+    fn GetClassNameW(hwnd: isize, class_name: *mut u16, max_count: i32) -> i32;
     fn EnumChildWindows(
         parent: isize,
         callback: Option<unsafe extern "system" fn(isize, isize) -> i32>,
         lparam: isize,
     ) -> i32;
     fn IsWindowVisible(hwnd: isize) -> i32;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn layout(monitor_bounds: Rect, bounds: Rect, primary: bool) -> TaskbarLayout {
+        TaskbarLayout {
+            bounds,
+            monitor_bounds,
+            obstacles: Vec::new(),
+            primary,
+        }
+    }
+
+    #[test]
+    fn mixed_1440p_and_1080p_monitors_select_by_physical_center() {
+        let layouts = [
+            layout(
+                Rect {
+                    left: 0,
+                    top: 0,
+                    right: 2560,
+                    bottom: 1440,
+                },
+                Rect {
+                    left: 0,
+                    top: 1392,
+                    right: 2560,
+                    bottom: 1440,
+                },
+                true,
+            ),
+            layout(
+                Rect {
+                    left: -1920,
+                    top: 365,
+                    right: 0,
+                    bottom: 1445,
+                },
+                Rect {
+                    left: -1920,
+                    top: 1397,
+                    right: 0,
+                    bottom: 1445,
+                },
+                false,
+            ),
+        ];
+
+        assert!(
+            select_for_point(&layouts, Point { x: 1800, y: 1400 })
+                .unwrap()
+                .primary
+        );
+        assert!(
+            !select_for_point(&layouts, Point { x: -900, y: 1405 })
+                .unwrap()
+                .primary
+        );
+    }
+
+    #[test]
+    fn mixed_dpi_selection_never_converts_physical_coordinates() {
+        // The 1440p monitor may be 2048x1152 logical pixels at 125%, but the
+        // Win32 monitor/taskbar rectangles remain 2560x1440 physical pixels.
+        let layouts = [
+            layout(
+                Rect {
+                    left: 0,
+                    top: 0,
+                    right: 2560,
+                    bottom: 1440,
+                },
+                Rect {
+                    left: 0,
+                    top: 1392,
+                    right: 2560,
+                    bottom: 1440,
+                },
+                true,
+            ),
+            layout(
+                Rect {
+                    left: 2560,
+                    top: 365,
+                    right: 4480,
+                    bottom: 1445,
+                },
+                Rect {
+                    left: 2560,
+                    top: 1397,
+                    right: 4480,
+                    bottom: 1445,
+                },
+                false,
+            ),
+        ];
+
+        assert_eq!(
+            select_for_point(&layouts, Point { x: 3200, y: 1405 })
+                .unwrap()
+                .monitor_bounds,
+            layouts[1].monitor_bounds
+        );
+    }
+
+    #[test]
+    fn point_between_monitors_uses_the_nearest_physical_monitor() {
+        let layouts = [
+            layout(
+                Rect {
+                    left: 0,
+                    top: 0,
+                    right: 1920,
+                    bottom: 1080,
+                },
+                Rect {
+                    left: 0,
+                    top: 1032,
+                    right: 1920,
+                    bottom: 1080,
+                },
+                true,
+            ),
+            layout(
+                Rect {
+                    left: 2200,
+                    top: 0,
+                    right: 4760,
+                    bottom: 1440,
+                },
+                Rect {
+                    left: 2200,
+                    top: 1392,
+                    right: 4760,
+                    bottom: 1440,
+                },
+                false,
+            ),
+        ];
+
+        assert!(
+            select_for_point(&layouts, Point { x: 2000, y: 700 })
+                .unwrap()
+                .primary
+        );
+        assert!(
+            !select_for_point(&layouts, Point { x: 2150, y: 700 })
+                .unwrap()
+                .primary
+        );
+    }
+
+    #[test]
+    fn primary_layout_falls_back_deterministically() {
+        let secondary = layout(
+            Rect {
+                left: 1920,
+                top: 0,
+                right: 3840,
+                bottom: 1080,
+            },
+            Rect {
+                left: 1920,
+                top: 1032,
+                right: 3840,
+                bottom: 1080,
+            },
+            false,
+        );
+        assert_eq!(
+            primary_layout(std::slice::from_ref(&secondary)),
+            Some(&secondary)
+        );
+        assert_eq!(primary_layout(&[]), None);
+    }
 }

--- a/apps/desktop-tauri/src-tauri/src/floatbar/window.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/window.rs
@@ -240,28 +240,40 @@ pub fn resize(
 /// discovery fails or no gap can fit the complete bar, the current position is
 /// deliberately left untouched.
 pub fn reposition_taskbar(window: &tauri::WebviewWindow, prefer_current: bool) {
-    let Some(layout) = super::taskbar::discover() else {
-        return;
-    };
-    reposition_taskbar_with_layout(window, &layout, prefer_current);
+    let layouts = super::taskbar::discover_all();
+    reposition_taskbar_with_layouts(window, &layouts, prefer_current);
 }
 
-fn reposition_taskbar_with_layout(
+fn reposition_taskbar_with_layouts(
     window: &tauri::WebviewWindow,
-    layout: &TaskbarLayout,
+    layouts: &[TaskbarLayout],
     prefer_current: bool,
 ) {
     let Ok(size) = window.outer_size() else {
         return;
     };
-    let preferred = if prefer_current {
-        window
-            .outer_position()
-            .map(|position| Point {
-                x: position.x,
-                y: position.y,
+    let current = window.outer_position().ok().map(|position| Point {
+        x: position.x,
+        y: position.y,
+    });
+    let layout = if prefer_current {
+        current
+            .and_then(|position| {
+                let center = Point {
+                    x: position.x.saturating_add((size.width / 2) as i32),
+                    y: position.y.saturating_add((size.height / 2) as i32),
+                };
+                super::taskbar::select_for_point(layouts, center)
             })
-            .unwrap_or_else(|_| layout.preferred_anchor())
+            .or_else(|| super::taskbar::primary_layout(layouts))
+    } else {
+        super::taskbar::primary_layout(layouts)
+    };
+    let Some(layout) = layout else {
+        return;
+    };
+    let preferred = if prefer_current {
+        current.unwrap_or_else(|| layout.preferred_anchor())
     } else {
         layout.preferred_anchor()
     };
@@ -298,7 +310,6 @@ pub fn install_z_order_guard(app: tauri::AppHandle) {
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
             let mut ticks = 0_u64;
-            let mut last_taskbar_layout: Option<TaskbarLayout> = None;
             loop {
                 interval.tick().await;
                 let Some(window) = app.get_webview_window(FLOATBAR_LABEL) else {
@@ -332,15 +343,8 @@ pub fn install_z_order_guard(app: tauri::AppHandle) {
                 if visible && repair_layout {
                     let settings = codexbar::settings::Settings::load();
                     if settings.float_bar_style == "taskbar" {
-                        let layout = super::taskbar::discover();
-                        if layout != last_taskbar_layout {
-                            if let Some(layout) = layout.as_ref() {
-                                reposition_taskbar_with_layout(&window, layout, true);
-                            }
-                            last_taskbar_layout = layout;
-                        }
-                    } else {
-                        last_taskbar_layout = None;
+                        let layouts = super::taskbar::discover_all();
+                        reposition_taskbar_with_layouts(&window, &layouts, true);
                     }
                 }
             }

--- a/apps/desktop-tauri/src-tauri/src/shell/dwm.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/dwm.rs
@@ -75,6 +75,36 @@ unsafe extern "system" {
     fn GetMonitorInfoW(hmonitor: isize, info: *mut MonitorInfo) -> i32;
 }
 
+/// Return the physical Win32 monitor rectangle containing `hwnd`.
+///
+/// Keeping this query beside the existing DWM declarations avoids duplicate
+/// extern signatures in other native window features.
+#[cfg(windows)]
+pub(crate) fn monitor_bounds_for_window(hwnd: isize) -> Option<(i32, i32, i32, i32)> {
+    const MONITOR_DEFAULTTONEAREST: u32 = 2;
+    unsafe {
+        let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+        if monitor == 0 {
+            return None;
+        }
+        let mut info = MonitorInfo {
+            cb_size: std::mem::size_of::<MonitorInfo>() as u32,
+            rc_monitor: WinRect::default(),
+            rc_work: WinRect::default(),
+            dw_flags: 0,
+        };
+        if GetMonitorInfoW(monitor, &mut info) == 0 {
+            return None;
+        }
+        Some((
+            info.rc_monitor.left,
+            info.rc_monitor.top,
+            info.rc_monitor.right,
+            info.rc_monitor.bottom,
+        ))
+    }
+}
+
 #[cfg(windows)]
 #[link(name = "comctl32")]
 unsafe extern "system" {


### PR DESCRIPTION
## Summary

- enumerate primary and secondary Windows taskbars instead of assuming `Shell_TrayWnd`
- associate each taskbar with its physical monitor rectangle
- choose the taskbar containing the floatbar's physical center, with deterministic nearest/primary fallbacks
- reevaluate monitor selection during taskbar recovery
- share the existing Win32 monitor query to keep one FFI signature

## Why

The previous taskbar foundation used physical pixels correctly but always discovered the primary taskbar. On mixed-resolution systems, a saved or moved floatbar on a secondary display could therefore snap back to the primary monitor.

## Validation

- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` (339 tests)
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml floatbar` (22 tests)
- `cargo clippy --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --all --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml`
- live Windows probe confirmed `Shell_TrayWnd` on 2560x1440 and `Shell_SecondaryTrayWnd` on vertically offset 1920x1080 monitor

Linear: SOU-173


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved floatbar positioning across multiple monitors, including mixed resolutions and DPI settings.
  * The floatbar now selects the taskbar nearest to its current location and handles negative virtual-screen coordinates correctly.
  * Improved Windows taskbar detection, including notification-area space and dynamic z-order repairs.
  * Added more reliable monitor boundary detection for window positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->