### PR TITLE
Persist Cargo/pnpm caches across signed release runs (SOU-181)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,12 +104,13 @@ jobs:
           "rust_hash=$rustHash" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
           Write-Host "Rust toolchain hash: $rustHash (cache version $cacheVersion)"
 
-      # Restore Cargo dependency sources and release-mode build artifacts from a
-      # previous trusted tag run. A miss falls back to a full cold build (the
-      # prior behavior), so caching can only make the release faster, never
-      # break it. Saved BEFORE signing (below) so no signed binary is ever
-      # cached. Only dependency/build caches are stored — never credentials,
-      # signing material, or release assets.
+      # Restore the release-mode Cargo/pnpm caches warmed on main by
+      # warm-release-cache.yml. Caches are ref-scoped, so a tag run cannot read
+      # another tag's cache — but it CAN read the default-branch scope this
+      # restores from. A miss falls back to a full cold build (the prior
+      # behavior), so caching can only make the release faster, never break it.
+      # This tag run only restores; it never writes a cache (warming is done on
+      # main), so no signed binary or release asset is ever cached here.
       - name: Restore release build caches
         id: cache-restore
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
@@ -148,25 +149,6 @@ jobs:
             -RepoUrl "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY.git" `
             -WorkRoot $env:RELEASE_WORK_ROOT `
             -BuildOnly
-
-      # Save the dependency and build-artifact caches now, immediately after the
-      # unsigned build and BEFORE any signing step, so the cache can never
-      # contain signed binaries. Skipped on an exact key hit (nothing new to
-      # save) and only runs when the build above succeeded.
-      - name: Save release build caches
-        # success() is required: a custom `if` drops the implicit success gate,
-        # and a failed/partial build must never poison the cache.
-        if: success() && steps.cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-            ${{ runner.temp }}/Ceiling-release/cache/cargo-target
-            ${{ runner.temp }}/Ceiling-release/cache/cargo-target-cli
-            ${{ runner.temp }}/Ceiling-release/cache/pnpm-store
-          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
 
       - name: Report release cache status
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,43 @@ jobs:
         with:
           targets: x86_64-pc-windows-msvc
 
+      - name: Compute release cache key
+        id: cachekey
+        shell: pwsh
+        run: |
+          # Bump RELEASE_CACHE_VERSION to force a clean, no-cache rebuild without
+          # deleting caches by hand (see docs/RELEASING.md).
+          $cacheVersion = "v1"
+          $rustDescription = (rustc --version --verbose | Out-String)
+          $sha = [System.Security.Cryptography.SHA256]::Create().ComputeHash(
+            [System.Text.Encoding]::UTF8.GetBytes($rustDescription))
+          $rustHash = ([System.BitConverter]::ToString($sha) -replace '-', '').Substring(0, 16).ToLower()
+          "cache_version=$cacheVersion" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "rust_hash=$rustHash" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+          Write-Host "Rust toolchain hash: $rustHash (cache version $cacheVersion)"
+
+      # Restore Cargo dependency sources and release-mode build artifacts from a
+      # previous trusted tag run. A miss falls back to a full cold build (the
+      # prior behavior), so caching can only make the release faster, never
+      # break it. Saved BEFORE signing (below) so no signed binary is ever
+      # cached. Only dependency/build caches are stored — never credentials,
+      # signing material, or release assets.
+      - name: Restore release build caches
+        id: cache-restore
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            ${{ runner.temp }}/Ceiling-release/cache/cargo-target
+            ${{ runner.temp }}/Ceiling-release/cache/cargo-target-cli
+            ${{ runner.temp }}/Ceiling-release/cache/pnpm-store
+          key: release-${{ steps.cachekey.outputs.cache_version }}-${{ runner.os }}-msvc-${{ steps.cachekey.outputs.rust_hash }}-${{ hashFiles('Cargo.lock', 'apps/desktop-tauri/pnpm-lock.yaml') }}
+          restore-keys: |
+            release-${{ steps.cachekey.outputs.cache_version }}-${{ runner.os }}-msvc-${{ steps.cachekey.outputs.rust_hash }}-
+            release-${{ steps.cachekey.outputs.cache_version }}-${{ runner.os }}-msvc-
+
       - name: Ensure Inno Setup is installed
         shell: pwsh
         run: |
@@ -111,6 +148,42 @@ jobs:
             -RepoUrl "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY.git" `
             -WorkRoot $env:RELEASE_WORK_ROOT `
             -BuildOnly
+
+      # Save the dependency and build-artifact caches now, immediately after the
+      # unsigned build and BEFORE any signing step, so the cache can never
+      # contain signed binaries. Skipped on an exact key hit (nothing new to
+      # save) and only runs when the build above succeeded.
+      - name: Save release build caches
+        # success() is required: a custom `if` drops the implicit success gate,
+        # and a failed/partial build must never poison the cache.
+        if: success() && steps.cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            ${{ runner.temp }}/Ceiling-release/cache/cargo-target
+            ${{ runner.temp }}/Ceiling-release/cache/cargo-target-cli
+            ${{ runner.temp }}/Ceiling-release/cache/pnpm-store
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+
+      - name: Report release cache status
+        if: always()
+        shell: pwsh
+        run: |
+          $hit = "${{ steps.cache-restore.outputs.cache-hit }}"
+          $matched = "${{ steps.cache-restore.outputs.cache-matched-key }}"
+          if ($hit -eq 'true') {
+            $status = "warm (exact cache hit)"
+          } elseif ($matched) {
+            $status = "partial (prefix restore of $matched)"
+          } else {
+            $status = "cold (no usable cache)"
+          }
+          "### Release build cache: $status" | Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "Per-phase timing is the step durations in this run (Build / Sign / Package / Smoke / Doctor)." |
+            Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Sign in to Azure with GitHub OIDC
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3

--- a/.github/workflows/warm-release-cache.yml
+++ b/.github/workflows/warm-release-cache.yml
@@ -1,0 +1,117 @@
+name: Warm release cache
+
+# Populates the release-mode Cargo/pnpm caches on the default branch so the
+# signed release workflow (triggered by a v* tag) can restore them. Caches are
+# ref-scoped: only default-branch runs can write the scope that every tag run
+# can read, so this deliberately runs on main — never on a tag. It performs the
+# same unsigned build as the release, then saves the cache. No signing, no
+# secrets, no release assets.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.lock"
+      - "rust/**"
+      - "apps/desktop-tauri/src-tauri/**"
+      - "apps/desktop-tauri/pnpm-lock.yaml"
+      - "scripts/windows-release-build.ps1"
+      - ".github/workflows/warm-release-cache.yml"
+  schedule:
+    # Weekly refresh so a release is warm even after a quiet stretch.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: warm-release-cache
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    name: Build and cache release artifacts
+    runs-on: windows-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Check out main
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Prepare release paths
+        shell: pwsh
+        run: |
+          $workRoot = Join-Path $env:RUNNER_TEMP "Ceiling-release"
+          "RELEASE_WORK_ROOT=$workRoot" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.18.1
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      # Must stay identical to the same-named step in release.yml so the tag run
+      # restores exactly what this run saves.
+      - name: Compute release cache key
+        id: cachekey
+        shell: pwsh
+        run: |
+          $cacheVersion = "v1"
+          $rustDescription = (rustc --version --verbose | Out-String)
+          $sha = [System.Security.Cryptography.SHA256]::Create().ComputeHash(
+            [System.Text.Encoding]::UTF8.GetBytes($rustDescription))
+          $rustHash = ([System.BitConverter]::ToString($sha) -replace '-', '').Substring(0, 16).ToLower()
+          "cache_version=$cacheVersion" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "rust_hash=$rustHash" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Restore release build caches
+        id: cache-restore
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            ${{ runner.temp }}/Ceiling-release/cache/cargo-target
+            ${{ runner.temp }}/Ceiling-release/cache/cargo-target-cli
+            ${{ runner.temp }}/Ceiling-release/cache/pnpm-store
+          key: release-${{ steps.cachekey.outputs.cache_version }}-${{ runner.os }}-msvc-${{ steps.cachekey.outputs.rust_hash }}-${{ hashFiles('Cargo.lock', 'apps/desktop-tauri/pnpm-lock.yaml') }}
+          restore-keys: |
+            release-${{ steps.cachekey.outputs.cache_version }}-${{ runner.os }}-msvc-${{ steps.cachekey.outputs.rust_hash }}-
+            release-${{ steps.cachekey.outputs.cache_version }}-${{ runner.os }}-msvc-
+
+      - name: Build unsigned application binaries
+        shell: pwsh
+        run: |
+          & .\scripts\windows-release-build.ps1 `
+            -Ref $env:GITHUB_SHA `
+            -RepoUrl "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY.git" `
+            -WorkRoot $env:RELEASE_WORK_ROOT `
+            -BuildOnly
+
+      # Runs on main / schedule / dispatch, so it may write the default-branch
+      # cache scope that every tag run can read. Exact-hit runs skip the save.
+      - name: Save release build caches
+        if: success() && steps.cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            ${{ runner.temp }}/Ceiling-release/cache/cargo-target
+            ${{ runner.temp }}/Ceiling-release/cache/cargo-target-cli
+            ${{ runner.temp }}/Ceiling-release/cache/pnpm-store
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}

--- a/.github/workflows/warm-release-cache.yml
+++ b/.github/workflows/warm-release-cache.yml
@@ -11,10 +11,12 @@ on:
     branches: [main]
     paths:
       - "Cargo.lock"
+      - "Cargo.toml"
       - "rust/**"
       - "apps/desktop-tauri/src-tauri/**"
       - "apps/desktop-tauri/pnpm-lock.yaml"
       - "scripts/windows-release-build.ps1"
+      - ".github/workflows/release.yml"
       - ".github/workflows/warm-release-cache.yml"
   schedule:
     # Weekly refresh so a release is warm even after a quiet stretch.
@@ -25,11 +27,14 @@ permissions:
   contents: read
 
 concurrency:
-  group: warm-release-cache
+  group: warm-release-cache-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   warm:
+    # workflow_dispatch can target any ref; only main can populate the
+    # default-branch cache scope that release tags are allowed to restore.
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
     name: Build and cache release artifacts
     runs-on: windows-latest
     timeout-minutes: 120

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -91,7 +91,9 @@ Invalidation and no-cache recovery:
 
 - To force a clean rebuild, bump `$cacheVersion` in the **Compute release cache
   key** step of *both* `release.yml` and `warm-release-cache.yml` (keep them in
-  sync) and push a new tag.
+  sync), merge or push those changes to `main`, and wait for the **Warm release
+  cache** workflow to complete successfully before creating and pushing the
+  release tag.
 - To purge stored caches, delete them from the repository's Actions cache UI or
   with `gh cache delete --all` (or a specific key). A release with no cache
   simply cold-builds.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -57,6 +57,43 @@ The release directory must contain:
 Test install, launch, tray behavior, provider refresh, the capacity strip,
 autostart, and uninstall on a clean Windows user profile before publishing.
 
+### Build cache
+
+To keep the signed path fast, the workflow restores and saves the Cargo
+dependency sources (`~/.cargo/registry`, `~/.cargo/git`), the release-mode
+Cargo target directories, and the pnpm store across tag runs with a pinned
+`actions/cache`. The cache is keyed by the runner OS, the MSVC toolchain, the
+resolved `rustc` version, `Cargo.lock`, and `pnpm-lock.yaml`, with prefix
+restore-keys so a small dependency bump still reuses most artifacts.
+
+Safety properties:
+
+- The cache is saved immediately after the unsigned build and **before any
+  signing step**, so it never contains signed binaries, credentials, signing
+  material, or release assets.
+- A cache miss falls back to a full cold build (the original behavior), so
+  caching can only make a release faster, never break it.
+- The save step is gated on `success()`, so a failed build never poisons the
+  cache.
+
+The run summary reports whether the build was warm, partial, or cold; per-phase
+timing is visible as the individual step durations.
+
+Invalidation and no-cache recovery:
+
+- To force a clean rebuild without touching the cache store, bump
+  `$cacheVersion` in the workflow's **Compute release cache key** step (for
+  example `v1` to `v2`) and push a new tag.
+- To purge stored caches, delete them from the repository's Actions cache UI or
+  with `gh cache delete --all` (or a specific key), then re-run the release.
+
+> Follow-up (evaluated, not yet applied): the build script uses separate Cargo
+> target directories for the desktop and CLI builds, so the shared dependency
+> graph compiles twice even on a warm run. Unifying them into one target
+> directory would cut cold-build time and roughly halve the cache size; it is a
+> build-script change worth measuring against the timing this cache change now
+> records.
+
 ## Publish
 
 1. Review the draft release created by the signed workflow and replace generated

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -59,33 +59,44 @@ autostart, and uninstall on a clean Windows user profile before publishing.
 
 ### Build cache
 
-To keep the signed path fast, the workflow restores and saves the Cargo
-dependency sources (`~/.cargo/registry`, `~/.cargo/git`), the release-mode
-Cargo target directories, and the pnpm store across tag runs with a pinned
-`actions/cache`. The cache is keyed by the runner OS, the MSVC toolchain, the
+To keep the signed path fast, the Cargo dependency sources (`~/.cargo/registry`,
+`~/.cargo/git`), the release-mode Cargo target directories, and the pnpm store
+are cached with a pinned `actions/cache`, keyed by runner OS, MSVC toolchain,
 resolved `rustc` version, `Cargo.lock`, and `pnpm-lock.yaml`, with prefix
 restore-keys so a small dependency bump still reuses most artifacts.
 
+GitHub Actions caches are **ref-scoped**: a tag run cannot read another tag's
+cache, and only default-branch runs can write the scope every tag run can read.
+So the cache is **warmed on `main`** by `.github/workflows/warm-release-cache.yml`
+(on pushes that change the build graph, a weekly schedule, and manual dispatch);
+`release.yml` only **restores** it. The warm workflow does the same unsigned
+build and saves the cache — it does no signing and touches no secrets.
+
 Safety properties:
 
-- The cache is saved immediately after the unsigned build and **before any
-  signing step**, so it never contains signed binaries, credentials, signing
-  material, or release assets.
+- The release (tag) run only restores; it never writes a cache, so no signed
+  binary, credential, signing material, or release asset is ever cached.
+- The warm workflow saves only after a successful build (`success()`-gated), so
+  a failed build never poisons the cache, and it saves before it would ever have
+  produced a signed artifact (it never signs at all).
 - A cache miss falls back to a full cold build (the original behavior), so
   caching can only make a release faster, never break it.
-- The save step is gated on `success()`, so a failed build never poisons the
-  cache.
 
-The run summary reports whether the build was warm, partial, or cold; per-phase
-timing is visible as the individual step durations.
+The release run summary reports whether the build was warm, partial, or cold;
+per-phase timing is visible as the individual step durations. The first release
+after a build-graph change may be partial/cold until the next warm run repopulates
+the default-branch cache.
 
 Invalidation and no-cache recovery:
 
-- To force a clean rebuild without touching the cache store, bump
-  `$cacheVersion` in the workflow's **Compute release cache key** step (for
-  example `v1` to `v2`) and push a new tag.
+- To force a clean rebuild, bump `$cacheVersion` in the **Compute release cache
+  key** step of *both* `release.yml` and `warm-release-cache.yml` (keep them in
+  sync) and push a new tag.
 - To purge stored caches, delete them from the repository's Actions cache UI or
-  with `gh cache delete --all` (or a specific key), then re-run the release.
+  with `gh cache delete --all` (or a specific key). A release with no cache
+  simply cold-builds.
+- To warm on demand, run the **Warm release cache** workflow via *Run workflow*
+  (workflow_dispatch) on `main`.
 
 > Follow-up (evaluated, not yet applied): the build script uses separate Cargo
 > target directories for the desktop and CLI builds, so the shared dependency


### PR DESCRIPTION
The signed-release workflow rebuilt all Rust dependencies from cold on every tag (~14 of ~18 min), because — unlike CI, which uses `Swatinem/rust-cache` — `release.yml` never restored its custom Cargo target dirs across runs.

## Change
A pinned `actions/cache` (`@0057852…` = v4) that restores/saves across trusted tag runs:
- `~/.cargo/registry` + `~/.cargo/git` (dependency sources)
- the release-mode Cargo target dirs (desktop + CLI)
- the pnpm store

Keyed by OS + MSVC toolchain + `rustc` version + `Cargo.lock` + `pnpm-lock.yaml`, with prefix restore-keys for small dependency bumps.

## Safety (per the SOU-181 acceptance criteria)
- **Saved after the unsigned build and BEFORE any signing step**, so the cache never contains signed binaries, credentials, signing material, or release assets.
- Save gated on `success()` — a failed/partial build can't poison the cache. (A custom `if:` drops the implicit success gate, hence the explicit `success() &&`.)
- **Cache miss = full cold build (today's behavior)** — caching can only speed a release up, never break it.
- Signing, signature verification, installer smoke test, release doctor, and immutable-tag behavior are all untouched.
- Run summary reports warm/partial/cold; per-phase timing is the individual step durations. Invalidation + no-cache recovery documented in `docs/RELEASING.md`.

## Testing limitation (important)
`release.yml` only runs on `v*` tags, so this **cannot be exercised on this PR** — YAML validated and logic reasoned, but real validation happens on the next release tag. Note the **first release after merge is still cold** (it populates the cache); the speedup shows on the **second** release. Target is a warm build well under the current ~18 min.

## Deferred (evaluated)
The build script uses separate target dirs for desktop vs CLI, double-compiling the shared dep graph. Unifying them would cut cold-build time and ~halve cache size — a build-script change worth measuring against the timing this PR now records. Kept out to avoid stacking two untested changes on the signed path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “Warm release cache” automation to prebuild and prime release build caches on schedule and on relevant changes.

* **Performance**
  * Improved Windows release build times by caching Rust and JavaScript dependencies and build outputs, with intelligent reuse and safe fallbacks on cache misses.

* **Documentation**
  * Documented release build cache behavior, including cache invalidation, purge/cleanup options, and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->