### PR TITLE
Fix reset notification delivery

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/capacity_events.rs
+++ b/apps/desktop-tauri/src-tauri/src/capacity_events.rs
@@ -19,6 +19,7 @@ pub enum CapacityEventKind {
     ScheduledReset,
     SurpriseReset,
     PartialReset,
+    BankedResetGranted,
     ResetTimeShift,
     WindowLifted,
     WindowRestored,
@@ -35,6 +36,10 @@ pub struct CapacityEventPayload {
     pub kind: CapacityEventKind,
     pub previous_used_percent: f64,
     pub current_used_percent: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_reset_credits: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_reset_credits: Option<u32>,
     pub previous_reset_at: String,
     pub current_reset_at: String,
     pub occurred_at: String,
@@ -49,6 +54,9 @@ impl CapacityEventPayload {
             }
             CapacityEventKind::PartialReset => {
                 format!("{} capacity partially restored", self.display_name)
+            }
+            CapacityEventKind::BankedResetGranted => {
+                format!("{} banked reset available", self.display_name)
             }
             CapacityEventKind::ResetTimeShift => {
                 format!("{} reset time changed", self.display_name)
@@ -80,6 +88,14 @@ impl CapacityEventPayload {
                 "{} dropped from {:.0}% to {:.0}% used. {:.0}% available now.",
                 self.window_label, self.previous_used_percent, self.current_used_percent, remaining
             ),
+            CapacityEventKind::BankedResetGranted => {
+                let available = self.current_reset_credits.unwrap_or(1);
+                format!(
+                    "{} banked reset{} available now.",
+                    available,
+                    if available == 1 { " is" } else { "s are" }
+                )
+            }
             CapacityEventKind::ResetTimeShift => {
                 format!("{} now has a different reset time.", self.window_label)
             }
@@ -116,12 +132,20 @@ struct ProviderObservation {
     inactive_windows: HashMap<String, String>,
     #[serde(default)]
     extra_window_ids: HashSet<String>,
+    #[serde(default)]
+    reset_credits_available: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PendingReset {
     event: PersistedEvent,
     candidate: ObservedWindow,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PendingResetCredits {
+    event: PersistedEvent,
+    candidate: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -145,6 +169,10 @@ struct PersistedEvent {
     kind: CapacityEventKind,
     previous_used_percent: f64,
     current_used_percent: f64,
+    #[serde(default)]
+    previous_reset_credits: Option<u32>,
+    #[serde(default)]
+    current_reset_credits: Option<u32>,
     previous_reset_at: DateTime<Utc>,
     current_reset_at: DateTime<Utc>,
     occurred_at: DateTime<Utc>,
@@ -160,6 +188,8 @@ impl PersistedEvent {
             kind: self.kind,
             previous_used_percent: self.previous_used_percent,
             current_used_percent: self.current_used_percent,
+            previous_reset_credits: self.previous_reset_credits,
+            current_reset_credits: self.current_reset_credits,
             previous_reset_at: self.previous_reset_at.to_rfc3339(),
             current_reset_at: self.current_reset_at.to_rfc3339(),
             occurred_at: self.occurred_at.to_rfc3339(),
@@ -174,6 +204,8 @@ pub struct CapacityEventObserver {
     /// unfinished event from the previous run as a fresh launch notification.
     #[serde(skip)]
     pending_resets: HashMap<String, PendingReset>,
+    #[serde(skip)]
+    pending_reset_credits: HashMap<String, PendingResetCredits>,
     #[serde(skip)]
     pending_transitions: HashMap<String, PendingTransition>,
     /// Every provider/account scope is re-baselined on its first live reading
@@ -197,6 +229,7 @@ impl CapacityEventObserver {
             .unwrap_or_default();
         // Explicitly discard candidates written by older builds.
         observer.pending_resets.clear();
+        observer.pending_reset_credits.clear();
         observer.pending_transitions.clear();
         observer.persistence_path = path;
         observer
@@ -216,6 +249,7 @@ impl CapacityEventObserver {
             windows,
             inactive_windows: inactive_windows(snapshot),
             extra_window_ids,
+            reset_credits_available: snapshot.reset_credits_available,
         };
 
         if self.seen_scopes.insert(scope.clone()) {
@@ -233,6 +267,30 @@ impl CapacityEventObserver {
         let mut emitted = Vec::new();
         let mut held_for_confirmation = false;
         let mut confirmed_windows = HashSet::new();
+        let reset_credit_key = format!("{scope}:banked-resets");
+        let mut confirmed_reset_credits = false;
+        if let Some(pending) = self.pending_reset_credits.get(&reset_credit_key).cloned() {
+            if current.reset_credits_available == Some(pending.candidate) {
+                if confirmation_is_mature(pending.event.occurred_at, current.observed_at) {
+                    self.pending_reset_credits.remove(&reset_credit_key);
+                    emitted.push(pending.event.payload());
+                    confirmed_reset_credits = true;
+                } else {
+                    held_for_confirmation = true;
+                }
+            } else {
+                self.pending_reset_credits.remove(&reset_credit_key);
+            }
+        }
+        if !confirmed_reset_credits
+            && !self.pending_reset_credits.contains_key(&reset_credit_key)
+            && let Some(event) = detect_banked_reset_grant(snapshot, &previous, &current)
+        {
+            let candidate = current.reset_credits_available.unwrap_or_default();
+            self.pending_reset_credits
+                .insert(reset_credit_key, PendingResetCredits { event, candidate });
+            held_for_confirmation = true;
+        }
         for (window_id, current_window) in &current.windows {
             let pending_key = format!("{scope}:{window_id}");
             if let Some(pending) = self.pending_resets.get(&pending_key).cloned() {
@@ -371,9 +429,40 @@ fn detect_reset(
         kind,
         previous_used_percent: previous.used_percent,
         current_used_percent: current.used_percent,
+        previous_reset_credits: None,
+        current_reset_credits: None,
         previous_reset_at: previous.resets_at,
         current_reset_at: current.resets_at,
         occurred_at: current_observation.observed_at,
+    })
+}
+
+fn detect_banked_reset_grant(
+    snapshot: &ProviderUsageSnapshot,
+    previous: &ProviderObservation,
+    current: &ProviderObservation,
+) -> Option<PersistedEvent> {
+    if snapshot.provider_id != "codex" {
+        return None;
+    }
+    let previous_credits = previous.reset_credits_available?;
+    let current_credits = current.reset_credits_available?;
+    if current_credits <= previous_credits {
+        return None;
+    }
+    Some(PersistedEvent {
+        provider_id: snapshot.provider_id.clone(),
+        display_name: snapshot.display_name.clone(),
+        window_id: "banked-resets".to_string(),
+        window_label: "Banked resets".to_string(),
+        kind: CapacityEventKind::BankedResetGranted,
+        previous_used_percent: 0.0,
+        current_used_percent: 0.0,
+        previous_reset_credits: Some(previous_credits),
+        current_reset_credits: Some(current_credits),
+        previous_reset_at: previous.observed_at,
+        current_reset_at: current.observed_at,
+        occurred_at: current.observed_at,
     })
 }
 
@@ -472,6 +561,8 @@ fn detect_transition(
             kind,
             previous_used_percent,
             current_used_percent,
+            previous_reset_credits: None,
+            current_reset_credits: None,
             previous_reset_at,
             current_reset_at,
             occurred_at: current.observed_at,
@@ -738,6 +829,14 @@ mod tests {
         snapshot
     }
 
+    fn with_reset_credits(
+        mut snapshot: ProviderUsageSnapshot,
+        available: u32,
+    ) -> ProviderUsageSnapshot {
+        snapshot.reset_credits_available = Some(available);
+        snapshot
+    }
+
     #[test]
     fn surprise_reset_requires_a_consistent_second_read() {
         let start = Utc::now();
@@ -762,6 +861,69 @@ mod tests {
         ));
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].kind, CapacityEventKind::SurpriseReset);
+    }
+
+    #[test]
+    fn banked_reset_grant_requires_a_consistent_second_read() {
+        let start = Utc::now();
+        let reset = start + Duration::days(7);
+        let mut observer = CapacityEventObserver::default();
+
+        assert!(
+            observer
+                .observe(&with_reset_credits(snapshot(start, 45.0, reset), 0))
+                .is_empty()
+        );
+        assert!(
+            observer
+                .observe(&with_reset_credits(
+                    snapshot(start + Duration::minutes(5), 46.0, reset),
+                    1,
+                ))
+                .is_empty()
+        );
+        let events = observer.observe(&with_reset_credits(
+            snapshot(start + Duration::minutes(10), 47.0, reset),
+            1,
+        ));
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, CapacityEventKind::BankedResetGranted);
+        assert_eq!(events[0].previous_reset_credits, Some(0));
+        assert_eq!(events[0].current_reset_credits, Some(1));
+        assert_eq!(
+            events[0].notification_title(),
+            "Codex banked reset available"
+        );
+        assert_eq!(
+            events[0].notification_body(),
+            "1 banked reset is available now."
+        );
+    }
+
+    #[test]
+    fn startup_and_consumed_banked_resets_do_not_emit() {
+        let start = Utc::now();
+        let reset = start + Duration::days(7);
+        let mut observer = CapacityEventObserver::default();
+
+        observer.observe(&with_reset_credits(snapshot(start, 45.0, reset), 1));
+        assert!(
+            observer
+                .observe(&with_reset_credits(
+                    snapshot(start + Duration::minutes(5), 46.0, reset),
+                    0,
+                ))
+                .is_empty()
+        );
+        assert!(
+            observer
+                .observe(&with_reset_credits(
+                    snapshot(start + Duration::minutes(10), 47.0, reset),
+                    0,
+                ))
+                .is_empty()
+        );
     }
 
     #[test]

--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -324,11 +324,18 @@ async fn refresh_provider(app: tauri::AppHandle, id: ProviderId, ctx: FetchConte
     if notification_settings.show_notifications
         && notification_settings.capacity_event_notifications_enabled
         && let Some((title, body)) = capacity_event_notification(&capacity_events)
-        && let Ok(mut guard) = state.lock()
     {
-        guard
-            .notification_manager
-            .notify_capacity_event(&title, &body);
+        let notified = state.lock().is_ok_and(|mut guard| {
+            guard
+                .notification_manager
+                .notify_capacity_event(&title, &body)
+        });
+        if notified {
+            codexbar::sound::play_alert(
+                codexbar::sound::AlertSound::Success,
+                &notification_settings,
+            );
+        }
     }
 }
 
@@ -340,6 +347,7 @@ fn capacity_event_uses_windows_notification(
         crate::capacity_events::CapacityEventKind::ScheduledReset
             | crate::capacity_events::CapacityEventKind::SurpriseReset
             | crate::capacity_events::CapacityEventKind::PartialReset
+            | crate::capacity_events::CapacityEventKind::BankedResetGranted
     )
 }
 
@@ -358,10 +366,20 @@ fn capacity_event_notification(
             let body = events
                 .iter()
                 .map(|event| {
-                    format!(
-                        "{} {:.0}% → {:.0}% used",
-                        event.window_label, event.previous_used_percent, event.current_used_percent
-                    )
+                    if event.kind == crate::capacity_events::CapacityEventKind::BankedResetGranted {
+                        let available = event.current_reset_credits.unwrap_or(1);
+                        format!(
+                            "{available} banked reset{} available",
+                            if available == 1 { "" } else { "s" }
+                        )
+                    } else {
+                        format!(
+                            "{} {:.0}% → {:.0}% used",
+                            event.window_label,
+                            event.previous_used_percent,
+                            event.current_used_percent
+                        )
+                    }
                 })
                 .collect::<Vec<_>>()
                 .join("; ");
@@ -851,6 +869,9 @@ mod predictive_warning_tests {
         assert!(capacity_event_uses_windows_notification(
             CapacityEventKind::PartialReset
         ));
+        assert!(capacity_event_uses_windows_notification(
+            CapacityEventKind::BankedResetGranted
+        ));
         for visual_only in [
             CapacityEventKind::ResetTimeShift,
             CapacityEventKind::WindowLifted,
@@ -874,6 +895,8 @@ mod predictive_warning_tests {
                 kind: CapacityEventKind::PartialReset,
                 previous_used_percent: before,
                 current_used_percent: after,
+                previous_reset_credits: None,
+                current_reset_credits: None,
                 previous_reset_at: "2026-08-06T22:49:57Z".into(),
                 current_reset_at: "2026-08-06T22:49:57Z".into(),
                 occurred_at: "2026-07-15T20:21:45Z".into(),

--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -325,11 +325,15 @@ async fn refresh_provider(app: tauri::AppHandle, id: ProviderId, ctx: FetchConte
         && notification_settings.capacity_event_notifications_enabled
         && let Some((title, body)) = capacity_event_notification(&capacity_events)
     {
-        let notified = state.lock().is_ok_and(|mut guard| {
-            guard
+        let notified = match state.lock() {
+            Ok(mut guard) => guard
                 .notification_manager
-                .notify_capacity_event(&title, &body)
-        });
+                .notify_capacity_event(&title, &body),
+            Err(error) => {
+                tracing::warn!("failed to lock app state for capacity notification: {error}");
+                false
+            }
+        };
         if notified {
             codexbar::sound::play_alert(
                 codexbar::sound::AlertSound::Success,
@@ -909,5 +913,43 @@ mod predictive_warning_tests {
         let (title, body) = capacity_event_notification(&events).unwrap();
         assert_eq!(title, "Cursor capacity restored");
         assert_eq!(body, "Auto 99% → 50% used; Plan 85% → 48% used.");
+    }
+
+    #[test]
+    fn batched_banked_resets_pluralize_without_disturbing_window_formatting() {
+        use crate::capacity_events::{CapacityEventKind, CapacityEventPayload};
+
+        let partial = CapacityEventPayload {
+            provider_id: "codex".into(),
+            display_name: "Codex".into(),
+            window_id: "weekly".into(),
+            window_label: "Weekly".into(),
+            kind: CapacityEventKind::PartialReset,
+            previous_used_percent: 90.0,
+            current_used_percent: 10.0,
+            previous_reset_credits: None,
+            current_reset_credits: None,
+            previous_reset_at: "2026-07-25T03:42:20Z".into(),
+            current_reset_at: "2026-07-25T03:42:20Z".into(),
+            occurred_at: "2026-07-18T03:25:06Z".into(),
+        };
+        let banked = CapacityEventPayload {
+            provider_id: "codex".into(),
+            display_name: "Codex".into(),
+            window_id: "banked-resets".into(),
+            window_label: "Banked resets".into(),
+            kind: CapacityEventKind::BankedResetGranted,
+            previous_used_percent: 0.0,
+            current_used_percent: 0.0,
+            previous_reset_credits: Some(1),
+            current_reset_credits: Some(2),
+            previous_reset_at: "2026-07-18T03:20:05Z".into(),
+            current_reset_at: "2026-07-18T03:25:06Z".into(),
+            occurred_at: "2026-07-18T03:25:06Z".into(),
+        };
+
+        let (title, body) = capacity_event_notification(&[partial, banked]).unwrap();
+        assert_eq!(title, "Codex capacity restored");
+        assert_eq!(body, "Weekly 90% → 10% used; 2 banked resets available.");
     }
 }

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
@@ -137,6 +137,29 @@ describe("GeneralTab", () => {
     );
   });
 
+  it("shows the Windows delivery error returned by the notification test", async () => {
+    sendTestNotificationMock.mockRejectedValueOnce(
+      "Windows notifications are turned off for Ceiling.",
+    );
+    render(
+      <GeneralTab
+        mode="notifications"
+        settings={settings}
+        set={vi.fn()}
+        saving={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "NotificationTestButton" }));
+
+    expect(
+      await screen.findByRole("alert"),
+    ).toHaveTextContent("Windows notifications are turned off for Ceiling.");
+    expect(
+      screen.getByRole("button", { name: "NotificationTestFailed" }),
+    ).toBeInTheDocument();
+  });
+
   it("disables the test notification button when notifications are off", () => {
     render(
       <GeneralTab

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.tsx
@@ -15,6 +15,7 @@ export default function GeneralTab({
   const { t } = useLocale();
   const [playingSound, setPlayingSound] = useState(false);
   const [testStatus, setTestStatus] = useState<TestNotificationStatus>("idle");
+  const [testError, setTestError] = useState<string | null>(null);
 
   const handleTestSound = useCallback(() => {
     setPlayingSound(true);
@@ -24,13 +25,19 @@ export default function GeneralTab({
 
   const handleTestNotification = useCallback(() => {
     setTestStatus("sending");
+    setTestError(null);
     void sendTestNotification()
       .then(() => setTestStatus("sent"))
-      .catch(() => setTestStatus("failed"))
+      .catch((error: unknown) => {
+        setTestStatus("failed");
+        setTestError(
+          typeof error === "string" ? error : t("NotificationTestFailed"),
+        );
+      })
       .finally(() => {
         window.setTimeout(() => setTestStatus("idle"), 4000);
       });
-  }, []);
+  }, [t]);
 
   return (
     <>
@@ -111,6 +118,11 @@ export default function GeneralTab({
                       : t("NotificationTestButton")}
               </button>
             </div>
+            {testError && (
+              <div className="settings-status settings-status--error" role="alert">
+                {testError}
+              </div>
+            )}
           </Field>
           <Field label={t("SoundEnabled")} description={t("SoundEnabledHelper")} leading>
             <div className="sound-enabled-row">

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -495,12 +495,15 @@ export interface CapacityEventPayload {
     | "scheduledReset"
     | "surpriseReset"
     | "partialReset"
+    | "bankedResetGranted"
     | "resetTimeShift"
     | "windowLifted"
     | "windowRestored"
     | "allowanceGranted";
   previousUsedPercent: number;
   currentUsedPercent: number;
+  previousResetCredits?: number;
+  currentResetCredits?: number;
   previousResetAt: string;
   currentResetAt: string;
   occurredAt: string;

--- a/rust/src/notifications.rs
+++ b/rust/src/notifications.rs
@@ -243,6 +243,11 @@ impl NotificationManager {
             );
             return false;
         }
+        #[cfg(all(target_os = "windows", not(test)))]
+        if let Err(reason) = windows_notification_delivery_check() {
+            tracing::warn!(title, %reason, "Windows notification delivery is disabled");
+            return false;
+        }
         if self.refresh_cycle_active {
             let now = std::time::Instant::now();
             while self
@@ -781,6 +786,7 @@ pub fn send_test_notification() -> Result<(), String> {
     use std::process::Command;
 
     ensure_aumid_registered_once();
+    windows_notification_delivery_check()?;
 
     let title = "Ceiling notifications are on";
     let body = "This is a test. Unexpected resets and usage alerts will look like this.";
@@ -810,6 +816,45 @@ pub fn send_test_notification() -> Result<(), String> {
     } else {
         Err(detail.to_string())
     }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_notification_delivery_check() -> Result<(), String> {
+    use winreg::RegKey;
+    use winreg::enums::HKEY_CURRENT_USER;
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    if let Ok(key) =
+        hkcu.open_subkey(r"SOFTWARE\Microsoft\Windows\CurrentVersion\PushNotifications")
+        && key.get_value::<u32, _>("ToastEnabled").ok() == Some(0)
+    {
+        return Err(
+            "Windows notifications are turned off. Turn them on in Settings > System > Notifications."
+                .to_string(),
+        );
+    }
+
+    if let Ok(key) = hkcu
+        .open_subkey(r"SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings\Ceiling")
+    {
+        let disabled = notification_channel_is_disabled(key.get_value::<u32, _>("Enabled").ok());
+        if disabled {
+            return Err(
+                "Windows notifications are turned off for Ceiling. Enable Ceiling in Settings > System > Notifications."
+                    .to_string(),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn notification_channel_is_disabled(enabled: Option<u32>) -> bool {
+    // `ShowInActionCenter=0` only disables notification-center history. Windows
+    // may leave it behind after the user re-enables the app channel, while
+    // banners are deliverable again. Only the explicit app toggle blocks us.
+    enabled == Some(0)
 }
 
 /// Non-Windows fallback for the test-notification button.
@@ -880,6 +925,14 @@ mod tests {
             eta_seconds,
             will_last_to_reset,
         }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn notification_channel_only_blocks_explicit_disable_flags() {
+        assert!(!notification_channel_is_disabled(None));
+        assert!(!notification_channel_is_disabled(Some(1)));
+        assert!(notification_channel_is_disabled(Some(0)));
     }
 
     fn window(now: DateTime<Utc>, offset: Duration, minutes: u32) -> RateWindow {


### PR DESCRIPTION
## Summary
- detect when Windows globally or specifically disables Ceiling notifications and surface the real test error
- notify after a confirmed Codex banked-reset credit arrives
- play the configured success sound for confirmed reset and banked-reset notifications

## Root cause
Ceiling trusted WinRT accepting a toast request even when Windows had explicitly disabled the app channel. Banked reset credits were displayed but were not observed as notification-worthy transitions.

## Validation
- `cargo test --manifest-path rust/Cargo.toml` (622 passed)
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` (374 passed)
- clippy with `-D warnings` on both Rust manifests
- `npm test -- --run` (247 passed)
- `npm run build`
- live Windows AUMID/WinRT toast accepted after restoring the Ceiling channel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new capacity event for banked reset credit grants, including optional previous/current credit counts and updated notification copy.
  * Expanded window-notification eligibility to include banked reset grants.
  * Added a success alert sound when capacity notifications are actually delivered.
* **Bug Fixes**
  * Windows toasts are now suppressed when notifications are globally or app/channel-disabled, with descriptive messaging.
  * Notification testing now shows the returned error text in the UI when delivery fails.
* **Tests**
  * Added/updated coverage for banked reset confirmation behavior, batched notification formatting, and Windows delivery disable settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->