### PR TITLE
Stop conflating inactive windows with provider-level lifted freshness

### DIFF
--- a/apps/desktop-tauri/src/floatbar/FloatBar.css
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.css
@@ -170,16 +170,8 @@ body.floatbar-window #root {
   background: rgba(248, 113, 113, 0.12);
   border-color: rgba(248, 113, 113, 0.28);
 }
-.floatbar__chip--lifted {
-  color: color-mix(in srgb, var(--ceiling-accent, #26b5ce) 85%, white);
-  background: color-mix(in srgb, var(--ceiling-accent, #26b5ce) 16%, transparent);
-  border: 1px dashed color-mix(in srgb, var(--ceiling-accent, #26b5ce) 45%, transparent);
-}
 .floatbar__pill--stale {
   opacity: 0.82;
-}
-.floatbar__pill--lifted {
-  border-style: dashed;
 }
 .floatbar__pill--error {
   border-color: color-mix(in srgb, #f87171 35%, var(--ceiling-glass-border, rgba(255, 255, 255, 0.1)));

--- a/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
@@ -300,9 +300,10 @@ describe("FloatBar", () => {
       expect(container.querySelector(".floatbar__pill--crit")).toBeNull();
       // No tiny companion chip anymore.
       expect(container.querySelector(".floatbar__companion")).toBeNull();
-      // Inactive windows no longer paint the whole provider "lifted" (SOU-152);
-      // the pill stays live and the inactive lane surfaces in the tray detail.
-      expect(container.querySelector(".floatbar__chip--lifted")).toBeNull();
+      // Inactive windows no longer paint the whole provider "lifted" (SOU-152).
+      // The provider timestamp is fresh (set above), so the pill is live with
+      // no state chip at all; the inactive lane surfaces in the tray detail.
+      expect(container.querySelector(".floatbar__chip")).toBeNull();
       expect(container.querySelector(".floatbar__pill--lifted")).toBeNull();
     });
   });

--- a/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
@@ -300,9 +300,10 @@ describe("FloatBar", () => {
       expect(container.querySelector(".floatbar__pill--crit")).toBeNull();
       // No tiny companion chip anymore.
       expect(container.querySelector(".floatbar__companion")).toBeNull();
-      expect(container.querySelector(".floatbar__chip--lifted")?.textContent).toBe(
-        "lifted",
-      );
+      // Inactive windows no longer paint the whole provider "lifted" (SOU-152);
+      // the pill stays live and the inactive lane surfaces in the tray detail.
+      expect(container.querySelector(".floatbar__chip--lifted")).toBeNull();
+      expect(container.querySelector(".floatbar__pill--lifted")).toBeNull();
     });
   });
 

--- a/apps/desktop-tauri/src/floatbar/FloatBar.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.tsx
@@ -228,8 +228,6 @@ function freshnessChipLabel(freshness: CapacityFreshness): string | null {
       return "stale";
     case "error":
       return "error";
-    case "lifted":
-      return "lifted";
     case "live":
       return null;
   }

--- a/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
@@ -140,7 +140,7 @@ describe("capacityPresentation", () => {
     ).toBe("exhausted");
   });
 
-  it("reports freshness precedence error > stale > lifted > live", () => {
+  it("reports freshness precedence error > stale > live", () => {
     expect(capacityFreshness(provider({ error: "fail" }))).toBe("error");
     expect(
       capacityFreshness(
@@ -149,20 +149,29 @@ describe("capacityPresentation", () => {
         }),
       ),
     ).toBe("stale");
+    expect(capacityFreshness(provider())).toBe("live");
+  });
+
+  it("keeps live freshness when only some windows are inactive (SOU-152)", () => {
+    // Inactive windows are surfaced as their own rows, never as a
+    // provider-level "lifted" freshness state.
+    const inactiveRateWindows = [
+      {
+        id: "cursor-auto",
+        title: "Auto",
+        description: "Not currently enforced by Cursor",
+      },
+    ];
+    expect(capacityFreshness(provider({ inactiveRateWindows }))).toBe("live");
+    // A stale timestamp still wins over inactive windows.
     expect(
       capacityFreshness(
         provider({
-          inactiveRateWindows: [
-            {
-              id: "cursor-auto",
-              title: "Auto",
-              description: "Not currently enforced by Cursor",
-            },
-          ],
+          updatedAt: new Date(Date.now() - 20 * 60 * 1000).toISOString(),
+          inactiveRateWindows,
         }),
       ),
-    ).toBe("lifted");
-    expect(capacityFreshness(provider())).toBe("live");
+    ).toBe("stale");
   });
 
   it("separates boost promos from inclusion notes", () => {

--- a/apps/desktop-tauri/src/lib/capacityPresentation.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.ts
@@ -3,7 +3,7 @@ import type {
   RateWindowSnapshot,
 } from "../types/bridge";
 
-export type CapacityFreshness = "live" | "stale" | "error" | "lifted";
+export type CapacityFreshness = "live" | "stale" | "error";
 
 export type ConstrainingWindow = {
   id: string;
@@ -180,7 +180,11 @@ export function providerGlanceStatus(
   return "ok";
 }
 
-/** Strip/flyout freshness: error > stale > lifted > live. */
+/**
+ * Strip/flyout freshness from the provider timestamp and error only:
+ * error > stale > live. Inactive/lifted windows are surfaced as their own
+ * `inactiveRateWindows` rows, never as provider-level freshness (SOU-152).
+ */
 export function capacityFreshness(
   provider: ProviderUsageSnapshot,
   nowMs = Date.now(),
@@ -189,9 +193,6 @@ export function capacityFreshness(
   const updated = Date.parse(provider.updatedAt);
   if (Number.isFinite(updated) && nowMs - updated > STALE_AFTER_MS) {
     return "stale";
-  }
-  if ((provider.inactiveRateWindows?.length ?? 0) > 0) {
-    return "lifted";
   }
   return "live";
 }

--- a/apps/desktop-tauri/src/surfaces/AccountsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/AccountsPanel.tsx
@@ -18,7 +18,7 @@ function statusOf(provider: ProviderUsageSnapshot, nowMs: number): Status {
   const freshness = capacityFreshness(provider, nowMs);
   if (freshness === "error") return "error";
   if (freshness === "stale") return "stale";
-  return "connected"; // live | lifted both count as connected
+  return "connected"; // live counts as connected
 }
 
 function normalizePlan(planName: string | null): string | null {

--- a/docs/CEILING_UI.md
+++ b/docs/CEILING_UI.md
@@ -39,7 +39,7 @@ Usage bars keep calm slate→cyan progression; warn/crit stay amber/red without 
 
 - One glance: provider mark + remaining/used %. Cursor headlines its account-wide
   **Total** meter; other providers use the constraining window.
-- State chip only when not live: `stale` | `error` | `lifted`.
+- State chip only when not live: `stale` | `error`.
 - Live pills omit the chip.
 - Optional reset countdown stays secondary, not a second percentage.
 
@@ -85,7 +85,7 @@ Detail lists **every** measured window plus inactive rows. Do not truncate to tw
 | Live | Normal pill, no chip | Quiet freshness text |
 | Cached / stale | Muted pill + `stale` chip | Dim metrics + stale label |
 | Error | Crit outline + `error` chip | Error line, no fake bars |
-| Not enforced | Hollow / dashed `lifted` treatment | Quiet named text row via `inactiveRateWindows` |
+| Not enforced | No provider chip; the constraining active window headlines as a live pill | Quiet named text row via `inactiveRateWindows` |
 
 Never invent `0%` or `100%` for an inactive window.
 
@@ -133,5 +133,5 @@ Light and dark, with at least one live Codex/Cursor account:
 
 1. Tray overview showing multiple windows + one inactive row.
 2. Tray provider detail with token history/limits if available.
-3. Capacity strip with a live pill and a stale/error/lifted pill.
+3. Capacity strip with a live pill and a stale/error pill.
 4. Settings / About showing Ceiling branding.

--- a/docs/CEILING_UI.md
+++ b/docs/CEILING_UI.md
@@ -85,7 +85,7 @@ Detail lists **every** measured window plus inactive rows. Do not truncate to tw
 | Live | Normal pill, no chip | Quiet freshness text |
 | Cached / stale | Muted pill + `stale` chip | Dim metrics + stale label |
 | Error | Crit outline + `error` chip | Error line, no fake bars |
-| Not enforced | No provider chip; the constraining active window headlines as a live pill | Quiet named text row via `inactiveRateWindows` |
+| Not enforced | No chip from inactive windows; the active window headlines and normal/stale/error freshness still controls the pill | Quiet named text row via `inactiveRateWindows` |
 
 Never invent `0%` or `100%` for an inactive window.
 


### PR DESCRIPTION
Fixes SOU-152.

## Problem
`capacityFreshness()` returned `"lifted"` whenever a provider had **any** inactive rate window, so the FloatBar painted the whole provider with a "lifted" chip + dashed pill even when the constraining live window was perfectly fine. That is exactly the fake-precision the product avoids, and it disagreed with `docs/CEILING_UI.md` (inactive windows belong in their own rows, not provider-level freshness).

## Fix
- `capacityFreshness()` now derives freshness from the timestamp + error only: `error > stale > live`. Inactive windows no longer affect it.
- Removed `"lifted"` from the `CapacityFreshness` type, the FloatBar `freshnessChipLabel` case, and the now-dead `.floatbar__chip--lifted` / `.floatbar__pill--lifted` CSS.
- Inactive windows keep their existing `inactiveRateWindows` row treatment (PlanStatusCard / detail "not currently enforced" rows) — unchanged.
- Updated `CEILING_UI.md` so the strip chip list and the not-enforced row both match the new behavior.

## Tests
- Reworked the freshness-precedence test and added a mixed-window case: a provider with one inactive + one live window now reports `live`, and a stale timestamp still wins over inactive windows.
- Updated the FloatBar test that asserted the buggy lifted chip.
- Full frontend suite green (220 tests), `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Removed “lifted” state indicators from capacity chips and pills.
  * Inactive/lifted behavior is now shown via inactive rows, while active constraints remain as live pills.
  * Capacity state precedence is now clearly `error > stale > live` (with stale/error preserved as applicable).

* **Documentation**
  * Updated ceiling UI guidance and screenshot expectations to remove “lifted” chip behavior.

* **Tests**
  * Adjusted FloatBar, capacity presentation, and regression coverage to match the new freshness/state logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->