### PR TITLE
Split Codex cost by real reasoning-effort tier (SOU-263)

### DIFF
--- a/rust/src/cli/cost.rs
+++ b/rust/src/cli/cost.rs
@@ -167,18 +167,18 @@ fn print_text_output(results: &[CostResult], use_color: bool, days: u32) {
                 }
             }
 
-            if !result.summary.by_speed.is_empty() {
-                println!("  Codex speed:");
-                for bucket in ["standard", "fast"] {
-                    if let Some(cost) = result.summary.by_speed.get(bucket) {
-                        let tokens = result
-                            .summary
-                            .by_speed_tokens
-                            .get(bucket)
-                            .map(|counts| format_number(counts.total()))
-                            .unwrap_or_else(|| "0".to_string());
-                        println!("    {}: ${:.2} ({} tokens)", bucket, cost, tokens);
-                    }
+            if !result.summary.by_effort.is_empty() {
+                println!("  Codex effort:");
+                let mut efforts: Vec<_> = result.summary.by_effort.iter().collect();
+                efforts.sort_by(|a, b| b.1.partial_cmp(a.1).unwrap_or(std::cmp::Ordering::Equal));
+                for (bucket, cost) in efforts {
+                    let tokens = result
+                        .summary
+                        .by_effort_tokens
+                        .get(bucket)
+                        .map(|counts| format_number(counts.total()))
+                        .unwrap_or_else(|| "0".to_string());
+                    println!("    {}: ${:.2} ({} tokens)", bucket, cost, tokens);
                 }
             }
         }
@@ -218,8 +218,8 @@ fn print_json_output(results: &[CostResult], pretty: bool, days: u32) -> anyhow:
                     },
                     "sessions_count": r.summary.sessions_count,
                     "by_model": r.summary.by_model,
-                    "by_speed": r.summary.by_speed,
-                    "by_speed_tokens": r.summary.by_speed_tokens.iter().map(|(bucket, counts)| {
+                    "by_effort": r.summary.by_effort,
+                    "by_effort_tokens": r.summary.by_effort_tokens.iter().map(|(bucket, counts)| {
                         (bucket.clone(), serde_json::json!({
                             "input": counts.input_tokens,
                             "output": counts.output_tokens,

--- a/rust/src/cli/cost.rs
+++ b/rust/src/cli/cost.rs
@@ -167,18 +167,26 @@ fn print_text_output(results: &[CostResult], use_color: bool, days: u32) {
                 }
             }
 
-            if !result.summary.by_effort.is_empty() {
+            // Render every effort tier that has tokens, including unpriced
+            // usage (present in by_effort_tokens but not by_effort). Cost
+            // defaults to $0.00, matching the JSON contract.
+            if !result.summary.by_effort_tokens.is_empty() {
                 println!("  Codex effort:");
-                let mut efforts: Vec<_> = result.summary.by_effort.iter().collect();
-                efforts.sort_by(|a, b| b.1.partial_cmp(a.1).unwrap_or(std::cmp::Ordering::Equal));
-                for (bucket, cost) in efforts {
-                    let tokens = result
-                        .summary
-                        .by_effort_tokens
-                        .get(bucket)
-                        .map(|counts| format_number(counts.total()))
-                        .unwrap_or_else(|| "0".to_string());
-                    println!("    {}: ${:.2} ({} tokens)", bucket, cost, tokens);
+                let cost_of =
+                    |bucket: &str| result.summary.by_effort.get(bucket).copied().unwrap_or(0.0);
+                let mut efforts: Vec<_> = result.summary.by_effort_tokens.iter().collect();
+                efforts.sort_by(|(a, _), (b, _)| {
+                    cost_of(b)
+                        .partial_cmp(&cost_of(a))
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                for (bucket, counts) in efforts {
+                    println!(
+                        "    {}: ${:.2} ({} tokens)",
+                        bucket,
+                        cost_of(bucket),
+                        format_number(counts.total())
+                    );
                 }
             }
         }

--- a/rust/src/codex_costs.rs
+++ b/rust/src/codex_costs.rs
@@ -39,7 +39,9 @@ pub(crate) fn add_codex_records_to_summary(
         CostUsageDayRange::is_in_range(&record.day_key, &range.since_key, &range.until_key)
     }) {
         let tokens = CodexTokenCounts::from_values(record.input, record.cached, record.output);
-        if let Some(cost) = add_codex_tokens_to_summary(summary, &record.model, tokens) {
+        if let Some(cost) =
+            add_codex_tokens_to_summary(summary, &record.model, record.effort.as_deref(), tokens)
+        {
             total_cost += cost;
             has_tokens = true;
         }
@@ -58,7 +60,7 @@ pub(crate) fn add_codex_record_to_summary(
     record: &CodexUsageRecord,
 ) -> Option<f64> {
     let tokens = CodexTokenCounts::from_values(record.input, record.cached, record.output);
-    add_codex_tokens_to_summary(summary, &record.model, tokens)
+    add_codex_tokens_to_summary(summary, &record.model, record.effort.as_deref(), tokens)
 }
 
 pub(crate) fn scan_codex_file_cost_for_range(path: &Path, range: &CostUsageDayRange) -> f64 {
@@ -114,6 +116,7 @@ fn add_tokens(summary: &mut ModelTokenCounts, tokens: CodexTokenCounts) {
 fn add_codex_tokens_to_summary(
     summary: &mut CostSummary,
     model: &str,
+    effort: Option<&str>,
     tokens: CodexTokenCounts,
 ) -> Option<f64> {
     if tokens.is_empty() {
@@ -125,7 +128,7 @@ fn add_codex_tokens_to_summary(
     summary.cached_tokens += tokens.cached;
     summary.cache_read_tokens += tokens.cached;
     summary.output_tokens += tokens.output;
-    let speed_bucket = codex_speed_bucket(model);
+    let effort_bucket = codex_effort_bucket(effort);
     add_tokens(
         summary
             .by_model_tokens
@@ -135,8 +138,8 @@ fn add_codex_tokens_to_summary(
     );
     add_tokens(
         summary
-            .by_speed_tokens
-            .entry(speed_bucket.to_string())
+            .by_effort_tokens
+            .entry(effort_bucket.to_string())
             .or_default(),
         tokens,
     );
@@ -151,8 +154,8 @@ fn add_codex_tokens_to_summary(
 
     *summary.by_model.entry(model.to_string()).or_insert(0.0) += cost;
     *summary
-        .by_speed
-        .entry(speed_bucket.to_string())
+        .by_effort
+        .entry(effort_bucket.to_string())
         .or_insert(0.0) += cost;
     Some(cost)
 }
@@ -181,16 +184,13 @@ fn codex_records_cost(records: &[CodexUsageRecord], range: &CostUsageDayRange) -
     total_cost
 }
 
-fn codex_speed_bucket(model: &str) -> &'static str {
-    let normalized = model.to_ascii_lowercase();
-    if normalized.contains("fast")
-        || normalized.contains("priority")
-        || normalized.contains("spark")
-        || normalized.contains("smoke")
-    {
-        "fast"
-    } else {
-        "standard"
+/// Map a rollout's reasoning-effort string to a stable bucket key. Codex logs
+/// declare effort in `turn_context` (e.g. "medium"/"high"/"xhigh"); usage
+/// without a declared effort is bucketed as "unknown" rather than guessed.
+fn codex_effort_bucket(effort: Option<&str>) -> String {
+    match effort.map(str::trim).filter(|effort| !effort.is_empty()) {
+        Some(effort) => effort.to_ascii_lowercase(),
+        None => "unknown".to_string(),
     }
 }
 
@@ -209,6 +209,7 @@ mod tests {
                 day_key: "2026-05-31".to_string(),
                 timestamp: None,
                 model: "gpt-5.6-sol".to_string(),
+                effort: Some("high".to_string()),
                 input: 200_000,
                 cached: 0,
                 output: 0,
@@ -218,6 +219,7 @@ mod tests {
                 day_key: "2026-05-31".to_string(),
                 timestamp: None,
                 model: "gpt-4o".to_string(),
+                effort: Some("medium".to_string()),
                 input: 1_000_000,
                 cached: 0,
                 output: 1_000_000,
@@ -235,6 +237,12 @@ mod tests {
         assert!(summary.unknown_models.contains("gpt-4o"));
         // Both models' tokens are preserved for coverage.
         assert_eq!(summary.input_tokens, 1_200_000);
+        // Effort tiers: only the priced record adds dollars, but both tiers
+        // record tokens.
+        assert!(summary.by_effort.contains_key("high"));
+        assert!(!summary.by_effort.contains_key("medium"));
+        assert!(summary.by_effort_tokens.contains_key("high"));
+        assert!(summary.by_effort_tokens.contains_key("medium"));
     }
 
     #[test]
@@ -246,6 +254,7 @@ mod tests {
                 day_key: "2026-05-31".to_string(),
                 timestamp: None,
                 model: "gpt-5.6-sol".to_string(),
+                effort: Some("high".to_string()),
                 input: 200_000,
                 cached: 0,
                 output: 0,
@@ -254,6 +263,7 @@ mod tests {
                 day_key: "2026-05-31".to_string(),
                 timestamp: None,
                 model: "gpt-5.6-sol".to_string(),
+                effort: Some("high".to_string()),
                 input: 200_000,
                 cached: 0,
                 output: 0,
@@ -262,6 +272,7 @@ mod tests {
                 day_key: "2026-05-30".to_string(),
                 timestamp: None,
                 model: "gpt-5.6-sol".to_string(),
+                effort: Some("high".to_string()),
                 input: 200_000,
                 cached: 0,
                 output: 0,
@@ -286,6 +297,7 @@ mod tests {
             day_key: "2026-05-31".to_string(),
             timestamp: None,
             model: "gpt-mystery".to_string(),
+            effort: None,
             input: 1_000_000,
             cached: 0,
             output: 1_000_000,
@@ -302,9 +314,34 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_speed_bucket() {
-        assert_eq!(codex_speed_bucket("gpt-5.5-fast"), "fast");
-        assert_eq!(codex_speed_bucket("gpt-5.3-codex-spark"), "fast");
-        assert_eq!(codex_speed_bucket("gpt-5-codex"), "standard");
+    fn test_codex_effort_bucket() {
+        // Declared effort is lowercased and trimmed to a stable key.
+        assert_eq!(codex_effort_bucket(Some("high")), "high");
+        assert_eq!(codex_effort_bucket(Some("  XHigh ")), "xhigh");
+        // Missing or blank effort buckets as "unknown", never guessed.
+        assert_eq!(codex_effort_bucket(None), "unknown");
+        assert_eq!(codex_effort_bucket(Some("   ")), "unknown");
+    }
+
+    #[test]
+    fn unpriced_usage_still_records_effort_tokens() {
+        let target = NaiveDate::from_ymd_opt(2026, 5, 31).unwrap();
+        let range = CostUsageDayRange::new(target, target);
+        let records = vec![CodexUsageRecord {
+            day_key: "2026-05-31".to_string(),
+            timestamp: None,
+            model: "gpt-mystery".to_string(),
+            effort: None,
+            input: 1_000_000,
+            cached: 0,
+            output: 0,
+        }];
+        let mut summary = CostSummary::default();
+
+        add_codex_records_to_summary(&mut summary, &records, &range);
+
+        // No dollars for the unknown model, but the effort tier keeps tokens.
+        assert!(summary.by_effort.is_empty());
+        assert!(summary.by_effort_tokens.contains_key("unknown"));
     }
 }

--- a/rust/src/core/jsonl_scanner.rs
+++ b/rust/src/core/jsonl_scanner.rs
@@ -69,6 +69,10 @@ pub struct CodexUsageRecord {
     pub day_key: String,
     pub timestamp: Option<DateTime<chrono::Utc>>,
     pub model: String,
+    /// Reasoning effort in force when this delta was billed (from the enclosing
+    /// `turn_context`, e.g. "medium"/"high"/"xhigh"). `None` when the log never
+    /// declared one.
+    pub effort: Option<String>,
     pub input: i32,
     pub cached: i32,
     pub output: i32,
@@ -128,6 +132,9 @@ enum ReplayGate {
 
 struct CodexParserState {
     current_model: Option<String>,
+    /// Reasoning effort from the most recent `turn_context`, attached to each
+    /// token delta so cost can be split by effort tier.
+    current_effort: Option<String>,
     previous_totals: Option<CodexTotals>,
     records: Vec<CodexUsageRecord>,
     /// `Some` while suppressing a child session's replayed parent history.
@@ -156,6 +163,8 @@ struct CodexFastPayload<'a> {
     model: Option<&'a str>,
     #[serde(default, borrow)]
     model_name: Option<&'a str>,
+    #[serde(default, borrow)]
+    effort: Option<&'a str>,
     #[serde(default, borrow)]
     info: Option<CodexFastInfo<'a>>,
     #[serde(default)]
@@ -195,6 +204,7 @@ struct CodexFastTotals {
 enum CodexFastEvent<'a> {
     TurnContext {
         model: Option<&'a str>,
+        effort: Option<&'a str>,
     },
     TokenCount {
         timestamp: &'a str,
@@ -206,6 +216,7 @@ impl CodexParserState {
     fn new(initial_model: Option<String>, initial_totals: Option<CodexTotals>) -> Self {
         Self {
             current_model: initial_model,
+            current_effort: None,
             previous_totals: initial_totals,
             records: Vec::new(),
             replay_gate: None,
@@ -265,9 +276,12 @@ impl CodexParserState {
 
     fn process_fast_event(&mut self, event: CodexFastEvent<'_>, range: &CostUsageDayRange) {
         match event {
-            CodexFastEvent::TurnContext { model } => {
+            CodexFastEvent::TurnContext { model, effort } => {
                 if let Some(model) = model.filter(|model| !model.is_empty()) {
                     self.current_model = Some(model.to_string());
+                }
+                if let Some(effort) = effort.filter(|effort| !effort.is_empty()) {
+                    self.current_effort = Some(effort.to_string());
                 }
             }
             CodexFastEvent::TokenCount { timestamp, payload } => {
@@ -288,6 +302,14 @@ impl CodexParserState {
             .and_then(|v| v.as_str())
         {
             self.current_model = Some(model.to_string());
+        }
+        if let Some(effort) = obj
+            .get("effort")
+            .or_else(|| obj.get("payload").and_then(|payload| payload.get("effort")))
+            .and_then(|v| v.as_str())
+            .filter(|effort| !effort.is_empty())
+        {
+            self.current_effort = Some(effort.to_string());
         }
     }
 
@@ -387,6 +409,7 @@ impl CodexParserState {
             day_key,
             timestamp,
             model: CostUsagePricing::normalize_codex_model(model),
+            effort: self.current_effort.clone(),
             input,
             cached: cached.min(input),
             output,
@@ -481,7 +504,8 @@ fn parse_codex_fast_event(line: &str) -> Option<CodexFastEvent<'_>> {
                     })
                 })
                 .or(parsed.model);
-            Some(CodexFastEvent::TurnContext { model })
+            let effort = parsed.payload.as_ref().and_then(|payload| payload.effort);
+            Some(CodexFastEvent::TurnContext { model, effort })
         }
         "event_msg" => {
             let payload = parsed.payload.or(parsed.event_msg)?;
@@ -953,6 +977,41 @@ mod tests {
         assert_eq!(totals.input, 1250);
         assert_eq!(totals.cached, 260);
         assert_eq!(totals.output, 90);
+    }
+
+    #[test]
+    fn turn_context_effort_attaches_to_following_token_records() {
+        let range = CostUsageDayRange::new(
+            NaiveDate::from_ymd_opt(2026, 5, 31).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 5, 31).unwrap(),
+        );
+        let mut parser = CodexParserState::new(Some("gpt-5".to_string()), None);
+
+        // A turn at "high" effort, then usage.
+        parser.process_line(
+            r#"{"timestamp":"2026-05-31T10:00:00.000Z","type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"high"}}"#,
+            &range,
+        );
+        parser.process_line(
+            r#"{"timestamp":"2026-05-31T10:00:01.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":0,"output_tokens":50}}}}"#,
+            &range,
+        );
+        // A later turn switches to "xhigh"; the next delta carries the new tier.
+        parser.process_line(
+            r#"{"timestamp":"2026-05-31T10:05:00.000Z","type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"xhigh"}}"#,
+            &range,
+        );
+        parser.process_line(
+            r#"{"timestamp":"2026-05-31T10:05:01.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1500,"cached_input_tokens":0,"output_tokens":90}}}}"#,
+            &range,
+        );
+
+        let efforts: Vec<_> = parser
+            .records
+            .iter()
+            .map(|record| record.effort.as_deref())
+            .collect();
+        assert_eq!(efforts, vec![Some("high"), Some("xhigh")]);
     }
 
     #[test]

--- a/rust/src/core/jsonl_scanner.rs
+++ b/rust/src/core/jsonl_scanner.rs
@@ -280,9 +280,12 @@ impl CodexParserState {
                 if let Some(model) = model.filter(|model| !model.is_empty()) {
                     self.current_model = Some(model.to_string());
                 }
-                if let Some(effort) = effort.filter(|effort| !effort.is_empty()) {
-                    self.current_effort = Some(effort.to_string());
-                }
+                // Effort is a per-turn setting: reset it for every turn_context
+                // so a turn that omits it (or leaves it blank) becomes
+                // "unknown" rather than inheriting the previous turn's tier.
+                self.current_effort = effort
+                    .filter(|effort| !effort.trim().is_empty())
+                    .map(|effort| effort.to_string());
             }
             CodexFastEvent::TokenCount { timestamp, payload } => {
                 self.record_fast_token_count(payload, timestamp, range);
@@ -303,14 +306,15 @@ impl CodexParserState {
         {
             self.current_model = Some(model.to_string());
         }
-        if let Some(effort) = obj
+        // Effort is a per-turn setting: reset it for every turn_context so a
+        // turn that omits it (or leaves it blank) becomes "unknown" rather
+        // than inheriting the previous turn's tier.
+        self.current_effort = obj
             .get("effort")
             .or_else(|| obj.get("payload").and_then(|payload| payload.get("effort")))
             .and_then(|v| v.as_str())
-            .filter(|effort| !effort.is_empty())
-        {
-            self.current_effort = Some(effort.to_string());
-        }
+            .filter(|effort| !effort.trim().is_empty())
+            .map(|effort| effort.to_string());
     }
 
     fn record_token_count(&mut self, obj: &Value, range: &CostUsageDayRange) {
@@ -1005,13 +1009,51 @@ mod tests {
             r#"{"timestamp":"2026-05-31T10:05:01.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1500,"cached_input_tokens":0,"output_tokens":90}}}}"#,
             &range,
         );
+        // A turn that omits effort must NOT inherit "xhigh" — it resets to None.
+        parser.process_line(
+            r#"{"timestamp":"2026-05-31T10:10:00.000Z","type":"turn_context","payload":{"model":"gpt-5.6-sol"}}"#,
+            &range,
+        );
+        parser.process_line(
+            r#"{"timestamp":"2026-05-31T10:10:01.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1600,"cached_input_tokens":0,"output_tokens":95}}}}"#,
+            &range,
+        );
+        // A whitespace-only effort is treated the same as missing.
+        parser.process_line(
+            r#"{"timestamp":"2026-05-31T10:15:00.000Z","type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"  "}}"#,
+            &range,
+        );
+        parser.process_line(
+            r#"{"timestamp":"2026-05-31T10:15:01.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1700,"cached_input_tokens":0,"output_tokens":99}}}}"#,
+            &range,
+        );
 
         let efforts: Vec<_> = parser
             .records
             .iter()
             .map(|record| record.effort.as_deref())
             .collect();
-        assert_eq!(efforts, vec![Some("high"), Some("xhigh")]);
+        assert_eq!(efforts, vec![Some("high"), Some("xhigh"), None, None]);
+    }
+
+    #[test]
+    fn update_current_model_resets_effort_each_turn_on_json_path() {
+        // The serde_json fallback path must also reset effort per turn_context.
+        let mut parser = CodexParserState::new(Some("gpt-5".to_string()), None);
+        parser.update_current_model(
+            &serde_json::json!({"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"high"}}),
+        );
+        assert_eq!(parser.current_effort.as_deref(), Some("high"));
+        // A turn without effort clears the prior tier instead of inheriting it.
+        parser.update_current_model(
+            &serde_json::json!({"type":"turn_context","payload":{"model":"gpt-5.6-sol"}}),
+        );
+        assert_eq!(parser.current_effort, None);
+        // Whitespace-only effort is treated as missing.
+        parser.update_current_model(
+            &serde_json::json!({"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"  "}}),
+        );
+        assert_eq!(parser.current_effort, None);
     }
 
     #[test]

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -41,10 +41,11 @@ pub struct CostSummary {
     pub by_model: HashMap<String, f64>,
     /// Token breakdown by model
     pub by_model_tokens: HashMap<String, ModelTokenCounts>,
-    /// Codex cost split by speed/tier when local logs expose it.
-    pub by_speed: HashMap<String, f64>,
-    /// Codex token split by speed/tier when local logs expose it.
-    pub by_speed_tokens: HashMap<String, ModelTokenCounts>,
+    /// Codex cost split by reasoning-effort tier (e.g. medium/high/xhigh) from
+    /// the rollout `turn_context`; keyed "unknown" when the log omits it.
+    pub by_effort: HashMap<String, f64>,
+    /// Codex token split by reasoning-effort tier, matching `by_effort`.
+    pub by_effort_tokens: HashMap<String, ModelTokenCounts>,
     /// Model IDs that were priced with fallback rates because no canonical rate is available.
     pub unknown_models: HashSet<String>,
     /// Period start date
@@ -920,11 +921,11 @@ fn merge_summary(target: &mut CostSummary, source: &CostSummary) {
         entry.output_tokens += tokens.output_tokens;
         entry.cached_tokens += tokens.cached_tokens;
     }
-    for (speed, cost) in &source.by_speed {
-        *target.by_speed.entry(speed.clone()).or_insert(0.0) += cost;
+    for (effort, cost) in &source.by_effort {
+        *target.by_effort.entry(effort.clone()).or_insert(0.0) += cost;
     }
-    for (speed, tokens) in &source.by_speed_tokens {
-        let entry = target.by_speed_tokens.entry(speed.clone()).or_default();
+    for (effort, tokens) in &source.by_effort_tokens {
+        let entry = target.by_effort_tokens.entry(effort.clone()).or_default();
         entry.input_tokens += tokens.input_tokens;
         entry.output_tokens += tokens.output_tokens;
         entry.cached_tokens += tokens.cached_tokens;


### PR DESCRIPTION
## What

Ceiling split Codex cost into a \"speed\" tier using a substring match on the model name (`codex_speed_bucket` looked for `fast`/`priority`/`spark`/`smoke`). No real Codex model id contains those tokens, so every request landed in one `standard` bucket - the breakdown was always 100% standard and told the user nothing.

The rollout logs already carry the real tier axis: `turn_context.effort` (`medium`/`high`/`xhigh`). It's present in every session that records usage (verified 13/13 on local logs).

## Changes

- Parser tracks `current_effort` from each `turn_context` (both the fast borrow path and the serde_json fallback) and stamps it onto every `CodexUsageRecord`.
- Cost and tokens are bucketed by that effort: `by_effort` / `by_effort_tokens`. Usage with no declared effort buckets as `unknown` rather than being guessed.
- Replaces the dead `by_speed` / `by_speed_tokens` fields. These had **no** frontend/tauri consumers - CLI-only - so there's no UI migration.
- CLI prints `Codex effort:` sorted by cost; JSON output emits `by_effort` / `by_effort_tokens`.

## Tests

- `turn_context_effort_attaches_to_following_token_records` - effort follows a mid-session tier switch (high then xhigh) onto the right deltas.
- `test_codex_effort_bucket` - trims/lowercases declared effort, maps missing/blank to `unknown`.
- `unpriced_usage_still_records_effort_tokens` - unknown-model usage records effort tokens without fabricating dollars.
- Updated the two summary tests to assert the effort split.

Full lib suite: 629 passed. `cargo check --workspace` clean, `cargo fmt --all --check` clean.

Third chunk of SOU-263 (chunk 1 = child-replay gate + unknown-model pricing #52; chunk 2 = archived-session dedup #53).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex cost reports now break down usage by reasoning effort level instead of speed.
  * Text and JSON reports include effort-based token and cost totals.
  * Missing or unspecified effort levels are grouped under “unknown.”

* **Bug Fixes**
  * Effort information is now correctly tracked as it changes during Codex sessions.
  * Token usage remains visible for unpriced or unknown models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->