### PR TITLE
Keep chart tooltips inside the dashboard

### DIFF
--- a/apps/desktop-tauri/src/components/charts/BarChart.tsx
+++ b/apps/desktop-tauri/src/components/charts/BarChart.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from "react";
+import { ChartTooltip } from "./ChartTooltip";
 import { useChartAnimation } from "./useChartAnimation";
 
 /**
@@ -124,11 +125,7 @@ export function BarChart({
                 className="chart__bar"
                 onMouseMove={(e) => onMove(e, i)}
                 onMouseLeave={onLeave}
-              >
-                <title>
-                  {p.label}: {fmt(p.value)}
-                </title>
-              </rect>
+              />
               {isPeak && (
                 <rect
                   x={x}
@@ -151,14 +148,10 @@ export function BarChart({
         <span>{data[data.length - 1].label.slice(-5)}</span>
       </div>
       {hover && !anim.running && (
-        <div
-          className="chart__tooltip"
-          style={{ left: hover.x, top: hover.y }}
-          role="tooltip"
-        >
+        <ChartTooltip containerRef={containerRef} x={hover.x} y={hover.y}>
           <span className="chart__tooltip-label">{data[hover.i].label}</span>
           <strong>{fmt(data[hover.i].value)}</strong>
-        </div>
+        </ChartTooltip>
       )}
     </div>
   );

--- a/apps/desktop-tauri/src/components/charts/ChartTooltip.test.ts
+++ b/apps/desktop-tauri/src/components/charts/ChartTooltip.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { clampChartTooltipLeft } from "./ChartTooltip";
+
+describe("clampChartTooltipLeft", () => {
+  it("centers a tooltip when there is room", () => {
+    expect(clampChartTooltipLeft(140, 100, 280)).toBe(90);
+  });
+
+  it("keeps a tooltip inside the right edge", () => {
+    expect(clampChartTooltipLeft(274, 120, 280)).toBe(152);
+  });
+
+  it("keeps a tooltip inside the left edge", () => {
+    expect(clampChartTooltipLeft(2, 120, 280)).toBe(8);
+  });
+});

--- a/apps/desktop-tauri/src/components/charts/ChartTooltip.tsx
+++ b/apps/desktop-tauri/src/components/charts/ChartTooltip.tsx
@@ -1,0 +1,51 @@
+import { useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from "react";
+
+const TOOLTIP_MARGIN = 8;
+
+export function clampChartTooltipLeft(
+  anchorX: number,
+  tooltipWidth: number,
+  containerWidth: number,
+  margin = TOOLTIP_MARGIN,
+): number {
+  const centered = anchorX - tooltipWidth / 2;
+  const maximum = Math.max(margin, containerWidth - tooltipWidth - margin);
+  return Math.min(Math.max(centered, margin), maximum);
+}
+
+interface ChartTooltipProps {
+  containerRef: RefObject<HTMLDivElement | null>;
+  x: number;
+  y: number;
+  children: ReactNode;
+}
+
+/** A measured tooltip that stays inside its chart container. */
+export function ChartTooltip({ containerRef, x, y, children }: ChartTooltipProps) {
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const [left, setLeft] = useState(TOOLTIP_MARGIN);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const tooltip = tooltipRef.current;
+    if (!container || !tooltip) return;
+
+    const nextLeft = clampChartTooltipLeft(
+      x,
+      tooltip.getBoundingClientRect().width,
+      container.getBoundingClientRect().width,
+    );
+    setLeft((current) => (current === nextLeft ? current : nextLeft));
+  }, [containerRef, x, children]);
+
+  return (
+    <div
+      ref={tooltipRef}
+      className="chart__tooltip"
+      style={{ left, top: y }}
+      role="tooltip"
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/desktop-tauri/src/components/charts/LineChart.tsx
+++ b/apps/desktop-tauri/src/components/charts/LineChart.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import { ChartTooltip } from "./ChartTooltip";
 import { useChartAnimation } from "./useChartAnimation";
 
 /**
@@ -142,11 +143,7 @@ export function LineChart({
             className="chart__point"
             onMouseMove={(e) => onPointMove(e, i)}
             onMouseLeave={onLeave}
-          >
-            <title>
-              {tooltipFmt(p.label)}: {fmt(p.value)}
-            </title>
-          </circle>
+          />
         ))}
       </svg>
       <div className="chart__axis">
@@ -155,14 +152,10 @@ export function LineChart({
         <span>{axisFmt(data[data.length - 1].label)}</span>
       </div>
       {hover && !anim.running && (
-        <div
-          className="chart__tooltip"
-          style={{ left: hover.x, top: hover.y }}
-          role="tooltip"
-        >
+        <ChartTooltip containerRef={containerRef} x={hover.x} y={hover.y}>
           <span className="chart__tooltip-label">{tooltipFmt(data[hover.i].label)}</span>
           <strong>{fmt(data[hover.i].value)}</strong>
-        </div>
+        </ChartTooltip>
       )}
     </div>
   );

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -2964,6 +2964,8 @@ body:has(.tray-panel-reveal) {
 
 .chart {
   position: relative;
+  min-width: 0;
+  overflow-x: clip;
 }
 
 .chart__empty {
@@ -3002,9 +3004,13 @@ body:has(.tray-panel-reveal) {
   font-size: 0.72rem;
   line-height: 1.3;
   white-space: nowrap;
+  box-sizing: border-box;
+  max-width: calc(100% - 16px);
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-variant-numeric: tabular-nums;
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
-  transform: translate(-50%, calc(-100% - 8px));
+  transform: translateY(calc(-100% - 8px));
 }
 
 .chart__tooltip-label {

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/UsageBreakdownChart.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/UsageBreakdownChart.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from "react";
+import { ChartTooltip } from "../../../../../components/charts/ChartTooltip";
 import { serviceColorVar } from "../../../../../components/charts/chartPalette";
 import { useChartAnimation } from "../../../../../components/charts/useChartAnimation";
 import type { DailyUsageBreakdown } from "../../../../../types/bridge";
@@ -129,11 +130,7 @@ export function UsageBreakdownChart({
                       className="chart__stack-rect"
                       onMouseMove={(e) => onSegMove(e, label, svc.creditsUsed)}
                       onMouseLeave={onSegLeave}
-                    >
-                      <title>
-                        {day.day} {svc.service}: {svc.creditsUsed.toFixed(2)}
-                      </title>
-                    </rect>
+                    />
                   );
                   xOffset += w;
                   return rect;
@@ -156,14 +153,10 @@ export function UsageBreakdownChart({
           </div>
         )}
         {hover && !anim.running && (
-          <div
-            className="chart__tooltip"
-            style={{ left: hover.x, top: hover.y }}
-            role="tooltip"
-          >
+          <ChartTooltip containerRef={containerRef} x={hover.x} y={hover.y}>
             <span className="chart__tooltip-label">{hover.label}</span>
             <strong>{hover.value.toFixed(2)}</strong>
-          </div>
+          </ChartTooltip>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- measure and clamp chart tooltips inside their chart container
- remove duplicate browser-native SVG tooltips
- apply the shared behavior to line, bar, and usage-breakdown charts
- prevent tooltip hover from creating horizontal page overflow

## Root cause

The styled tooltip was centered directly on the pointer without accounting for its rendered width. Points near the dashboard edge placed part of the tooltip outside the window. SVG title elements also produced a second native tooltip.

## Validation

- pnpm test -- src/components/charts/ChartTooltip.test.ts src/surfaces/settings/providers/sections/charts/QuotaHistoryChart.test.tsx
- pnpm run build
- pnpm test (one unrelated ProvidersSidebar timing test failed in the full parallel run, then passed in isolation)

Linear: SOU-187