### PR TITLE
Fix release cache cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,8 @@ jobs:
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: apps/desktop-tauri/pnpm-lock.yaml
+          # The release builder uses its own WorkRoot pnpm store. Enabling the
+          # setup-node cache here points at an unused store and fails in cleanup.
 
       - name: Check Tauri package versions
         shell: pwsh


### PR DESCRIPTION
## Summary
- stop `actions/setup-node` from saving a pnpm cache path the release builder never uses
- leave the release builder's explicit WorkRoot store unchanged

## Why
The 0.43.3-beta.2 signed build, signing, installer smoke test, release doctor, artifact upload, and draft creation all passed. The workflow was marked failed afterward because setup-node tried to save its unused default pnpm store and rejected the missing path.

## Validation
- parsed `.github/workflows/release.yml` with PyYAML
- `git diff --check`

Linear: SOU-181 tracks the larger Rust release-cache optimization separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Windows signed release process by preventing cleanup failures caused by conflicting package cache settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->