### PR TITLE
Onboarding checklist + provider data-source explainer (SOU-157, SOU-179)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Ceiling runs on Windows 10 and 11.
 
 **[Download for Windows &rarr;](https://ceiling.win/download)** &nbsp;·&nbsp; [ceiling.win](https://ceiling.win) &nbsp;·&nbsp; [all releases](https://github.com/tsouth89/ceiling/releases)
 
-The installer and portable build are code-signed. Everything stays local-first: your credentials and usage data never leave your machine.
+The installer and portable build are code-signed. Ceiling is local-first: it reads usage from sources on your PC or from each provider's own usage endpoint, and never sends your credentials or usage data to Ceiling-operated servers. See [How Ceiling gets your data](docs/DATA_SOURCES.md) for the per-provider detail.
 
 ## Development
 

--- a/apps/desktop-tauri/src/components/FirstRunChecklist.test.tsx
+++ b/apps/desktop-tauri/src/components/FirstRunChecklist.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FirstRunChecklist } from "./FirstRunChecklist";
+
+const t = (k: string) => k;
+
+function setup(overrides: Partial<Parameters<typeof FirstRunChecklist>[0]> = {}) {
+  const props = {
+    enabledCount: 0,
+    hasWorkingAuth: false,
+    floatbarEnabled: false,
+    onOpenProviders: vi.fn(),
+    onOpenDisplay: vi.fn(),
+    onDismiss: vi.fn(),
+    t,
+    ...overrides,
+  };
+  render(<FirstRunChecklist {...props} />);
+  return props;
+}
+
+describe("FirstRunChecklist", () => {
+  it("renders all three steps as actionable when nothing is set up", () => {
+    setup();
+    expect(screen.getByText("FirstRunStepEnable")).toBeInTheDocument();
+    expect(screen.getByText("FirstRunStepAuth")).toBeInTheDocument();
+    expect(screen.getByText("FirstRunStepFloatbar")).toBeInTheDocument();
+    // Steps 1 and 2 both link to provider settings.
+    expect(screen.getAllByText("FirstRunOpenProviders")).toHaveLength(2);
+  });
+
+  it("marks a completed step done and drops its action button", () => {
+    setup({ enabledCount: 2, floatbarEnabled: true });
+    const enable = screen.getByText("FirstRunStepEnable").closest("li");
+    expect(enable?.className).toContain("first-run__step--done");
+    // Only the auth step's action remains (enable + floatbar are done).
+    expect(screen.getAllByText("FirstRunOpenProviders")).toHaveLength(1);
+    expect(screen.queryByText("FirstRunOpenDisplay")).toBeNull();
+  });
+
+  it("dismiss calls onDismiss", () => {
+    const props = setup();
+    fireEvent.click(screen.getByText("FirstRunDismiss"));
+    expect(props.onDismiss).toHaveBeenCalled();
+  });
+
+  it("the floatbar step opens display settings", () => {
+    const props = setup();
+    fireEvent.click(screen.getByText("FirstRunOpenDisplay"));
+    expect(props.onOpenDisplay).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop-tauri/src/components/FirstRunChecklist.tsx
+++ b/apps/desktop-tauri/src/components/FirstRunChecklist.tsx
@@ -1,0 +1,105 @@
+import type { LocaleKey } from "../i18n/keys";
+
+const DISMISS_KEY = "ceiling.first-run.dismissed.v1";
+
+/** Whether the user has dismissed the first-run checklist on this machine. */
+export function firstRunDismissed(): boolean {
+  try {
+    return localStorage.getItem(DISMISS_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Remember that the first-run checklist was dismissed. */
+export function dismissFirstRun(): void {
+  try {
+    localStorage.setItem(DISMISS_KEY, "1");
+  } catch {
+    // Ignore storage failures (private mode, disabled storage, etc.).
+  }
+}
+
+interface Props {
+  enabledCount: number;
+  hasWorkingAuth: boolean;
+  floatbarEnabled: boolean;
+  onOpenProviders: () => void;
+  onOpenDisplay: () => void;
+  onDismiss: () => void;
+  t: (key: LocaleKey) => string;
+}
+
+/**
+ * Light, dismissible first-run checklist shown in the empty dashboard when no
+ * provider has produced usage yet (SOU-157). Each step reflects real state and
+ * deep-links into the matching Settings tab. Dismissal is remembered in
+ * localStorage (same pattern as the detected-accounts card); a returning user
+ * who already has working auth never lands here because the dashboard shows
+ * their providers instead of the empty state.
+ */
+export function FirstRunChecklist({
+  enabledCount,
+  hasWorkingAuth,
+  floatbarEnabled,
+  onOpenProviders,
+  onOpenDisplay,
+  onDismiss,
+  t,
+}: Props) {
+  const steps = [
+    {
+      done: enabledCount > 0,
+      label: t("FirstRunStepEnable"),
+      action: t("FirstRunOpenProviders"),
+      onAction: onOpenProviders,
+    },
+    {
+      done: hasWorkingAuth,
+      label: t("FirstRunStepAuth"),
+      action: t("FirstRunOpenProviders"),
+      onAction: onOpenProviders,
+    },
+    {
+      done: floatbarEnabled,
+      label: t("FirstRunStepFloatbar"),
+      action: t("FirstRunOpenDisplay"),
+      onAction: onOpenDisplay,
+    },
+  ];
+
+  return (
+    <section className="first-run" aria-label={t("FirstRunTitle")}>
+      <div className="first-run__header">
+        <h3 className="first-run__title">{t("FirstRunTitle")}</h3>
+        <button
+          type="button"
+          className="first-run__dismiss"
+          onClick={onDismiss}
+        >
+          {t("FirstRunDismiss")}
+        </button>
+      </div>
+      <ol className="first-run__steps">
+        {steps.map((step, index) => (
+          <li
+            key={index}
+            className={`first-run__step${step.done ? " first-run__step--done" : ""}`}
+          >
+            <span className="first-run__check" aria-hidden="true" />
+            <span className="first-run__label">{step.label}</span>
+            {!step.done && (
+              <button
+                type="button"
+                className="first-run__action"
+                onClick={step.onAction}
+              >
+                {step.action}
+              </button>
+            )}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/apps/desktop-tauri/src/i18n/keys.ts
+++ b/apps/desktop-tauri/src/i18n/keys.ts
@@ -602,6 +602,24 @@ export const ALL_LOCALE_KEYS = [
   "TrayPaceBadgeBurning",
   "TrayResetsInLabel",
   "TrayResetsDueNow",
+  // Provider data-source / privacy explainer (SOU-179)
+  "DataSourceSectionTitle",
+  "DataSourcePrivacyNote",
+  "DataSourceLearnMore",
+  "DataSourceClaude",
+  "DataSourceCodex",
+  "DataSourceCursor",
+  "DataSourceCopilot",
+  "DataSourceGemini",
+  "DataSourceGeneric",
+  // First-run checklist (SOU-157)
+  "FirstRunTitle",
+  "FirstRunStepEnable",
+  "FirstRunStepAuth",
+  "FirstRunStepFloatbar",
+  "FirstRunOpenProviders",
+  "FirstRunOpenDisplay",
+  "FirstRunDismiss",
 ] as const;
 
 export type LocaleKey = (typeof ALL_LOCALE_KEYS)[number];

--- a/apps/desktop-tauri/src/lib/providerProvenance.test.ts
+++ b/apps/desktop-tauri/src/lib/providerProvenance.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { ALL_LOCALE_KEYS } from "../i18n/keys";
+import {
+  DETAILED_PROVENANCE_PROVIDERS,
+  providerProvenanceKey,
+} from "./providerProvenance";
+
+describe("providerProvenance", () => {
+  it("gives the five first-class providers dedicated (non-generic) copy", () => {
+    expect([...DETAILED_PROVENANCE_PROVIDERS].sort()).toEqual(
+      ["claude", "codex", "copilot", "cursor", "gemini"].sort(),
+    );
+    for (const id of DETAILED_PROVENANCE_PROVIDERS) {
+      expect(providerProvenanceKey(id)).not.toBe("DataSourceGeneric");
+    }
+  });
+
+  it("falls back to the generic line for providers without dedicated copy", () => {
+    expect(providerProvenanceKey("openrouter")).toBe("DataSourceGeneric");
+    expect(providerProvenanceKey("brand-new-provider")).toBe("DataSourceGeneric");
+  });
+
+  // Guardrail (SOU-179): every provenance key a provider can resolve to must
+  // exist in the locale set, so a provider can never render a missing string.
+  it("every provenance key exists in the locale key set", () => {
+    const keys = [
+      ...DETAILED_PROVENANCE_PROVIDERS.map(providerProvenanceKey),
+      providerProvenanceKey("unknown"),
+    ];
+    for (const key of keys) {
+      expect(ALL_LOCALE_KEYS).toContain(key);
+    }
+  });
+});

--- a/apps/desktop-tauri/src/lib/providerProvenance.ts
+++ b/apps/desktop-tauri/src/lib/providerProvenance.ts
@@ -1,0 +1,31 @@
+import type { LocaleKey } from "../i18n/keys";
+
+/**
+ * Providers with hand-written, source-verified provenance copy for the
+ * "How Ceiling gets this data" block (SOU-179). Every other provider falls
+ * back to `DataSourceGeneric`.
+ *
+ * The copy behind these keys is verified against the real fetch paths in
+ * `rust/src/providers/*` and must stay in sync with `docs/DATA_SOURCES.md`.
+ * A test (`providerProvenance.test.ts`) asserts these five keep dedicated
+ * copy so a rename can't silently drop a first-class provider to the generic
+ * line.
+ */
+const PROVENANCE_KEYS: Record<string, LocaleKey> = {
+  claude: "DataSourceClaude",
+  codex: "DataSourceCodex",
+  cursor: "DataSourceCursor",
+  copilot: "DataSourceCopilot",
+  gemini: "DataSourceGemini",
+};
+
+/** Provider ids that ship dedicated (non-generic) provenance copy. */
+export const DETAILED_PROVENANCE_PROVIDERS = Object.keys(PROVENANCE_KEYS);
+
+/**
+ * Locale key describing how Ceiling obtains this provider's data. Providers
+ * without dedicated copy get the precise generic statement.
+ */
+export function providerProvenanceKey(providerId: string): LocaleKey {
+  return PROVENANCE_KEYS[providerId] ?? "DataSourceGeneric";
+}

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -8289,3 +8289,125 @@ body:has(.dashboard-shell) #root {
   color: var(--provider-row-text-primary);
   border: 1px solid var(--provider-icon-ring);
 }
+
+/* ── Provider data-source explainer (SOU-179) ─────────────────────────── */
+.provider-detail-datasource__source {
+  margin: 0 0 8px;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--provider-row-text-primary);
+}
+.provider-detail-datasource__privacy {
+  margin: 0 0 8px;
+  font-size: 0.76rem;
+  line-height: 1.5;
+  color: var(--provider-row-text-secondary);
+}
+.provider-detail-datasource__link {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 0.78rem;
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: underline;
+}
+.provider-detail-datasource__link:hover {
+  opacity: 0.85;
+}
+
+/* ── First-run checklist (SOU-157) ────────────────────────────────────── */
+.first-run {
+  margin: 0 0 12px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  border: 1px solid var(--provider-icon-ring, rgba(255, 255, 255, 0.08));
+  background: var(--provider-row-bg, rgba(255, 255, 255, 0.03));
+}
+.first-run__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+.first-run__title {
+  margin: 0;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.first-run__dismiss {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 2px 4px;
+  font: inherit;
+  font-size: 0.76rem;
+  color: var(--provider-row-text-secondary);
+  cursor: pointer;
+}
+.first-run__dismiss:hover {
+  color: var(--text-primary);
+}
+.first-run__steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.first-run__step {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.82rem;
+  color: var(--text-primary);
+}
+.first-run__check {
+  flex: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1.5px solid var(--provider-icon-ring, rgba(255, 255, 255, 0.25));
+  position: relative;
+}
+.first-run__step--done .first-run__check {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.first-run__step--done .first-run__check::after {
+  content: "";
+  position: absolute;
+  left: 5px;
+  top: 2px;
+  width: 4px;
+  height: 8px;
+  border: solid #fff;
+  border-width: 0 1.5px 1.5px 0;
+  transform: rotate(45deg);
+}
+.first-run__step--done .first-run__label {
+  color: var(--provider-row-text-secondary);
+  text-decoration: line-through;
+}
+.first-run__label {
+  flex: 1;
+}
+.first-run__action {
+  appearance: none;
+  flex: none;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 4px 10px;
+  font: inherit;
+  font-size: 0.76rem;
+  cursor: pointer;
+}
+.first-run__action:hover {
+  opacity: 0.9;
+}

--- a/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
@@ -13,6 +13,11 @@ import ChartsPanel from "./ChartsPanel";
 import AccountsPanel from "./AccountsPanel";
 import ProviderDetailView from "./ProviderDetailView";
 import { MenuEmpty } from "../components/MenuSurface";
+import {
+  FirstRunChecklist,
+  firstRunDismissed,
+  dismissFirstRun,
+} from "../components/FirstRunChecklist";
 import UpdateBanner from "../components/UpdateBanner";
 import DetectedAccountsCard from "../components/DetectedAccountsCard";
 import { orderProviderSnapshots } from "../lib/providerOrder";
@@ -191,6 +196,13 @@ export default function PopOutPanel({
   const openSettings = useCallback(() => {
     openSettingsWindow("general");
   }, []);
+  const [firstRunHidden, setFirstRunHidden] = useState(() =>
+    firstRunDismissed(),
+  );
+  const handleDismissFirstRun = useCallback(() => {
+    dismissFirstRun();
+    setFirstRunHidden(true);
+  }, []);
   const quitApp = useCallback(() => {
     void quitApplication();
   }, []);
@@ -352,10 +364,23 @@ export default function PopOutPanel({
                   onManage={() => openSettingsWindow("providers")}
                 />
                 {sorted.length === 0 ? (
-                  <MenuEmpty
-                    isLoading={isRefreshing && !hasCachedData}
-                    onSettings={openSettings}
-                  />
+                  isRefreshing && !hasCachedData ? (
+                    <MenuEmpty isLoading onSettings={openSettings} />
+                  ) : firstRunHidden ? (
+                    <MenuEmpty isLoading={false} onSettings={openSettings} />
+                  ) : (
+                    <FirstRunChecklist
+                      enabledCount={settings.enabledProviders.length}
+                      hasWorkingAuth={false}
+                      floatbarEnabled={
+                        settings.floatBarEnabled || settings.taskbarWidgetEnabled
+                      }
+                      onOpenProviders={() => openSettingsWindow("providers")}
+                      onOpenDisplay={() => openSettingsWindow("menu")}
+                      onDismiss={handleDismissFirstRun}
+                      t={t}
+                    />
+                  )
                 ) : (
                   <div
                     className={`menu-stack${selectedProviderId === null ? " menu-stack--overview" : ""}`}

--- a/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
@@ -371,7 +371,12 @@ export default function PopOutPanel({
                   ) : (
                     <FirstRunChecklist
                       enabledCount={settings.enabledProviders.length}
-                      hasWorkingAuth={false}
+                      hasWorkingAuth={providers.some(
+                        (provider) =>
+                          settings.enabledProviders.includes(
+                            provider.providerId,
+                          ) && !provider.error,
+                      )}
                       floatbarEnabled={
                         settings.floatBarEnabled || settings.taskbarWidgetEnabled
                       }

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
@@ -24,6 +24,7 @@ import {
 import { listen } from "@tauri-apps/api/event";
 
 import { IdentitySection } from "./sections/IdentitySection";
+import { DataSourceSection } from "./sections/DataSourceSection";
 import { UsageSection } from "./sections/UsageSection";
 import { PaceSection } from "./sections/PaceSection";
 import { CostSection } from "./sections/CostSection";
@@ -282,6 +283,8 @@ export function ProviderDetailPane({
   return (
     <div className="provider-detail">
       <IdentitySection provider={detail} subtitle={subtitle} t={t} />
+
+      <DataSourceSection provider={detail} t={t} />
 
       {detail.lastError && (
         <ProviderIssueNotice

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/DataSourceSection.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/DataSourceSection.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DataSourceSection } from "./DataSourceSection";
+import type { ProviderDetail } from "../../../../types/bridge";
+
+vi.mock("../../../../lib/tauri", () => ({
+  openExternalUrl: vi.fn(() => Promise.resolve()),
+}));
+
+const t = (k: string) => k;
+
+function provider(id: string): ProviderDetail {
+  return { id, displayName: id } as unknown as ProviderDetail;
+}
+
+describe("DataSourceSection", () => {
+  it("shows provider-specific provenance for a first-class provider", () => {
+    render(<DataSourceSection provider={provider("claude")} t={t} />);
+    expect(screen.getByText("DataSourceClaude")).toBeInTheDocument();
+    expect(screen.getByText("DataSourcePrivacyNote")).toBeInTheDocument();
+    expect(screen.getByText("DataSourceLearnMore")).toBeInTheDocument();
+  });
+
+  it("falls back to the generic line for providers without dedicated copy", () => {
+    render(<DataSourceSection provider={provider("openrouter")} t={t} />);
+    expect(screen.getByText("DataSourceGeneric")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/DataSourceSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/DataSourceSection.tsx
@@ -1,0 +1,41 @@
+import type { ProviderDetail } from "../../../../types/bridge";
+import type { LocaleKey } from "../../../../i18n/keys";
+import { openExternalUrl } from "../../../../lib/tauri";
+import { providerProvenanceKey } from "../../../../lib/providerProvenance";
+
+const DATA_SOURCES_DOC_URL =
+  "https://github.com/tsouth89/ceiling/blob/main/docs/DATA_SOURCES.md";
+
+interface Props {
+  provider: ProviderDetail;
+  t: (key: LocaleKey) => string;
+}
+
+/**
+ * "How Ceiling gets this data" — a short, provider-specific provenance line
+ * plus a precise privacy note (SOU-179). The copy is verified against the real
+ * fetch paths documented in `docs/DATA_SOURCES.md`; providers without dedicated
+ * copy fall back to a precise generic statement. Storage/DPAPI detail lives in
+ * the separate CredentialStorageSection, so this block stays about *where the
+ * data comes from* and *what is (and isn't) sent over the network*.
+ */
+export function DataSourceSection({ provider, t }: Props) {
+  return (
+    <section className="provider-detail-section provider-detail-datasource">
+      <h4>{t("DataSourceSectionTitle")}</h4>
+      <p className="provider-detail-datasource__source">
+        {t(providerProvenanceKey(provider.id))}
+      </p>
+      <p className="provider-detail-datasource__privacy">
+        {t("DataSourcePrivacyNote")}
+      </p>
+      <button
+        type="button"
+        className="provider-detail-datasource__link"
+        onClick={() => void openExternalUrl(DATA_SOURCES_DOC_URL)}
+      >
+        {t("DataSourceLearnMore")}
+      </button>
+    </section>
+  );
+}

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -1,0 +1,48 @@
+# How Ceiling gets your data
+
+Ceiling is a local-first Windows app. It reads your AI usage from sources that
+already live on your PC, or by calling each provider's own usage endpoint.
+**Your provider credentials and usage data stay on this PC. Ceiling does not
+send them to any Ceiling-operated server.** Network requests go only to the
+provider you enabled (and, for Wayfinder, to the local gateway URL you
+configure yourself).
+
+This document is the maintained reference behind the "How Ceiling gets this
+data" panel in a provider's Settings detail view.
+
+## What Ceiling stores locally
+
+| Data | Where | Protection |
+|------|-------|------------|
+| API keys | `%APPDATA%\Ceiling` (ApiKeys store) | Windows DPAPI, user-only file ACL |
+| Manual cookies | `%APPDATA%\Ceiling` (ManualCookies store) | Windows DPAPI, user-only file ACL |
+| OAuth token accounts | `%APPDATA%\Ceiling` (token store) | Windows DPAPI, user-only file ACL |
+| Settings | `%APPDATA%\Ceiling\settings.json` | Local file |
+
+Ceiling also *reads* credentials that other tools already wrote (for example
+`~/.codex/auth.json`, the Cursor IDE session database, or your browser's cookie
+database). It does not copy those into its own storage unless you explicitly
+import them. See [COOKIES.md](COOKIES.md) for browser cookie extraction and
+App-Bound Encryption details.
+
+## Per-provider sources
+
+| Provider | How Ceiling reads usage | Talks to |
+|----------|-------------------------|----------|
+| **Claude** | Your signed-in Claude Code / Claude Desktop session, an OAuth token, or claude.ai cookies you provide; plus local `~/.claude` logs for cost and tokens | api.anthropic.com, claude.ai |
+| **Codex / OpenAI** | The OAuth token from your Codex CLI (`~/.codex/auth.json`) plus local `~/.codex/sessions` logs | chatgpt.com |
+| **Cursor** | Your signed-in Cursor IDE session (`state.vscdb`), or cursor.com cookies you provide | cursor.com |
+| **GitHub Copilot** | Your GitHub CLI / Git Credential Manager token (or a device-flow sign-in) | api.github.com, or your GitHub Enterprise host |
+| **Gemini** | The OAuth token from the Gemini CLI (`~/.gemini/oauth_creds.json`) | Google Code Assist and OAuth endpoints |
+| Other providers | A local session or token on this PC, or the provider's own usage endpoint | The provider's own domain only |
+
+## Network policy
+
+- The Ceiling desktop app makes no analytics or telemetry calls to
+  Ceiling-operated servers.
+- Every usage request targets the provider's own domain listed above.
+- The only non-provider destination is **Wayfinder**, which calls the local
+  gateway URL you configure yourself.
+
+If you enable a provider and don't see it described here or in the in-app panel,
+that's a bug. Please open an issue.

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -2,10 +2,11 @@
 
 Ceiling is a local-first Windows app. It reads your AI usage from sources that
 already live on your PC, or by calling each provider's own usage endpoint.
-**Your provider credentials and usage data stay on this PC. Ceiling does not
-send them to any Ceiling-operated server.** Network requests go only to the
-provider you enabled (and, for Wayfinder, to the local gateway URL you
-configure yourself).
+**Your provider credentials and usage data are stored only on this PC, and
+Ceiling never sends them to a Ceiling-operated server.** Fetching usage does
+make network requests, but only to the provider you enabled (and, for Wayfinder,
+to the local gateway URL you configure yourself), never to Ceiling's own
+servers.
 
 This document is the maintained reference behind the "How Ceiling gets this
 data" panel in a provider's Settings detail view.

--- a/rust/src/locale.rs
+++ b/rust/src/locale.rs
@@ -854,6 +854,26 @@ locale_keys! {
     TrayPaceBadgeBurning,
     TrayResetsInLabel,
     TrayResetsDueNow,
+
+    // Provider data-source / privacy explainer (SOU-179)
+    DataSourceSectionTitle,
+    DataSourcePrivacyNote,
+    DataSourceLearnMore,
+    DataSourceClaude,
+    DataSourceCodex,
+    DataSourceCursor,
+    DataSourceCopilot,
+    DataSourceGemini,
+    DataSourceGeneric,
+
+    // First-run checklist (SOU-157)
+    FirstRunTitle,
+    FirstRunStepEnable,
+    FirstRunStepAuth,
+    FirstRunStepFloatbar,
+    FirstRunOpenProviders,
+    FirstRunOpenDisplay,
+    FirstRunDismiss,
 }
 
 #[cfg(test)]

--- a/rust/src/locale/en-US.ftl
+++ b/rust/src/locale/en-US.ftl
@@ -594,14 +594,14 @@ TrayResetsDueNow = Resetting…
 
 # Provider data-source / privacy explainer (SOU-179)
 DataSourceSectionTitle = How Ceiling gets this data
-DataSourcePrivacyNote = Ceiling reads your usage from local app sessions and logs on this PC, or by calling the provider's own usage endpoint. Your credentials and usage data stay on this PC. They are never sent to Ceiling-operated servers, only to the provider itself.
+DataSourcePrivacyNote = Ceiling reads your usage from local app sessions and logs on this PC, or by calling the provider's own usage endpoint. Your credentials and usage are stored only on this PC and are never sent to Ceiling-operated servers. Usage requests go only to the provider you enabled, or for Wayfinder the local gateway you configure.
 DataSourceLearnMore = Learn how Ceiling gets each provider's data
 DataSourceClaude = Reads usage from your signed-in Claude Code or Claude Desktop session, an OAuth token, or claude.ai cookies you provide. Talks only to api.anthropic.com and claude.ai.
 DataSourceCodex = Uses the OAuth token from your Codex CLI (~/.codex) plus local session logs on this PC. Talks only to chatgpt.com.
 DataSourceCursor = Uses your signed-in Cursor IDE session, or cursor.com cookies you provide. Talks only to cursor.com.
-DataSourceCopilot = Uses your GitHub CLI or Git Credential Manager token. Talks only to api.github.com, or your configured GitHub Enterprise host.
+DataSourceCopilot = Uses your GitHub CLI or Git Credential Manager token, or a device-flow sign-in. Talks only to api.github.com, or your configured GitHub Enterprise host.
 DataSourceGemini = Reads the OAuth token from the Gemini CLI (~/.gemini). Talks only to Google's Code Assist and OAuth endpoints.
-DataSourceGeneric = Reads this provider's usage from a local session or token on this PC, or by calling the provider's own usage endpoint. Your credentials stay on this PC and are only sent to the provider.
+DataSourceGeneric = Reads this provider's usage from a local session or token on this PC, or by calling the provider's own usage endpoint. Your credentials are stored only on this PC and are never sent to Ceiling-operated servers; usage requests go only to that provider (or, for Wayfinder, your configured gateway).
 
 # First-run checklist (SOU-157)
 FirstRunTitle = Finish setting up Ceiling

--- a/rust/src/locale/en-US.ftl
+++ b/rust/src/locale/en-US.ftl
@@ -591,3 +591,23 @@ TrayPaceBadgeRacing = Racing
 TrayPaceBadgeBurning = Burning
 TrayResetsInLabel = Resets in { "{}" }
 TrayResetsDueNow = Resetting…
+
+# Provider data-source / privacy explainer (SOU-179)
+DataSourceSectionTitle = How Ceiling gets this data
+DataSourcePrivacyNote = Ceiling reads your usage from local app sessions and logs on this PC, or by calling the provider's own usage endpoint. Your credentials and usage data stay on this PC. They are never sent to Ceiling-operated servers, only to the provider itself.
+DataSourceLearnMore = Learn how Ceiling gets each provider's data
+DataSourceClaude = Reads usage from your signed-in Claude Code or Claude Desktop session, an OAuth token, or claude.ai cookies you provide. Talks only to api.anthropic.com and claude.ai.
+DataSourceCodex = Uses the OAuth token from your Codex CLI (~/.codex) plus local session logs on this PC. Talks only to chatgpt.com.
+DataSourceCursor = Uses your signed-in Cursor IDE session, or cursor.com cookies you provide. Talks only to cursor.com.
+DataSourceCopilot = Uses your GitHub CLI or Git Credential Manager token. Talks only to api.github.com, or your configured GitHub Enterprise host.
+DataSourceGemini = Reads the OAuth token from the Gemini CLI (~/.gemini). Talks only to Google's Code Assist and OAuth endpoints.
+DataSourceGeneric = Reads this provider's usage from a local session or token on this PC, or by calling the provider's own usage endpoint. Your credentials stay on this PC and are only sent to the provider.
+
+# First-run checklist (SOU-157)
+FirstRunTitle = Finish setting up Ceiling
+FirstRunStepEnable = Enable the providers you use
+FirstRunStepAuth = Connect or confirm your sign-in
+FirstRunStepFloatbar = Turn on the floating bar or taskbar glance
+FirstRunOpenProviders = Open provider settings
+FirstRunOpenDisplay = Open display settings
+FirstRunDismiss = Dismiss

--- a/rust/src/locale/es-MX.ftl
+++ b/rust/src/locale/es-MX.ftl
@@ -591,23 +591,22 @@ PredictivePaceWarningTitle = Aviso de ritmo de { "{}" } ({ "{}" })
 PredictivePaceWarningBody = La cuota puede agotarse en { "{}" }
 ShowResetWhenExhausted = Mostrar reinicio al agotar la cuota
 ShowResetWhenExhaustedHelper = Reemplaza el porcentaje agotado con la cuenta regresiva del reinicio
+# Provider data-source / privacy explainer (SOU-179) — English only
+DataSourceSectionTitle = How Ceiling gets this data
+DataSourcePrivacyNote = Ceiling reads your usage from local app sessions and logs on this PC, or by calling the provider's own usage endpoint. Your credentials and usage data stay on this PC. They are never sent to Ceiling-operated servers, only to the provider itself.
+DataSourceLearnMore = Learn how Ceiling gets each provider's data
+DataSourceClaude = Reads usage from your signed-in Claude Code or Claude Desktop session, an OAuth token, or claude.ai cookies you provide. Talks only to api.anthropic.com and claude.ai.
+DataSourceCodex = Uses the OAuth token from your Codex CLI (~/.codex) plus local session logs on this PC. Talks only to chatgpt.com.
+DataSourceCursor = Uses your signed-in Cursor IDE session, or cursor.com cookies you provide. Talks only to cursor.com.
+DataSourceCopilot = Uses your GitHub CLI or Git Credential Manager token. Talks only to api.github.com, or your configured GitHub Enterprise host.
+DataSourceGemini = Reads the OAuth token from the Gemini CLI (~/.gemini). Talks only to Google's Code Assist and OAuth endpoints.
+DataSourceGeneric = Reads this provider's usage from a local session or token on this PC, or by calling the provider's own usage endpoint. Your credentials stay on this PC and are only sent to the provider.
 
-# Provider data-source / privacy explainer (SOU-179)
-DataSourceSectionTitle = Cómo obtiene Ceiling estos datos
-DataSourcePrivacyNote = Ceiling lee tu uso desde sesiones y registros de apps locales en esta PC, o llamando al propio endpoint de uso del proveedor. Tus credenciales y datos de uso permanecen en esta PC. Nunca se envían a servidores operados por Ceiling, solo al proveedor.
-DataSourceLearnMore = Descubre cómo Ceiling obtiene los datos de cada proveedor
-DataSourceClaude = Lee el uso desde tu sesión de Claude Code o Claude Desktop, un token OAuth o cookies de claude.ai que proporciones. Solo se comunica con api.anthropic.com y claude.ai.
-DataSourceCodex = Usa el token OAuth de tu CLI de Codex (~/.codex) y los registros de sesión locales en esta PC. Solo se comunica con chatgpt.com.
-DataSourceCursor = Usa tu sesión del IDE de Cursor, o cookies de cursor.com que proporciones. Solo se comunica con cursor.com.
-DataSourceCopilot = Usa el token de tu CLI de GitHub o del Administrador de credenciales de Git. Solo se comunica con api.github.com, o con tu host de GitHub Enterprise configurado.
-DataSourceGemini = Lee el token OAuth de la CLI de Gemini (~/.gemini). Solo se comunica con los endpoints de Code Assist y OAuth de Google.
-DataSourceGeneric = Lee el uso de este proveedor desde una sesión o token local en esta PC, o llamando al propio endpoint de uso del proveedor. Tus credenciales permanecen en esta PC y solo se envían al proveedor.
-
-# First-run checklist (SOU-157)
-FirstRunTitle = Termina de configurar Ceiling
-FirstRunStepEnable = Habilita los proveedores que usas
-FirstRunStepAuth = Conecta o confirma tu inicio de sesión
-FirstRunStepFloatbar = Activa la barra flotante o el vistazo en la barra de tareas
-FirstRunOpenProviders = Abrir configuración de proveedores
-FirstRunOpenDisplay = Abrir configuración de pantalla
-FirstRunDismiss = Descartar
+# First-run checklist (SOU-157) — English only
+FirstRunTitle = Finish setting up Ceiling
+FirstRunStepEnable = Enable the providers you use
+FirstRunStepAuth = Connect or confirm your sign-in
+FirstRunStepFloatbar = Turn on the floating bar or taskbar glance
+FirstRunOpenProviders = Open provider settings
+FirstRunOpenDisplay = Open display settings
+FirstRunDismiss = Dismiss

--- a/rust/src/locale/es-MX.ftl
+++ b/rust/src/locale/es-MX.ftl
@@ -591,3 +591,23 @@ PredictivePaceWarningTitle = Aviso de ritmo de { "{}" } ({ "{}" })
 PredictivePaceWarningBody = La cuota puede agotarse en { "{}" }
 ShowResetWhenExhausted = Mostrar reinicio al agotar la cuota
 ShowResetWhenExhaustedHelper = Reemplaza el porcentaje agotado con la cuenta regresiva del reinicio
+
+# Provider data-source / privacy explainer (SOU-179)
+DataSourceSectionTitle = Cómo obtiene Ceiling estos datos
+DataSourcePrivacyNote = Ceiling lee tu uso desde sesiones y registros de apps locales en esta PC, o llamando al propio endpoint de uso del proveedor. Tus credenciales y datos de uso permanecen en esta PC. Nunca se envían a servidores operados por Ceiling, solo al proveedor.
+DataSourceLearnMore = Descubre cómo Ceiling obtiene los datos de cada proveedor
+DataSourceClaude = Lee el uso desde tu sesión de Claude Code o Claude Desktop, un token OAuth o cookies de claude.ai que proporciones. Solo se comunica con api.anthropic.com y claude.ai.
+DataSourceCodex = Usa el token OAuth de tu CLI de Codex (~/.codex) y los registros de sesión locales en esta PC. Solo se comunica con chatgpt.com.
+DataSourceCursor = Usa tu sesión del IDE de Cursor, o cookies de cursor.com que proporciones. Solo se comunica con cursor.com.
+DataSourceCopilot = Usa el token de tu CLI de GitHub o del Administrador de credenciales de Git. Solo se comunica con api.github.com, o con tu host de GitHub Enterprise configurado.
+DataSourceGemini = Lee el token OAuth de la CLI de Gemini (~/.gemini). Solo se comunica con los endpoints de Code Assist y OAuth de Google.
+DataSourceGeneric = Lee el uso de este proveedor desde una sesión o token local en esta PC, o llamando al propio endpoint de uso del proveedor. Tus credenciales permanecen en esta PC y solo se envían al proveedor.
+
+# First-run checklist (SOU-157)
+FirstRunTitle = Termina de configurar Ceiling
+FirstRunStepEnable = Habilita los proveedores que usas
+FirstRunStepAuth = Conecta o confirma tu inicio de sesión
+FirstRunStepFloatbar = Activa la barra flotante o el vistazo en la barra de tareas
+FirstRunOpenProviders = Abrir configuración de proveedores
+FirstRunOpenDisplay = Abrir configuración de pantalla
+FirstRunDismiss = Descartar

--- a/rust/src/locale/ja-JP.ftl
+++ b/rust/src/locale/ja-JP.ftl
@@ -591,23 +591,22 @@ PredictivePaceWarningTitle = { "{}" } ? { "{}" } ?????
 PredictivePaceWarningBody = ?? { "{}" } ???????????????
 ShowResetWhenExhausted = ???????????????
 ShowResetWhenExhaustedHelper = ??????????????????????????????
+# Provider data-source / privacy explainer (SOU-179) — English only
+DataSourceSectionTitle = How Ceiling gets this data
+DataSourcePrivacyNote = Ceiling reads your usage from local app sessions and logs on this PC, or by calling the provider's own usage endpoint. Your credentials and usage data stay on this PC. They are never sent to Ceiling-operated servers, only to the provider itself.
+DataSourceLearnMore = Learn how Ceiling gets each provider's data
+DataSourceClaude = Reads usage from your signed-in Claude Code or Claude Desktop session, an OAuth token, or claude.ai cookies you provide. Talks only to api.anthropic.com and claude.ai.
+DataSourceCodex = Uses the OAuth token from your Codex CLI (~/.codex) plus local session logs on this PC. Talks only to chatgpt.com.
+DataSourceCursor = Uses your signed-in Cursor IDE session, or cursor.com cookies you provide. Talks only to cursor.com.
+DataSourceCopilot = Uses your GitHub CLI or Git Credential Manager token. Talks only to api.github.com, or your configured GitHub Enterprise host.
+DataSourceGemini = Reads the OAuth token from the Gemini CLI (~/.gemini). Talks only to Google's Code Assist and OAuth endpoints.
+DataSourceGeneric = Reads this provider's usage from a local session or token on this PC, or by calling the provider's own usage endpoint. Your credentials stay on this PC and are only sent to the provider.
 
-# Provider data-source / privacy explainer (SOU-179)
-DataSourceSectionTitle = Ceiling がこのデータを取得する方法
-DataSourcePrivacyNote = Ceiling は、この PC 上のローカルアプリのセッションやログから、またはプロバイダー自身の使用状況エンドポイントを呼び出して使用状況を読み取ります。認証情報と使用状況データはこの PC に留まり、Ceiling が運用するサーバーに送信されることは決してなく、プロバイダー本体にのみ送信されます。
-DataSourceLearnMore = Ceiling が各プロバイダーのデータを取得する方法を見る
-DataSourceClaude = ログイン済みの Claude Code または Claude Desktop のセッション、OAuth トークン、または提供された claude.ai の Cookie から使用状況を読み取ります。api.anthropic.com と claude.ai のみと通信します。
-DataSourceCodex = Codex CLI (~/.codex) の OAuth トークンと、この PC 上のローカルセッションログを使用します。chatgpt.com のみと通信します。
-DataSourceCursor = ログイン済みの Cursor IDE セッション、または提供された cursor.com の Cookie を使用します。cursor.com のみと通信します。
-DataSourceCopilot = GitHub CLI または Git 資格情報マネージャーのトークンを使用します。api.github.com、または設定した GitHub Enterprise ホストのみと通信します。
-DataSourceGemini = Gemini CLI (~/.gemini) から OAuth トークンを読み取ります。Google の Code Assist と OAuth のエンドポイントのみと通信します。
-DataSourceGeneric = この PC 上のローカルセッションまたはトークンから、あるいはプロバイダー自身の使用状況エンドポイントを呼び出して、このプロバイダーの使用状況を読み取ります。認証情報はこの PC に留まり、プロバイダーにのみ送信されます。
-
-# First-run checklist (SOU-157)
-FirstRunTitle = Ceiling のセットアップを完了する
-FirstRunStepEnable = 使用するプロバイダーを有効にする
-FirstRunStepAuth = サインインを接続または確認する
-FirstRunStepFloatbar = フローティングバーまたはタスクバーグランスをオンにする
-FirstRunOpenProviders = プロバイダー設定を開く
-FirstRunOpenDisplay = 表示設定を開く
-FirstRunDismiss = 閉じる
+# First-run checklist (SOU-157) — English only
+FirstRunTitle = Finish setting up Ceiling
+FirstRunStepEnable = Enable the providers you use
+FirstRunStepAuth = Connect or confirm your sign-in
+FirstRunStepFloatbar = Turn on the floating bar or taskbar glance
+FirstRunOpenProviders = Open provider settings
+FirstRunOpenDisplay = Open display settings
+FirstRunDismiss = Dismiss

--- a/rust/src/locale/ja-JP.ftl
+++ b/rust/src/locale/ja-JP.ftl
@@ -591,3 +591,23 @@ PredictivePaceWarningTitle = { "{}" } ? { "{}" } ?????
 PredictivePaceWarningBody = ?? { "{}" } ???????????????
 ShowResetWhenExhausted = ???????????????
 ShowResetWhenExhaustedHelper = ??????????????????????????????
+
+# Provider data-source / privacy explainer (SOU-179)
+DataSourceSectionTitle = Ceiling がこのデータを取得する方法
+DataSourcePrivacyNote = Ceiling は、この PC 上のローカルアプリのセッションやログから、またはプロバイダー自身の使用状況エンドポイントを呼び出して使用状況を読み取ります。認証情報と使用状況データはこの PC に留まり、Ceiling が運用するサーバーに送信されることは決してなく、プロバイダー本体にのみ送信されます。
+DataSourceLearnMore = Ceiling が各プロバイダーのデータを取得する方法を見る
+DataSourceClaude = ログイン済みの Claude Code または Claude Desktop のセッション、OAuth トークン、または提供された claude.ai の Cookie から使用状況を読み取ります。api.anthropic.com と claude.ai のみと通信します。
+DataSourceCodex = Codex CLI (~/.codex) の OAuth トークンと、この PC 上のローカルセッションログを使用します。chatgpt.com のみと通信します。
+DataSourceCursor = ログイン済みの Cursor IDE セッション、または提供された cursor.com の Cookie を使用します。cursor.com のみと通信します。
+DataSourceCopilot = GitHub CLI または Git 資格情報マネージャーのトークンを使用します。api.github.com、または設定した GitHub Enterprise ホストのみと通信します。
+DataSourceGemini = Gemini CLI (~/.gemini) から OAuth トークンを読み取ります。Google の Code Assist と OAuth のエンドポイントのみと通信します。
+DataSourceGeneric = この PC 上のローカルセッションまたはトークンから、あるいはプロバイダー自身の使用状況エンドポイントを呼び出して、このプロバイダーの使用状況を読み取ります。認証情報はこの PC に留まり、プロバイダーにのみ送信されます。
+
+# First-run checklist (SOU-157)
+FirstRunTitle = Ceiling のセットアップを完了する
+FirstRunStepEnable = 使用するプロバイダーを有効にする
+FirstRunStepAuth = サインインを接続または確認する
+FirstRunStepFloatbar = フローティングバーまたはタスクバーグランスをオンにする
+FirstRunOpenProviders = プロバイダー設定を開く
+FirstRunOpenDisplay = 表示設定を開く
+FirstRunDismiss = 閉じる

--- a/rust/src/locale/ko-KR.ftl
+++ b/rust/src/locale/ko-KR.ftl
@@ -591,3 +591,23 @@ PredictivePaceWarningTitle = { "{}" } { "{}" } ?? ?? ??
 PredictivePaceWarningBody = { "{}" } ? ???? ??? ? ????
 ShowResetWhenExhausted = ?? ? ??? ?? ??
 ShowResetWhenExhaustedHelper = ??? ??? ??? ??? ??????? ????
+
+# Provider data-source / privacy explainer (SOU-179)
+DataSourceSectionTitle = Ceiling이 이 데이터를 가져오는 방법
+DataSourcePrivacyNote = Ceiling은 이 PC의 로컬 앱 세션과 로그에서, 또는 제공업체 자체의 사용량 엔드포인트를 호출하여 사용량을 읽습니다. 자격 증명과 사용량 데이터는 이 PC에 남아 있으며, Ceiling이 운영하는 서버로 전송되지 않고 제공업체에만 전송됩니다.
+DataSourceLearnMore = Ceiling이 각 제공업체의 데이터를 가져오는 방법 알아보기
+DataSourceClaude = 로그인된 Claude Code 또는 Claude Desktop 세션, OAuth 토큰, 또는 사용자가 제공한 claude.ai 쿠키에서 사용량을 읽습니다. api.anthropic.com과 claude.ai에만 통신합니다.
+DataSourceCodex = Codex CLI(~/.codex)의 OAuth 토큰과 이 PC의 로컬 세션 로그를 사용합니다. chatgpt.com에만 통신합니다.
+DataSourceCursor = 로그인된 Cursor IDE 세션 또는 사용자가 제공한 cursor.com 쿠키를 사용합니다. cursor.com에만 통신합니다.
+DataSourceCopilot = GitHub CLI 또는 Git 자격 증명 관리자 토큰을 사용합니다. api.github.com 또는 구성한 GitHub Enterprise 호스트에만 통신합니다.
+DataSourceGemini = Gemini CLI(~/.gemini)에서 OAuth 토큰을 읽습니다. Google의 Code Assist 및 OAuth 엔드포인트에만 통신합니다.
+DataSourceGeneric = 이 PC의 로컬 세션이나 토큰에서, 또는 제공업체 자체의 사용량 엔드포인트를 호출하여 이 제공업체의 사용량을 읽습니다. 자격 증명은 이 PC에 남아 있으며 제공업체에만 전송됩니다.
+
+# First-run checklist (SOU-157)
+FirstRunTitle = Ceiling 설정 완료하기
+FirstRunStepEnable = 사용하는 제공업체 활성화
+FirstRunStepAuth = 로그인 연결 또는 확인
+FirstRunStepFloatbar = 플로팅 바 또는 작업 표시줄 미리 보기 켜기
+FirstRunOpenProviders = 제공업체 설정 열기
+FirstRunOpenDisplay = 디스플레이 설정 열기
+FirstRunDismiss = 닫기

--- a/rust/src/locale/ko-KR.ftl
+++ b/rust/src/locale/ko-KR.ftl
@@ -591,23 +591,22 @@ PredictivePaceWarningTitle = { "{}" } { "{}" } ?? ?? ??
 PredictivePaceWarningBody = { "{}" } ? ???? ??? ? ????
 ShowResetWhenExhausted = ?? ? ??? ?? ??
 ShowResetWhenExhaustedHelper = ??? ??? ??? ??? ??????? ????
+# Provider data-source / privacy explainer (SOU-179) — English only
+DataSourceSectionTitle = How Ceiling gets this data
+DataSourcePrivacyNote = Ceiling reads your usage from local app sessions and logs on this PC, or by calling the provider's own usage endpoint. Your credentials and usage data stay on this PC. They are never sent to Ceiling-operated servers, only to the provider itself.
+DataSourceLearnMore = Learn how Ceiling gets each provider's data
+DataSourceClaude = Reads usage from your signed-in Claude Code or Claude Desktop session, an OAuth token, or claude.ai cookies you provide. Talks only to api.anthropic.com and claude.ai.
+DataSourceCodex = Uses the OAuth token from your Codex CLI (~/.codex) plus local session logs on this PC. Talks only to chatgpt.com.
+DataSourceCursor = Uses your signed-in Cursor IDE session, or cursor.com cookies you provide. Talks only to cursor.com.
+DataSourceCopilot = Uses your GitHub CLI or Git Credential Manager token. Talks only to api.github.com, or your configured GitHub Enterprise host.
+DataSourceGemini = Reads the OAuth token from the Gemini CLI (~/.gemini). Talks only to Google's Code Assist and OAuth endpoints.
+DataSourceGeneric = Reads this provider's usage from a local session or token on this PC, or by calling the provider's own usage endpoint. Your credentials stay on this PC and are only sent to the provider.
 
-# Provider data-source / privacy explainer (SOU-179)
-DataSourceSectionTitle = Ceiling이 이 데이터를 가져오는 방법
-DataSourcePrivacyNote = Ceiling은 이 PC의 로컬 앱 세션과 로그에서, 또는 제공업체 자체의 사용량 엔드포인트를 호출하여 사용량을 읽습니다. 자격 증명과 사용량 데이터는 이 PC에 남아 있으며, Ceiling이 운영하는 서버로 전송되지 않고 제공업체에만 전송됩니다.
-DataSourceLearnMore = Ceiling이 각 제공업체의 데이터를 가져오는 방법 알아보기
-DataSourceClaude = 로그인된 Claude Code 또는 Claude Desktop 세션, OAuth 토큰, 또는 사용자가 제공한 claude.ai 쿠키에서 사용량을 읽습니다. api.anthropic.com과 claude.ai에만 통신합니다.
-DataSourceCodex = Codex CLI(~/.codex)의 OAuth 토큰과 이 PC의 로컬 세션 로그를 사용합니다. chatgpt.com에만 통신합니다.
-DataSourceCursor = 로그인된 Cursor IDE 세션 또는 사용자가 제공한 cursor.com 쿠키를 사용합니다. cursor.com에만 통신합니다.
-DataSourceCopilot = GitHub CLI 또는 Git 자격 증명 관리자 토큰을 사용합니다. api.github.com 또는 구성한 GitHub Enterprise 호스트에만 통신합니다.
-DataSourceGemini = Gemini CLI(~/.gemini)에서 OAuth 토큰을 읽습니다. Google의 Code Assist 및 OAuth 엔드포인트에만 통신합니다.
-DataSourceGeneric = 이 PC의 로컬 세션이나 토큰에서, 또는 제공업체 자체의 사용량 엔드포인트를 호출하여 이 제공업체의 사용량을 읽습니다. 자격 증명은 이 PC에 남아 있으며 제공업체에만 전송됩니다.
-
-# First-run checklist (SOU-157)
-FirstRunTitle = Ceiling 설정 완료하기
-FirstRunStepEnable = 사용하는 제공업체 활성화
-FirstRunStepAuth = 로그인 연결 또는 확인
-FirstRunStepFloatbar = 플로팅 바 또는 작업 표시줄 미리 보기 켜기
-FirstRunOpenProviders = 제공업체 설정 열기
-FirstRunOpenDisplay = 디스플레이 설정 열기
-FirstRunDismiss = 닫기
+# First-run checklist (SOU-157) — English only
+FirstRunTitle = Finish setting up Ceiling
+FirstRunStepEnable = Enable the providers you use
+FirstRunStepAuth = Connect or confirm your sign-in
+FirstRunStepFloatbar = Turn on the floating bar or taskbar glance
+FirstRunOpenProviders = Open provider settings
+FirstRunOpenDisplay = Open display settings
+FirstRunDismiss = Dismiss

--- a/rust/src/locale/zh-CN.ftl
+++ b/rust/src/locale/zh-CN.ftl
@@ -591,23 +591,22 @@ PredictivePaceWarningTitle = { "{}" } { "{}" }??????
 PredictivePaceWarningBody = ????? { "{}" } ???
 ShowResetWhenExhausted = ?????????
 ShowResetWhenExhaustedHelper = ?????????????????
+# Provider data-source / privacy explainer (SOU-179) — English only
+DataSourceSectionTitle = How Ceiling gets this data
+DataSourcePrivacyNote = Ceiling reads your usage from local app sessions and logs on this PC, or by calling the provider's own usage endpoint. Your credentials and usage data stay on this PC. They are never sent to Ceiling-operated servers, only to the provider itself.
+DataSourceLearnMore = Learn how Ceiling gets each provider's data
+DataSourceClaude = Reads usage from your signed-in Claude Code or Claude Desktop session, an OAuth token, or claude.ai cookies you provide. Talks only to api.anthropic.com and claude.ai.
+DataSourceCodex = Uses the OAuth token from your Codex CLI (~/.codex) plus local session logs on this PC. Talks only to chatgpt.com.
+DataSourceCursor = Uses your signed-in Cursor IDE session, or cursor.com cookies you provide. Talks only to cursor.com.
+DataSourceCopilot = Uses your GitHub CLI or Git Credential Manager token. Talks only to api.github.com, or your configured GitHub Enterprise host.
+DataSourceGemini = Reads the OAuth token from the Gemini CLI (~/.gemini). Talks only to Google's Code Assist and OAuth endpoints.
+DataSourceGeneric = Reads this provider's usage from a local session or token on this PC, or by calling the provider's own usage endpoint. Your credentials stay on this PC and are only sent to the provider.
 
-# Provider data-source / privacy explainer (SOU-179)
-DataSourceSectionTitle = Ceiling 如何获取这些数据
-DataSourcePrivacyNote = Ceiling 从本机的本地应用会话和日志读取你的用量，或调用服务商自己的用量接口。你的凭据和用量数据保留在本机，绝不会发送到 Ceiling 运营的服务器，只会发送给服务商本身。
-DataSourceLearnMore = 了解 Ceiling 如何获取各服务商的数据
-DataSourceClaude = 从你已登录的 Claude Code 或 Claude Desktop 会话、OAuth 令牌，或你提供的 claude.ai Cookie 读取用量。仅与 api.anthropic.com 和 claude.ai 通信。
-DataSourceCodex = 使用你的 Codex CLI (~/.codex) 中的 OAuth 令牌以及本机的本地会话日志。仅与 chatgpt.com 通信。
-DataSourceCursor = 使用你已登录的 Cursor IDE 会话，或你提供的 cursor.com Cookie。仅与 cursor.com 通信。
-DataSourceCopilot = 使用你的 GitHub CLI 或 Git 凭据管理器令牌。仅与 api.github.com 或你配置的 GitHub Enterprise 主机通信。
-DataSourceGemini = 从 Gemini CLI (~/.gemini) 读取 OAuth 令牌。仅与 Google 的 Code Assist 和 OAuth 接口通信。
-DataSourceGeneric = 从本机的本地会话或令牌读取该服务商的用量，或调用服务商自己的用量接口。你的凭据保留在本机，只会发送给服务商。
-
-# First-run checklist (SOU-157)
-FirstRunTitle = 完成 Ceiling 设置
-FirstRunStepEnable = 启用你使用的服务商
-FirstRunStepAuth = 连接或确认你的登录
-FirstRunStepFloatbar = 打开悬浮条或任务栏概览
-FirstRunOpenProviders = 打开服务商设置
-FirstRunOpenDisplay = 打开显示设置
-FirstRunDismiss = 忽略
+# First-run checklist (SOU-157) — English only
+FirstRunTitle = Finish setting up Ceiling
+FirstRunStepEnable = Enable the providers you use
+FirstRunStepAuth = Connect or confirm your sign-in
+FirstRunStepFloatbar = Turn on the floating bar or taskbar glance
+FirstRunOpenProviders = Open provider settings
+FirstRunOpenDisplay = Open display settings
+FirstRunDismiss = Dismiss

--- a/rust/src/locale/zh-CN.ftl
+++ b/rust/src/locale/zh-CN.ftl
@@ -591,3 +591,23 @@ PredictivePaceWarningTitle = { "{}" } { "{}" }??????
 PredictivePaceWarningBody = ????? { "{}" } ???
 ShowResetWhenExhausted = ?????????
 ShowResetWhenExhaustedHelper = ?????????????????
+
+# Provider data-source / privacy explainer (SOU-179)
+DataSourceSectionTitle = Ceiling 如何获取这些数据
+DataSourcePrivacyNote = Ceiling 从本机的本地应用会话和日志读取你的用量，或调用服务商自己的用量接口。你的凭据和用量数据保留在本机，绝不会发送到 Ceiling 运营的服务器，只会发送给服务商本身。
+DataSourceLearnMore = 了解 Ceiling 如何获取各服务商的数据
+DataSourceClaude = 从你已登录的 Claude Code 或 Claude Desktop 会话、OAuth 令牌，或你提供的 claude.ai Cookie 读取用量。仅与 api.anthropic.com 和 claude.ai 通信。
+DataSourceCodex = 使用你的 Codex CLI (~/.codex) 中的 OAuth 令牌以及本机的本地会话日志。仅与 chatgpt.com 通信。
+DataSourceCursor = 使用你已登录的 Cursor IDE 会话，或你提供的 cursor.com Cookie。仅与 cursor.com 通信。
+DataSourceCopilot = 使用你的 GitHub CLI 或 Git 凭据管理器令牌。仅与 api.github.com 或你配置的 GitHub Enterprise 主机通信。
+DataSourceGemini = 从 Gemini CLI (~/.gemini) 读取 OAuth 令牌。仅与 Google 的 Code Assist 和 OAuth 接口通信。
+DataSourceGeneric = 从本机的本地会话或令牌读取该服务商的用量，或调用服务商自己的用量接口。你的凭据保留在本机，只会发送给服务商。
+
+# First-run checklist (SOU-157)
+FirstRunTitle = 完成 Ceiling 设置
+FirstRunStepEnable = 启用你使用的服务商
+FirstRunStepAuth = 连接或确认你的登录
+FirstRunStepFloatbar = 打开悬浮条或任务栏概览
+FirstRunOpenProviders = 打开服务商设置
+FirstRunOpenDisplay = 打开显示设置
+FirstRunDismiss = 忽略

--- a/rust/src/locale/zh-TW.ftl
+++ b/rust/src/locale/zh-TW.ftl
@@ -591,23 +591,22 @@ PredictivePaceWarningTitle = { "{}" } { "{}" }??????
 PredictivePaceWarningBody = ????? { "{}" } ???
 ShowResetWhenExhausted = ?????????
 ShowResetWhenExhaustedHelper = ????????????????
+# Provider data-source / privacy explainer (SOU-179) — English only
+DataSourceSectionTitle = How Ceiling gets this data
+DataSourcePrivacyNote = Ceiling reads your usage from local app sessions and logs on this PC, or by calling the provider's own usage endpoint. Your credentials and usage data stay on this PC. They are never sent to Ceiling-operated servers, only to the provider itself.
+DataSourceLearnMore = Learn how Ceiling gets each provider's data
+DataSourceClaude = Reads usage from your signed-in Claude Code or Claude Desktop session, an OAuth token, or claude.ai cookies you provide. Talks only to api.anthropic.com and claude.ai.
+DataSourceCodex = Uses the OAuth token from your Codex CLI (~/.codex) plus local session logs on this PC. Talks only to chatgpt.com.
+DataSourceCursor = Uses your signed-in Cursor IDE session, or cursor.com cookies you provide. Talks only to cursor.com.
+DataSourceCopilot = Uses your GitHub CLI or Git Credential Manager token. Talks only to api.github.com, or your configured GitHub Enterprise host.
+DataSourceGemini = Reads the OAuth token from the Gemini CLI (~/.gemini). Talks only to Google's Code Assist and OAuth endpoints.
+DataSourceGeneric = Reads this provider's usage from a local session or token on this PC, or by calling the provider's own usage endpoint. Your credentials stay on this PC and are only sent to the provider.
 
-# Provider data-source / privacy explainer (SOU-179)
-DataSourceSectionTitle = Ceiling 如何取得這些資料
-DataSourcePrivacyNote = Ceiling 會從本機的本機應用程式工作階段和記錄讀取你的用量，或呼叫服務商自己的用量端點。你的憑證和用量資料會保留在本機，絕不會傳送到 Ceiling 營運的伺服器，只會傳送給服務商本身。
-DataSourceLearnMore = 了解 Ceiling 如何取得各服務商的資料
-DataSourceClaude = 從你已登入的 Claude Code 或 Claude Desktop 工作階段、OAuth 權杖，或你提供的 claude.ai Cookie 讀取用量。僅與 api.anthropic.com 和 claude.ai 通訊。
-DataSourceCodex = 使用你的 Codex CLI (~/.codex) 中的 OAuth 權杖以及本機的本機工作階段記錄。僅與 chatgpt.com 通訊。
-DataSourceCursor = 使用你已登入的 Cursor IDE 工作階段，或你提供的 cursor.com Cookie。僅與 cursor.com 通訊。
-DataSourceCopilot = 使用你的 GitHub CLI 或 Git 認證管理員權杖。僅與 api.github.com 或你設定的 GitHub Enterprise 主機通訊。
-DataSourceGemini = 從 Gemini CLI (~/.gemini) 讀取 OAuth 權杖。僅與 Google 的 Code Assist 和 OAuth 端點通訊。
-DataSourceGeneric = 從本機的本機工作階段或權杖讀取該服務商的用量，或呼叫服務商自己的用量端點。你的憑證會保留在本機，只會傳送給服務商。
-
-# First-run checklist (SOU-157)
-FirstRunTitle = 完成 Ceiling 設定
-FirstRunStepEnable = 啟用你使用的服務商
-FirstRunStepAuth = 連接或確認你的登入
-FirstRunStepFloatbar = 開啟浮動列或工作列一覽
-FirstRunOpenProviders = 開啟服務商設定
-FirstRunOpenDisplay = 開啟顯示設定
-FirstRunDismiss = 略過
+# First-run checklist (SOU-157) — English only
+FirstRunTitle = Finish setting up Ceiling
+FirstRunStepEnable = Enable the providers you use
+FirstRunStepAuth = Connect or confirm your sign-in
+FirstRunStepFloatbar = Turn on the floating bar or taskbar glance
+FirstRunOpenProviders = Open provider settings
+FirstRunOpenDisplay = Open display settings
+FirstRunDismiss = Dismiss

--- a/rust/src/locale/zh-TW.ftl
+++ b/rust/src/locale/zh-TW.ftl
@@ -591,3 +591,23 @@ PredictivePaceWarningTitle = { "{}" } { "{}" }??????
 PredictivePaceWarningBody = ????? { "{}" } ???
 ShowResetWhenExhausted = ?????????
 ShowResetWhenExhaustedHelper = ????????????????
+
+# Provider data-source / privacy explainer (SOU-179)
+DataSourceSectionTitle = Ceiling 如何取得這些資料
+DataSourcePrivacyNote = Ceiling 會從本機的本機應用程式工作階段和記錄讀取你的用量，或呼叫服務商自己的用量端點。你的憑證和用量資料會保留在本機，絕不會傳送到 Ceiling 營運的伺服器，只會傳送給服務商本身。
+DataSourceLearnMore = 了解 Ceiling 如何取得各服務商的資料
+DataSourceClaude = 從你已登入的 Claude Code 或 Claude Desktop 工作階段、OAuth 權杖，或你提供的 claude.ai Cookie 讀取用量。僅與 api.anthropic.com 和 claude.ai 通訊。
+DataSourceCodex = 使用你的 Codex CLI (~/.codex) 中的 OAuth 權杖以及本機的本機工作階段記錄。僅與 chatgpt.com 通訊。
+DataSourceCursor = 使用你已登入的 Cursor IDE 工作階段，或你提供的 cursor.com Cookie。僅與 cursor.com 通訊。
+DataSourceCopilot = 使用你的 GitHub CLI 或 Git 認證管理員權杖。僅與 api.github.com 或你設定的 GitHub Enterprise 主機通訊。
+DataSourceGemini = 從 Gemini CLI (~/.gemini) 讀取 OAuth 權杖。僅與 Google 的 Code Assist 和 OAuth 端點通訊。
+DataSourceGeneric = 從本機的本機工作階段或權杖讀取該服務商的用量，或呼叫服務商自己的用量端點。你的憑證會保留在本機，只會傳送給服務商。
+
+# First-run checklist (SOU-157)
+FirstRunTitle = 完成 Ceiling 設定
+FirstRunStepEnable = 啟用你使用的服務商
+FirstRunStepAuth = 連接或確認你的登入
+FirstRunStepFloatbar = 開啟浮動列或工作列一覽
+FirstRunOpenProviders = 開啟服務商設定
+FirstRunOpenDisplay = 開啟顯示設定
+FirstRunDismiss = 略過


### PR DESCRIPTION
Two v1 trust/onboarding surfaces. **Both are visual and user-facing copy — needs an eyeball on Windows (dark + light) before merge.**

## SOU-179 — "How Ceiling gets this data" (High, security)

A new block in every provider detail pane (under the identity rows) with a short, **source-verified** provenance line + a precise privacy note.

- Dedicated copy for **Claude, Codex, Cursor, Copilot, Gemini**, checked against the real fetch paths in `rust/src/providers/*`; every other provider gets a precise **generic** line. `providerProvenance.ts` maps id → locale key.
- **Review coverage** (the issue asked for this): `providerProvenance.test.ts` asserts the five keep dedicated copy and every resolvable key exists in the locale set — a new/renamed provider can't silently drop to generic or a missing string.
- **Privacy copy follows the guardrail**: no "never leaves your PC" (credentials *are* sent to the provider's own endpoint to fetch usage). It states data is never sent to *Ceiling-operated* servers, only to the provider. I also **corrected the README's inaccurate "never leave your machine" line**.
- New **`docs/DATA_SOURCES.md`** maintained reference, linked from the panel (opens the doc) and the README.

## SOU-157 — first-run checklist (Medium)

A dismissible 3-step checklist (enable providers → connect/confirm auth → turn on floatbar/tray) in the empty PopOut dashboard. Steps reflect real state (`enabledProviders`, floatbar/taskbar enabled) and deep-link into the matching Settings tab. Dismissal persists in `localStorage` (same pattern as the detected-accounts card); a returning user with working auth never sees it because the dashboard shows their providers instead of the empty state. Loading still shows the spinner.

Deep-linking is tab-level (existing mechanism); sub-section/provider jump would need new plumbing and is deferred.

## Verification
- `pnpm test` — 48 files / 235 tests (9 new)
- `pnpm run build` — check-locale (16 new keys, TS↔Rust parity) + tsc + vite green
- `cargo check` (shared crate) — green

## Eyeball checklist (Windows, both themes)
- Provider detail → the "How Ceiling gets this data" block reads clearly; "Learn more" opens the doc
- Fresh profile (or clear `localStorage`) → empty dashboard shows the checklist; steps flip to done as you enable a provider / turn on the floatbar; dismiss sticks

Closes SOU-179. Addresses SOU-157.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dismissible first-run checklist in the main overview (with saved dismissal) to guide enabling providers, completing sign-in, and activating display/floatbar steps.
  * Added a provider data-source/privacy explainer section in provider settings, including a “Learn more” link.
  * Added provider-specific provenance messaging with a generic fallback.
* **Documentation**
  * Updated README download/privacy wording and added detailed local-first data-sources/privacy documentation.
* **Tests**
  * Added UI tests for checklist interactions and validation coverage for provenance fallback and localization key consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->