### PR TITLE
Per-effort dollar breakdown card (SOU-263 UI)

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -86,6 +86,10 @@ pub struct ProviderLocalUsageSummary {
     /// Priced and unpriced models are both included.
     #[serde(default)]
     pub model_breakdown: Vec<LocalModelCost>,
+    /// Per-reasoning-effort spend over the 30-day period (Codex only; empty
+    /// for providers without an effort tier). Sorted by cost then tokens.
+    #[serde(default)]
+    pub effort_breakdown: Vec<LocalEffortCost>,
     pub estimate_note: String,
     pub token_cost_updated_at_ms: i64,
 }
@@ -182,6 +186,16 @@ pub struct LocalTokenBreakdown {
 #[serde(rename_all = "camelCase")]
 pub struct LocalModelCost {
     pub model: String,
+    pub cost: Option<f64>,
+    pub tokens: u64,
+}
+
+/// Per-reasoning-effort local spend for a period (Codex only: "high"/"xhigh"/
+/// "medium"/"unknown"). `cost` is `None` when the tier's models are unpriced.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalEffortCost {
+    pub effort: String,
     pub cost: Option<f64>,
     pub tokens: u64,
 }
@@ -569,6 +583,7 @@ fn local_usage_summary_from_report(
         latest_tokens: non_zero_u64(last_session_tokens),
         top_model: top_model(&report.thirty_days),
         model_breakdown: model_breakdown(&report.thirty_days),
+        effort_breakdown: effort_breakdown(&report.thirty_days),
         estimate_note: localized_estimate_note(provider_id, lang),
         token_cost_updated_at_ms: current_unix_ms(),
     })
@@ -654,6 +669,7 @@ fn load_local_usage_summary_with_unknown_models(
             latest_tokens: non_zero_u64(latest_tokens),
             top_model: top_model(&thirty_day),
             model_breakdown: model_breakdown(&thirty_day),
+            effort_breakdown: effort_breakdown(&thirty_day),
             estimate_note: localized_estimate_note(provider_id, lang),
             token_cost_updated_at_ms: current_unix_ms(),
         }),
@@ -914,6 +930,30 @@ fn model_breakdown(summary: &CostSummary) -> Vec<LocalModelCost> {
     rows
 }
 
+/// Per-reasoning-effort spend for a period, mirroring `model_breakdown`.
+/// Codex populates `by_effort` / `by_effort_tokens`; other providers leave
+/// them empty, so this returns an empty vec for them.
+fn effort_breakdown(summary: &CostSummary) -> Vec<LocalEffortCost> {
+    let mut rows: Vec<LocalEffortCost> = summary
+        .by_effort_tokens
+        .iter()
+        .map(|(effort, counts)| LocalEffortCost {
+            effort: effort.clone(),
+            cost: summary.by_effort.get(effort).copied(),
+            tokens: counts.total(),
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        b.cost
+            .is_some()
+            .cmp(&a.cost.is_some())
+            .then_with(|| b.cost.unwrap_or(0.0).total_cmp(&a.cost.unwrap_or(0.0)))
+            .then(b.tokens.cmp(&a.tokens))
+            .then(a.effort.cmp(&b.effort))
+    });
+    rows
+}
+
 fn top_model(summary: &CostSummary) -> Option<String> {
     summary
         .by_model_tokens
@@ -990,10 +1030,10 @@ fn load_openai_dashboard_chart_data(
 #[cfg(test)]
 mod tests {
     use super::{
-        CostFetchFailure, LocalModelCost, LocalTokenBreakdown, ProviderLocalUsageSummary,
-        comparison_period_specs, cost_fetch_failure_allows_early_retry,
-        local_usage_summary_from_report, localized_estimate_note, model_breakdown, token_breakdown,
-        token_cost_cache_is_fresh,
+        CostFetchFailure, LocalEffortCost, LocalModelCost, LocalTokenBreakdown,
+        ProviderLocalUsageSummary, comparison_period_specs, cost_fetch_failure_allows_early_retry,
+        effort_breakdown, local_usage_summary_from_report, localized_estimate_note,
+        model_breakdown, token_breakdown, token_cost_cache_is_fresh,
     };
     use crate::commands::is_provider_cache_fresh;
     use chrono::Utc;
@@ -1046,6 +1086,11 @@ mod tests {
             top_model: Some("gpt-5".to_string()),
             model_breakdown: vec![LocalModelCost {
                 model: "gpt-5".to_string(),
+                cost: Some(2.0),
+                tokens: 300,
+            }],
+            effort_breakdown: vec![LocalEffortCost {
+                effort: "high".to_string(),
                 cost: Some(2.0),
                 tokens: 300,
             }],
@@ -1134,6 +1179,64 @@ mod tests {
                     model: "unpriced".to_string(),
                     cost: None,
                     tokens: 1000,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn effort_breakdown_orders_by_cost_and_is_empty_without_effort_data() {
+        // No effort data (e.g. Claude) yields an empty breakdown.
+        assert!(effort_breakdown(&CostSummary::default()).is_empty());
+
+        let mut summary = CostSummary::default();
+        summary.by_effort.insert("high".to_string(), 8.0);
+        summary.by_effort.insert("medium".to_string(), 2.0);
+        summary.by_effort_tokens.insert(
+            "high".to_string(),
+            ModelTokenCounts {
+                input_tokens: 50,
+                output_tokens: 50,
+                cached_tokens: 0,
+            },
+        );
+        summary.by_effort_tokens.insert(
+            "medium".to_string(),
+            ModelTokenCounts {
+                input_tokens: 200,
+                output_tokens: 200,
+                cached_tokens: 0,
+            },
+        );
+        // Unknown-effort usage with no price sorts last.
+        summary.by_effort_tokens.insert(
+            "unknown".to_string(),
+            ModelTokenCounts {
+                input_tokens: 900,
+                output_tokens: 900,
+                cached_tokens: 0,
+            },
+        );
+
+        let rows = effort_breakdown(&summary);
+
+        assert_eq!(
+            rows,
+            vec![
+                LocalEffortCost {
+                    effort: "high".to_string(),
+                    cost: Some(8.0),
+                    tokens: 100,
+                },
+                LocalEffortCost {
+                    effort: "medium".to_string(),
+                    cost: Some(2.0),
+                    tokens: 400,
+                },
+                LocalEffortCost {
+                    effort: "unknown".to_string(),
+                    cost: None,
+                    tokens: 1800,
                 },
             ]
         );

--- a/apps/desktop-tauri/src-tauri/src/powertoys.rs
+++ b/apps/desktop-tauri/src-tauri/src/powertoys.rs
@@ -243,6 +243,7 @@ mod tests {
                 latest_tokens: Some(1_200),
                 top_model: Some("gpt-5".to_string()),
                 model_breakdown: Vec::new(),
+                effort_breakdown: Vec::new(),
                 estimate_note: "cached".to_string(),
                 token_cost_updated_at_ms: 1234,
             }),

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
@@ -62,6 +62,11 @@ const enrichedData = {
       { model: "claude-sonnet-5", cost: 2_700, tokens: 3_500_000_000 },
       { model: "claude-retired-x", cost: null, tokens: 50_000_000 },
     ],
+    effortBreakdown: [
+      { effort: "high", cost: 12_000, tokens: 16_000_000_000 },
+      { effort: "xhigh", cost: 5_700, tokens: 7_500_000_000 },
+      { effort: "unknown", cost: null, tokens: 50_000_000 },
+    ],
     estimateNote: "API-equivalent estimate from local logs; not subscription spend",
     tokenCostUpdatedAtMs: 1,
     sevenDayTokenBreakdown: {
@@ -114,6 +119,15 @@ describe("ChartsSection local usage summary", () => {
     expect(models.textContent).toContain("Not priced");
     // Header total = sum of priced rows only ($15,000 + $2,700).
     expect(models.textContent).toContain("$17,700.00");
+
+    const efforts = getByLabelText("Cost by reasoning effort over 30 days");
+    // Effort tiers show friendly labels and dollars; total sums priced rows.
+    expect(efforts.textContent).toContain("High");
+    expect(efforts.textContent).toContain("$12,000.00");
+    expect(efforts.textContent).toContain("Extra high");
+    expect(efforts.textContent).toContain("$5,700.00");
+    expect(efforts.textContent).toContain("Unspecified");
+    expect(efforts.textContent).toContain("$17,700.00");
   });
 
   it("keeps quota history visible while local history loads, then enriches promptly", async () => {

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -5,6 +5,7 @@ import {
   providerSupportsChartData,
 } from "../../../../../lib/providerCharts";
 import type {
+  LocalEffortCost,
   LocalModelCost,
   LocalTokenBreakdown,
   ProviderChartData,
@@ -121,6 +122,41 @@ function ModelBreakdown({ models }: { models: LocalModelCost[] }) {
           Not priced · tokens counted, but no public rate is available for this model.
         </p>
       )}
+    </div>
+  );
+}
+
+const EFFORT_LABELS: Record<string, string> = {
+  xhigh: "Extra high",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+  unknown: "Unspecified",
+};
+
+function effortLabel(effort: string): string {
+  return EFFORT_LABELS[effort] ?? effort;
+}
+
+function EffortBreakdown({ efforts }: { efforts: LocalEffortCost[] }) {
+  const priced = efforts.reduce((sum, tier) => sum + (tier.cost ?? 0), 0);
+  return (
+    <div className="usage-model-costs" aria-label="Cost by reasoning effort over 30 days">
+      <div className="usage-model-costs__header">
+        <span className="usage-model-costs__title">Cost by effort · 30 days</span>
+        <span className="usage-model-costs__total">{formatUsd(priced)}</span>
+      </div>
+      <ul className="usage-model-costs__rows">
+        {efforts.map((tier) => (
+          <li className="usage-model-costs__row" key={tier.effort}>
+            <span className="usage-model-costs__name">{effortLabel(tier.effort)}</span>
+            <span className="usage-model-costs__tokens">{formatTokens(tier.tokens)}</span>
+            <span className="usage-model-costs__cost">
+              {tier.cost == null ? "Not priced" : formatUsd(tier.cost)}
+            </span>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
@@ -372,6 +408,9 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
           </div>
           {data.localUsage.modelBreakdown && data.localUsage.modelBreakdown.length > 0 && (
             <ModelBreakdown models={data.localUsage.modelBreakdown} />
+          )}
+          {data.localUsage.effortBreakdown && data.localUsage.effortBreakdown.length > 0 && (
+            <EffortBreakdown efforts={data.localUsage.effortBreakdown} />
           )}
         </div>
       )}

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -621,6 +621,7 @@ export interface ProviderLocalUsageSummary {
   latestTokens: number | null;
   topModel: string | null;
   modelBreakdown?: LocalModelCost[];
+  effortBreakdown?: LocalEffortCost[];
   estimateNote: string;
   tokenCostUpdatedAtMs: number;
 }
@@ -628,6 +629,14 @@ export interface ProviderLocalUsageSummary {
 export interface LocalModelCost {
   model: string;
   /** Dollar cost for the period, or null when the model has no canonical price. */
+  cost: number | null;
+  tokens: number;
+}
+
+export interface LocalEffortCost {
+  /** Reasoning-effort tier (Codex only): "high" / "xhigh" / "medium" / "unknown". */
+  effort: string;
+  /** Dollar cost for the tier, or null when its models have no canonical price. */
   cost: number | null;
   tokens: number;
 }


### PR DESCRIPTION
## What

Surfaces the reasoning-effort spend split (added to the cost scanner in #54) that was computed but never shown. Codex-only: other providers leave `by_effort` empty, so the card is hidden for them.

## Changes

- **chart.rs**: `LocalEffortCost { effort, cost: Option<f64>, tokens }` and an `effortBreakdown` field on `ProviderLocalUsageSummary`, built from the 30-day `by_effort` / `by_effort_tokens` with the same priced-first sort as the model breakdown (unpriced tiers keep tokens, no fabricated dollars).
- **bridge.ts**: matching `LocalEffortCost` type + `effortBreakdown` field.
- **ChartsSection**: a "Cost by effort - 30 days" card under the model breakdown, with friendly tier labels (High / Extra high / Medium / Unspecified), reusing the model-cost card styling.

## Tests

- Backend `effort_breakdown_orders_by_cost_and_is_empty_without_effort_data` - priced tiers lead, unpriced sorts last, and no effort data yields an empty vec (Claude).
- Frontend ChartsSection test asserts the tier labels, dollars, and priced-only total.

Desktop 377 / frontend 247 green; `cargo fmt --all --check` + `tsc` clean.

Second UI pass of the SOU-262 dollar-analytics epic (after per-model #55). Cross-provider total card follows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a 30-day “Cost by reasoning effort” breakdown to provider usage charts.
  - Displays usage and costs for reasoning tiers such as High, Extra high, Medium, Low, and Unspecified.
  - Unpriced tiers are clearly labeled “Not priced.”
  - Summary totals include only tiers with available pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->