### PR TITLE
Enlarge the taskbar strip on the site

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -222,7 +222,7 @@
       }
 
       .taskbar {
-        width: min(620px, 94vw);
+        width: min(840px, 96vw);
         overflow: hidden;
         border: 1px solid rgba(255, 255, 255, 0.09);
         border-radius: 9px;
@@ -294,7 +294,7 @@
         }
 
         .taskbar {
-          width: min(540px, 84vw);
+          width: min(720px, 88vw);
         }
 
         .dashboard-frame {
@@ -309,7 +309,7 @@
         }
 
         .taskbar {
-          width: min(490px, 76vw);
+          width: min(640px, 80vw);
         }
       }
 

--- a/site/index.html
+++ b/site/index.html
@@ -222,7 +222,7 @@
       }
 
       .taskbar {
-        width: min(840px, 96vw);
+        width: min(840px, 92vw);
         overflow: hidden;
         border: 1px solid rgba(255, 255, 255, 0.09);
         border-radius: 9px;


### PR DESCRIPTION
Keeps the full taskbar strip (weather widget + Start button + Ceiling usage pills) but displays it larger (620px -> 840px, near the screenshot's native width) so the pills and reset times are readable without cropping anything out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the landing page taskbar preview sizing for a wider, more consistent appearance.
  * Adjusted responsive width constraints across key screen-height ranges to enhance the visual layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->