### PR TITLE
Per-model dollar breakdown in local usage (SOU-266)

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -902,9 +902,12 @@ fn model_breakdown(summary: &CostSummary) -> Vec<LocalModelCost> {
         })
         .collect();
     rows.sort_by(|a, b| {
+        // Priced models always lead unpriced ones, even a priced $0.00 model,
+        // so an unpriced row can't jump ahead on token count alone.
         b.cost
-            .unwrap_or(0.0)
-            .total_cmp(&a.cost.unwrap_or(0.0))
+            .is_some()
+            .cmp(&a.cost.is_some())
+            .then_with(|| b.cost.unwrap_or(0.0).total_cmp(&a.cost.unwrap_or(0.0)))
             .then(b.tokens.cmp(&a.tokens))
             .then(a.model.cmp(&b.model))
     });
@@ -1069,6 +1072,17 @@ mod tests {
         // Two priced models and one unpriced (tokens only, no dollars).
         summary.by_model.insert("cheap".to_string(), 1.0);
         summary.by_model.insert("pricey".to_string(), 9.0);
+        // A priced $0.00 model must still lead any unpriced model, even though
+        // the unpriced one below has far more tokens.
+        summary.by_model.insert("free".to_string(), 0.0);
+        summary.by_model_tokens.insert(
+            "free".to_string(),
+            ModelTokenCounts {
+                input_tokens: 1,
+                output_tokens: 1,
+                cached_tokens: 0,
+            },
+        );
         summary.by_model_tokens.insert(
             "cheap".to_string(),
             ModelTokenCounts {
@@ -1108,6 +1122,12 @@ mod tests {
                     model: "cheap".to_string(),
                     cost: Some(1.0),
                     tokens: 200,
+                },
+                // Priced $0.00 still leads the unpriced model despite fewer tokens.
+                LocalModelCost {
+                    model: "free".to_string(),
+                    cost: Some(0.0),
+                    tokens: 2,
                 },
                 // Unpriced model keeps its tokens but sorts last with no dollars.
                 LocalModelCost {

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -82,6 +82,10 @@ pub struct ProviderLocalUsageSummary {
     /// transcript/session, rather than today's aggregate.
     pub latest_tokens: Option<u64>,
     pub top_model: Option<String>,
+    /// Per-model spend over the 30-day period, sorted by cost then tokens.
+    /// Priced and unpriced models are both included.
+    #[serde(default)]
+    pub model_breakdown: Vec<LocalModelCost>,
     pub estimate_note: String,
     pub token_cost_updated_at_ms: i64,
 }
@@ -170,6 +174,16 @@ pub struct LocalTokenBreakdown {
     pub output_tokens: u64,
     pub cache_read_tokens: u64,
     pub cache_write_tokens: u64,
+}
+
+/// Per-model local spend for a period. `cost` is `None` for models with no
+/// canonical price (their tokens still count, but no dollars are fabricated).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalModelCost {
+    pub model: String,
+    pub cost: Option<f64>,
+    pub tokens: u64,
 }
 
 /// Full chart data bundle for one provider.
@@ -554,6 +568,7 @@ fn local_usage_summary_from_report(
         comparison_periods,
         latest_tokens: non_zero_u64(last_session_tokens),
         top_model: top_model(&report.thirty_days),
+        model_breakdown: model_breakdown(&report.thirty_days),
         estimate_note: localized_estimate_note(provider_id, lang),
         token_cost_updated_at_ms: current_unix_ms(),
     })
@@ -638,6 +653,7 @@ fn load_local_usage_summary_with_unknown_models(
             comparison_periods: Vec::new(),
             latest_tokens: non_zero_u64(latest_tokens),
             top_model: top_model(&thirty_day),
+            model_breakdown: model_breakdown(&thirty_day),
             estimate_note: localized_estimate_note(provider_id, lang),
             token_cost_updated_at_ms: current_unix_ms(),
         }),
@@ -871,6 +887,30 @@ fn non_zero_u64(value: u64) -> Option<u64> {
     (value > 0).then_some(value)
 }
 
+/// Per-model spend for a period: every model that recorded tokens, with its
+/// dollar cost when the model is priced (`None` otherwise). Sorted by cost
+/// descending, then tokens descending, so the priciest models lead and
+/// unpriced models fall to the end.
+fn model_breakdown(summary: &CostSummary) -> Vec<LocalModelCost> {
+    let mut rows: Vec<LocalModelCost> = summary
+        .by_model_tokens
+        .iter()
+        .map(|(model, counts)| LocalModelCost {
+            model: model.clone(),
+            cost: summary.by_model.get(model).copied(),
+            tokens: counts.total(),
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        b.cost
+            .unwrap_or(0.0)
+            .total_cmp(&a.cost.unwrap_or(0.0))
+            .then(b.tokens.cmp(&a.tokens))
+            .then(a.model.cmp(&b.model))
+    });
+    rows
+}
+
 fn top_model(summary: &CostSummary) -> Option<String> {
     summary
         .by_model_tokens
@@ -947,13 +987,14 @@ fn load_openai_dashboard_chart_data(
 #[cfg(test)]
 mod tests {
     use super::{
-        CostFetchFailure, LocalTokenBreakdown, ProviderLocalUsageSummary, comparison_period_specs,
-        cost_fetch_failure_allows_early_retry, local_usage_summary_from_report,
-        localized_estimate_note, token_breakdown, token_cost_cache_is_fresh,
+        CostFetchFailure, LocalModelCost, LocalTokenBreakdown, ProviderLocalUsageSummary,
+        comparison_period_specs, cost_fetch_failure_allows_early_retry,
+        local_usage_summary_from_report, localized_estimate_note, model_breakdown, token_breakdown,
+        token_cost_cache_is_fresh,
     };
     use crate::commands::is_provider_cache_fresh;
     use chrono::Utc;
-    use codexbar::cost_scanner::{CostSummary, CostUsageReport};
+    use codexbar::cost_scanner::{CostSummary, CostUsageReport, ModelTokenCounts};
     use codexbar::settings::Language;
     use std::time::{Duration, Instant};
 
@@ -1000,6 +1041,11 @@ mod tests {
             comparison_periods: Vec::new(),
             latest_tokens: Some(40),
             top_model: Some("gpt-5".to_string()),
+            model_breakdown: vec![LocalModelCost {
+                model: "gpt-5".to_string(),
+                cost: Some(2.0),
+                tokens: 300,
+            }],
             estimate_note: "estimated".to_string(),
             token_cost_updated_at_ms: 1234,
         };
@@ -1008,6 +1054,68 @@ mod tests {
         assert_eq!(
             json.get("tokenCostUpdatedAtMs").and_then(|v| v.as_i64()),
             Some(1234)
+        );
+        assert_eq!(
+            json.get("modelBreakdown")
+                .and_then(|v| v.as_array())
+                .map(|rows| rows.len()),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn model_breakdown_orders_priced_first_and_keeps_unpriced() {
+        let mut summary = CostSummary::default();
+        // Two priced models and one unpriced (tokens only, no dollars).
+        summary.by_model.insert("cheap".to_string(), 1.0);
+        summary.by_model.insert("pricey".to_string(), 9.0);
+        summary.by_model_tokens.insert(
+            "cheap".to_string(),
+            ModelTokenCounts {
+                input_tokens: 100,
+                output_tokens: 100,
+                cached_tokens: 0,
+            },
+        );
+        summary.by_model_tokens.insert(
+            "pricey".to_string(),
+            ModelTokenCounts {
+                input_tokens: 10,
+                output_tokens: 10,
+                cached_tokens: 0,
+            },
+        );
+        summary.by_model_tokens.insert(
+            "unpriced".to_string(),
+            ModelTokenCounts {
+                input_tokens: 500,
+                output_tokens: 500,
+                cached_tokens: 0,
+            },
+        );
+
+        let rows = model_breakdown(&summary);
+
+        assert_eq!(
+            rows,
+            vec![
+                LocalModelCost {
+                    model: "pricey".to_string(),
+                    cost: Some(9.0),
+                    tokens: 20,
+                },
+                LocalModelCost {
+                    model: "cheap".to_string(),
+                    cost: Some(1.0),
+                    tokens: 200,
+                },
+                // Unpriced model keeps its tokens but sorts last with no dollars.
+                LocalModelCost {
+                    model: "unpriced".to_string(),
+                    cost: None,
+                    tokens: 1000,
+                },
+            ]
         );
     }
 

--- a/apps/desktop-tauri/src-tauri/src/powertoys.rs
+++ b/apps/desktop-tauri/src-tauri/src/powertoys.rs
@@ -242,6 +242,7 @@ mod tests {
                 comparison_periods: Vec::new(),
                 latest_tokens: Some(1_200),
                 top_model: Some("gpt-5".to_string()),
+                model_breakdown: Vec::new(),
                 estimate_note: "cached".to_string(),
                 token_cost_updated_at_ms: 1234,
             }),

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -7801,6 +7801,73 @@ body:has(.dashboard-shell) #root {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+.usage-model-costs {
+  grid-column: 1 / -1;
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, var(--ceiling-glass-border) 70%, transparent);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--text-primary) 2%, transparent);
+}
+.usage-model-costs__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+  margin-bottom: 7px;
+}
+.usage-model-costs__title {
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+.usage-model-costs__total {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.usage-model-costs__rows {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.usage-model-costs__row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 10px;
+  align-items: baseline;
+}
+.usage-model-costs__name {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.usage-model-costs__tokens {
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.usage-model-costs__cost {
+  min-width: 56px;
+  color: var(--text-primary);
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+.usage-model-costs__note {
+  margin: 7px 0 0;
+  color: var(--text-secondary);
+  font-size: 9.5px;
+  line-height: 1.4;
+}
 .quota-history {
   display: grid;
   gap: 12px;

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
@@ -57,6 +57,11 @@ const enrichedData = {
     comparisonPeriods: [],
     latestTokens: 2_100_000,
     topModel: "claude-opus-4-8",
+    modelBreakdown: [
+      { model: "claude-opus-4-8", cost: 15_000, tokens: 20_000_000_000 },
+      { model: "claude-sonnet-5", cost: 2_700, tokens: 3_500_000_000 },
+      { model: "claude-retired-x", cost: null, tokens: 50_000_000 },
+    ],
     estimateNote: "API-equivalent estimate from local logs; not subscription spend",
     tokenCostUpdatedAtMs: 1,
     sevenDayTokenBreakdown: {
@@ -97,6 +102,18 @@ describe("ChartsSection local usage summary", () => {
     expect(mix.textContent).toContain("Output14.1M");
     expect(mix.textContent).toContain("Cache read4.8B");
     expect(mix.textContent).toContain("Cache write118.6M");
+
+    const models = getByLabelText("Cost by model over 30 days");
+    // Priced models show dollars; the total sums only priced rows.
+    expect(models.textContent).toContain("claude-opus-4-8");
+    expect(models.textContent).toContain("$15,000.00");
+    expect(models.textContent).toContain("claude-sonnet-5");
+    expect(models.textContent).toContain("$2,700.00");
+    // Unpriced model keeps its tokens but shows "Not priced", no dollars.
+    expect(models.textContent).toContain("claude-retired-x");
+    expect(models.textContent).toContain("Not priced");
+    // Header total = sum of priced rows only ($15,000 + $2,700).
+    expect(models.textContent).toContain("$17,700.00");
   });
 
   it("keeps quota history visible while local history loads, then enriches promptly", async () => {

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -5,6 +5,7 @@ import {
   providerSupportsChartData,
 } from "../../../../../lib/providerCharts";
 import type {
+  LocalModelCost,
   LocalTokenBreakdown,
   ProviderChartData,
   ProviderUsageSnapshot,
@@ -82,6 +83,44 @@ function TokenMix({ breakdown }: { breakdown: LocalTokenBreakdown }) {
           </span>
         ))}
       </div>
+    </div>
+  );
+}
+
+function formatUsd(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(value);
+}
+
+function ModelBreakdown({ models }: { models: LocalModelCost[] }) {
+  const priced = models.reduce((sum, model) => sum + (model.cost ?? 0), 0);
+  const hasUnpriced = models.some((model) => model.cost == null);
+  return (
+    <div className="usage-model-costs" aria-label="Cost by model over 30 days">
+      <div className="usage-model-costs__header">
+        <span className="usage-model-costs__title">Cost by model · 30 days</span>
+        <span className="usage-model-costs__total">{formatUsd(priced)}</span>
+      </div>
+      <ul className="usage-model-costs__rows">
+        {models.map((model) => (
+          <li className="usage-model-costs__row" key={model.model}>
+            <span className="usage-model-costs__name" title={model.model}>
+              {model.model}
+            </span>
+            <span className="usage-model-costs__tokens">{formatTokens(model.tokens)}</span>
+            <span className="usage-model-costs__cost">
+              {model.cost == null ? "Not priced" : formatUsd(model.cost)}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {hasUnpriced && (
+        <p className="usage-model-costs__note">
+          Not priced · tokens counted, but no public rate is available for this model.
+        </p>
+      )}
     </div>
   );
 }
@@ -331,6 +370,9 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
             )}
             <span>Processed includes fresh input, output, cache reads, and cache writes.</span>
           </div>
+          {data.localUsage.modelBreakdown && data.localUsage.modelBreakdown.length > 0 && (
+            <ModelBreakdown models={data.localUsage.modelBreakdown} />
+          )}
         </div>
       )}
       {available.length > 1 && (

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -620,8 +620,16 @@ export interface ProviderLocalUsageSummary {
   comparisonPeriods: LocalUsageComparisonPeriod[];
   latestTokens: number | null;
   topModel: string | null;
+  modelBreakdown?: LocalModelCost[];
   estimateNote: string;
   tokenCostUpdatedAtMs: number;
+}
+
+export interface LocalModelCost {
+  model: string;
+  /** Dollar cost for the period, or null when the model has no canonical price. */
+  cost: number | null;
+  tokens: number;
 }
 
 export interface LocalUsageWindowRequest {


### PR DESCRIPTION
## What

Surfaces the per-model spend the cost scanner already computes but never exposed to the UI. Previously the frontend only had `topModel` (a single name); the `by_model` dollar amounts stayed backend-only. This is OpenUsage's signature per-model view.

## Changes

- **chart.rs**: new `LocalModelCost { model, cost: Option<f64>, tokens }` and a `modelBreakdown` field on `ProviderLocalUsageSummary`, built from the 30-day summary's `by_model` / `by_model_tokens`. Priced and unpriced models are both included; unpriced models carry `cost: None` (tokens counted, no fabricated dollars) and sort last. Sorted by cost desc, then tokens desc.
- **bridge.ts**: matching `LocalModelCost` type + `modelBreakdown` field.
- **ChartsSection**: a "Cost by model - 30 days" card under the usage summary. Each row shows model, tokens, and cost (or "Not priced"); the header total sums only priced rows; an explanatory note shows when any model is unpriced. Currency via `Intl.NumberFormat`. Styling mirrors the existing token-mix card.

## Tests

- Backend `model_breakdown_orders_priced_first_and_keeps_unpriced` - priced models lead by cost, the unpriced model keeps its tokens and sorts last with no dollars.
- Frontend ChartsSection test asserts the priced rows, the "Not priced" row, and the priced-only header total.

Desktop 376 / frontend 247 green; `cargo fmt --all --check` + `tsc` clean.

First UI pass of the SOU-262 dollar-analytics epic (backend integrity landed in #52/#53/#54). Effort-tier and cross-provider-total cards follow in separate PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Cost by model · 30 days” breakdown to local usage charts when model breakdown data is available.
  * Displays per-model token totals and estimated USD costs, ordered by highest priced usage.
  * Models without known pricing show as “Not priced,” and the header total reflects only priced models.
* **Style**
  * Added new dashboard styling for the model cost breakdown section (totals, rows, formatting, and notes).
* **Tests**
  * Updated unit and UI tests to validate priced vs unpriced behavior, formatting, totals, and display ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->