### PR TITLE
Fix PopOut dashboard collapsing to its minimum size (SOU-222)

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/shell/position.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/position.rs
@@ -230,6 +230,12 @@ pub fn remember_current_geometry_if_eligible(window: &tauri::Window) {
     };
     let current_mode = {
         let guard = st.lock().unwrap();
+        if guard.geometry_capture_suppressed(std::time::Instant::now()) {
+            // A programmatic layout (open/transition) is still applying
+            // size/position; its resize/move events must not be persisted as a
+            // user drag (SOU-222).
+            return;
+        }
         guard.surface_machine.current()
     };
     // The TrayPanel flyout persists its size explicitly from the frontend (only

--- a/apps/desktop-tauri/src-tauri/src/shell/window.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/window.rs
@@ -86,9 +86,23 @@ pub fn apply_window_layout(
         // The canonical surface mode drives geometry restore — no brittle
         // shape-matching of WindowProperties. logical_size_from_geometry
         // falls back to the mode's default size for non-remembered modes.
+        // Arm geometry-capture suppression: the set_size below (and the
+        // transition's subsequent position apply) fire OS resize/move events
+        // that must not be persisted as if the user had dragged the window
+        // (SOU-222). Without this, a monitor-read that caps the window to its
+        // minimum was saved as the remembered size and reopened tiny forever.
+        if let Some(st) = window.app_handle().try_state::<Mutex<AppState>>()
+            && let Ok(mut guard) = st.lock()
+        {
+            guard.arm_geometry_capture_suppression(
+                std::time::Instant::now() + std::time::Duration::from_millis(750),
+            );
+        }
+
         let (width, height) =
             logical_size_from_geometry(mode, props, crate::geometry_store::load(mode));
-        let (width, height) = capped_logical_size(window, width, height);
+        let (width, height) =
+            capped_logical_size(window, width, height, props.min_width, props.min_height);
         let size = tauri::LogicalSize::new(width, height);
         window.set_size(size).map_err(map_err)?;
 
@@ -133,7 +147,13 @@ pub(super) fn logical_size_from_geometry(
     )
 }
 
-fn capped_logical_size(window: &WebviewWindow, width: f64, height: f64) -> (f64, f64) {
+fn capped_logical_size(
+    window: &WebviewWindow,
+    width: f64,
+    height: f64,
+    min_width: Option<f64>,
+    min_height: Option<f64>,
+) -> (f64, f64) {
     const MARGIN: f64 = 16.0;
 
     let Some(monitor) = window
@@ -152,9 +172,31 @@ fn capped_logical_size(window: &WebviewWindow, width: f64, height: f64) -> (f64,
         1.0
     };
     let work_area = monitor.work_area();
-    let max_width = (work_area.size.width as f64 / scale - MARGIN).max(320.0);
-    let max_height = (work_area.size.height as f64 / scale - MARGIN).max(240.0);
+    cap_to_available(
+        width,
+        height,
+        work_area.size.width as f64 / scale - MARGIN,
+        work_area.size.height as f64 / scale - MARGIN,
+        min_width,
+        min_height,
+    )
+}
 
+/// Cap a logical size to the available work area, but never below the window's
+/// own minimum. Capping below the minimum makes `set_size` request a
+/// sub-minimum size that the OS clamps back up to the minimum — and that clamp
+/// used to be persisted as the remembered size, collapsing the window
+/// permanently (SOU-222). Modes without a minimum keep a small 320x240 floor.
+fn cap_to_available(
+    width: f64,
+    height: f64,
+    available_width: f64,
+    available_height: f64,
+    min_width: Option<f64>,
+    min_height: Option<f64>,
+) -> (f64, f64) {
+    let max_width = available_width.max(min_width.unwrap_or(320.0));
+    let max_height = available_height.max(min_height.unwrap_or(240.0));
     (width.min(max_width), height.min(max_height))
 }
 
@@ -272,4 +314,45 @@ where
         transition,
         target: state.current_target.clone(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cap_to_available;
+
+    #[test]
+    fn cap_never_shrinks_below_minimum() {
+        // A transient tiny work-area read must not cap a 720x560 window below
+        // its 520x400 minimum (SOU-222). The cap floors to the minimum, so
+        // set_size never requests a sub-minimum size the OS clamps + persists.
+        assert_eq!(
+            cap_to_available(720.0, 560.0, 100.0, 80.0, Some(520.0), Some(400.0)),
+            (520.0, 400.0)
+        );
+    }
+
+    #[test]
+    fn cap_applies_available_when_between_min_and_requested() {
+        assert_eq!(
+            cap_to_available(720.0, 560.0, 640.0, 500.0, Some(520.0), Some(400.0)),
+            (640.0, 500.0)
+        );
+    }
+
+    #[test]
+    fn cap_keeps_requested_size_when_it_fits() {
+        assert_eq!(
+            cap_to_available(720.0, 560.0, 1904.0, 1040.0, Some(520.0), Some(400.0)),
+            (720.0, 560.0)
+        );
+    }
+
+    #[test]
+    fn cap_uses_default_floor_for_min_less_modes() {
+        // Modes without an explicit minimum keep the 320x240 baseline floor.
+        assert_eq!(
+            cap_to_available(1000.0, 800.0, 50.0, 50.0, None, None),
+            (320.0, 240.0)
+        );
+    }
 }

--- a/apps/desktop-tauri/src-tauri/src/shell/window.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/window.rs
@@ -86,11 +86,18 @@ pub fn apply_window_layout(
         // The canonical surface mode drives geometry restore — no brittle
         // shape-matching of WindowProperties. logical_size_from_geometry
         // falls back to the mode's default size for non-remembered modes.
-        // Arm geometry-capture suppression: the set_size below (and the
-        // transition's subsequent position apply) fire OS resize/move events
-        // that must not be persisted as if the user had dragged the window
-        // (SOU-222). Without this, a monitor-read that caps the window to its
-        // minimum was saved as the remembered size and reopened tiny forever.
+        let (width, height) =
+            logical_size_from_geometry(mode, props, crate::geometry_store::load(mode));
+        let (width, height) =
+            capped_logical_size(window, width, height, props.min_width, props.min_height);
+        let size = tauri::LogicalSize::new(width, height);
+
+        // Arm geometry-capture suppression immediately before the programmatic
+        // set_size (and the transition's subsequent position apply) so their OS
+        // resize/move events are not persisted as if the user had dragged the
+        // window (SOU-222). Armed here — after the geometry load/cap above — so
+        // the 750 ms window starts at the actual mutation, not before slow prep,
+        // and set_size can't run after the guard has already expired.
         if let Some(st) = window.app_handle().try_state::<Mutex<AppState>>()
             && let Ok(mut guard) = st.lock()
         {
@@ -99,11 +106,6 @@ pub fn apply_window_layout(
             );
         }
 
-        let (width, height) =
-            logical_size_from_geometry(mode, props, crate::geometry_store::load(mode));
-        let (width, height) =
-            capped_logical_size(window, width, height, props.min_width, props.min_height);
-        let size = tauri::LogicalSize::new(width, height);
         window.set_size(size).map_err(map_err)?;
 
         if let (Some(min_w), Some(min_h)) = (props.min_width, props.min_height) {

--- a/apps/desktop-tauri/src-tauri/src/state.rs
+++ b/apps/desktop-tauri/src-tauri/src/state.rs
@@ -143,6 +143,11 @@ pub struct AppState {
     /// One-shot grace for a blur event caused while revealing the tray panel
     /// during explicit startup.
     pub startup_tray_blur_grace_until: Option<std::time::Instant>,
+    /// Set while the app is programmatically sizing/positioning a window, so
+    /// the OS resize/move events that follow are not captured as if the user
+    /// had dragged the window (SOU-222: stopped the PopOut from persisting a
+    /// clamped-to-minimum size and reopening tiny forever).
+    pub suppress_geometry_capture_until: Option<std::time::Instant>,
     /// Whether the explicit startup path may use its delayed shell fallback.
     pub startup_tray_reveal_pending: bool,
     /// One-shot permission for frontend layout code to reveal a newly opened flyout.
@@ -194,6 +199,7 @@ impl AppState {
             capacity_event_observer: crate::capacity_events::CapacityEventObserver::load_default(),
             last_shown_at: None,
             startup_tray_blur_grace_until: None,
+            suppress_geometry_capture_until: None,
             startup_tray_reveal_pending: false,
             flyout_reveal_pending: false,
             gesture_blur_guard: None,
@@ -223,6 +229,19 @@ impl AppState {
     pub fn take_startup_tray_blur_grace(&mut self, now: std::time::Instant) -> bool {
         self.startup_tray_blur_grace_until
             .take()
+            .is_some_and(|until| now <= until)
+    }
+
+    /// Suppress automatic geometry capture until `until`. Armed right before
+    /// the app programmatically resizes/moves a window.
+    pub fn arm_geometry_capture_suppression(&mut self, until: std::time::Instant) {
+        self.suppress_geometry_capture_until = Some(until);
+    }
+
+    /// Whether a programmatic layout is still in its suppression window, so the
+    /// current resize/move event should not be persisted as user geometry.
+    pub fn geometry_capture_suppressed(&self, now: std::time::Instant) -> bool {
+        self.suppress_geometry_capture_until
             .is_some_and(|until| now <= until)
     }
 
@@ -350,6 +369,22 @@ mod tests {
 
         assert!(transition.is_some());
         assert_eq!(state.current_target, SurfaceTarget::Summary);
+    }
+
+    #[test]
+    fn geometry_capture_suppression_expires() {
+        use std::time::{Duration, Instant};
+        let mut state = AppState::new();
+        let now = Instant::now();
+        // Nothing armed -> capture is allowed.
+        assert!(!state.geometry_capture_suppressed(now));
+
+        let until = now + Duration::from_millis(750);
+        state.arm_geometry_capture_suppression(until);
+        assert!(state.geometry_capture_suppressed(now));
+        assert!(state.geometry_capture_suppressed(until));
+        // Past the window, capture resumes (a genuine user drag is persisted).
+        assert!(!state.geometry_capture_suppressed(until + Duration::from_millis(1)));
     }
 
     #[test]


### PR DESCRIPTION
Fixes SOU-222.

## Problem
The main dashboard (PopOut) reopened at exactly its 520x400 minimum instead of the 720x560 default, on every launch (reported in 0.43.3: tiny/hard-to-find window, felt non-resizable). Evidence: `window_geometry.json` had `popOut` saved at exactly the minimum.

## Root cause
A self-reinforcing collapse:
1. `capped_logical_size` capped the window to the monitor work area, flooring only to 320x240 — on a transient/incorrect monitor read it could cap **below** PopOut's 520x400 minimum.
2. `set_size` then requested a sub-minimum size; the OS + `set_min_size` clamped it back up to 520x400.
3. That clamp fired a resize event, and `remember_current_geometry_if_eligible` **persisted the clamped minimum as if the user had resized** — so it reopened tiny forever.

## Fix
1. **Don't persist the app's own programmatic sizing.** New `AppState::suppress_geometry_capture_until`: `apply_window_layout` arms a 750 ms suppression right before its `set_size`, and the window-event save path skips while it's active. The app's open/transition layout can no longer be mistaken for a user drag. (This is the core fix — even a transient collapse is never persisted.)
2. **Cap never drops below the minimum.** Extracted a pure `cap_to_available` helper; the work-area cap floors to the window's own `min_width`/`min_height` (320x240 baseline for min-less modes). No sub-minimum `set_size` -> no OS clamp -> nothing to mis-persist.

## Tests
- `cap_to_available`: floors to the minimum on a tiny work area, applies the available size between min and requested, keeps the requested size when it fits, and keeps the 320x240 baseline for min-less modes.
- `AppState` geometry-capture suppression arms and expires correctly.
- Full crate suite green (370 passed), `clippy -D warnings` clean, `fmt --check` clean.

Note: couldn't reproduce the GUI end-to-end headlessly; logic + unit tests verified. The "can't resize" secondary note in the issue (borderless hit-testing) is left for follow-up — at the restored default size the window resizes fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic window transitions from overwriting users’ saved window position and size.
  * Improved window sizing when restoring or displaying the desktop app.
  * Preserved configured minimum window dimensions while fitting windows to the available screen area.

* **Tests**
  * Added coverage for window sizing limits and temporary geometry-capture suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->