### PR TITLE
Total API-value donut card (SOU-265 pass 3b)

### DIFF
--- a/apps/desktop-tauri/src/components/TotalApiValueCard.test.tsx
+++ b/apps/desktop-tauri/src/components/TotalApiValueCard.test.tsx
@@ -1,0 +1,82 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const tauriMocks = vi.hoisted(() => ({
+  getLocalApiValueTotals: vi.fn(),
+}));
+
+vi.mock("../lib/tauri", () => tauriMocks);
+
+import { TotalApiValueCard } from "./TotalApiValueCard";
+
+function period(over: Record<string, number | boolean>) {
+  return {
+    apiValueUsd: 0,
+    tokens: 0,
+    pricedTokens: 0,
+    totalTokens: 0,
+    hasData: false,
+    ...over,
+  };
+}
+
+const twoProviders = [
+  {
+    providerId: "codex",
+    today: period({ apiValueUsd: 90, tokens: 9000, pricedTokens: 8000, totalTokens: 9000, hasData: true }),
+    yesterday: period({}),
+    thirtyDays: period({ apiValueUsd: 300, tokens: 30000, pricedTokens: 30000, totalTokens: 30000, hasData: true }),
+  },
+  {
+    providerId: "claude",
+    today: period({ apiValueUsd: 30, tokens: 3000, pricedTokens: 3000, totalTokens: 3000, hasData: true }),
+    yesterday: period({}),
+    thirtyDays: period({ apiValueUsd: 100, tokens: 10000, pricedTokens: 10000, totalTokens: 10000, hasData: true }),
+  },
+];
+
+describe("TotalApiValueCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the aggregate total, ranked legend, and pricing coverage", async () => {
+    tauriMocks.getLocalApiValueTotals.mockResolvedValue(twoProviders);
+    const { getByLabelText, getByText } = render(<TotalApiValueCard />);
+
+    await waitFor(() => expect(getByText("$120.00")).toBeTruthy()); // 90 + 30, Today
+    const ring = getByLabelText(/API value for Today/i);
+    expect(ring).toBeTruthy();
+    // Ranked legend: Codex leads at 75%, Claude at 25%.
+    expect(getByText("Codex")).toBeTruthy();
+    expect(getByText("Claude")).toBeTruthy();
+    expect(getByText("75%")).toBeTruthy();
+    expect(getByText("25%")).toBeTruthy();
+    // Codex has unpriced tokens today (8000 of 9000) -> coverage 12000/12000? No:
+    // priced 8000+3000=11000 of 12000 total = 92%.
+    expect(getByText(/92% of tokens priced/)).toBeTruthy();
+    expect(getByText(/unpriced models in Codex/)).toBeTruthy();
+  });
+
+  it('shows "No data" for a period with no provider data', async () => {
+    tauriMocks.getLocalApiValueTotals.mockResolvedValue([
+      {
+        providerId: "codex",
+        today: period({ apiValueUsd: 5, tokens: 500, pricedTokens: 500, totalTokens: 500, hasData: true }),
+        yesterday: period({}),
+        thirtyDays: period({ apiValueUsd: 5, tokens: 500, pricedTokens: 500, totalTokens: 500, hasData: true }),
+      },
+    ]);
+    const { getByText, getAllByText, findByText } = render(<TotalApiValueCard />);
+    // Default period is Today (has data); $5.00 appears in the ring and legend.
+    await waitFor(() => expect(getAllByText("$5.00").length).toBeGreaterThan(0));
+    getByText("Yesterday").click();
+    expect(await findByText(/No data for Yesterday/)).toBeTruthy();
+  });
+
+  it("surfaces an unavailable state when the command fails", async () => {
+    tauriMocks.getLocalApiValueTotals.mockRejectedValue(new Error("boom"));
+    const { findByText } = render(<TotalApiValueCard />);
+    expect(await findByText(/unavailable right now/)).toBeTruthy();
+  });
+});

--- a/apps/desktop-tauri/src/components/TotalApiValueCard.tsx
+++ b/apps/desktop-tauri/src/components/TotalApiValueCard.tsx
@@ -93,7 +93,9 @@ export function TotalApiValueCard() {
   const segments = ringSegments(model.slices, CIRCUMFERENCE);
   const coveragePercent =
     model.coverage == null ? null : Math.round(model.coverage * 100);
-  const showCoverage = coveragePercent != null && coveragePercent < 100;
+  // Compare the raw ratio so 99.6% (rounds to 100) still shows the coverage
+  // note when any tokens are unpriced.
+  const showCoverage = model.coverage != null && model.coverage < 1;
 
   const ariaSummary = model.isEmpty
     ? `No local ${metricLabel} data for ${periodLabel}.`
@@ -111,13 +113,12 @@ export function TotalApiValueCard() {
           </p>
         </div>
         <div className="api-value-card__switchers">
-          <div className="api-value-card__switch" role="tablist" aria-label="Period">
+          <div className="api-value-card__switch" role="group" aria-label="Period">
             {PERIODS.map((p) => (
               <button
                 key={p.key}
                 type="button"
-                role="tab"
-                aria-selected={p.key === period}
+                aria-pressed={p.key === period}
                 data-active={p.key === period}
                 className="api-value-card__switch-btn"
                 onClick={() => setPeriod(p.key)}
@@ -126,13 +127,12 @@ export function TotalApiValueCard() {
               </button>
             ))}
           </div>
-          <div className="api-value-card__switch" role="tablist" aria-label="Metric">
+          <div className="api-value-card__switch" role="group" aria-label="Metric">
             {METRICS.map((m) => (
               <button
                 key={m.key}
                 type="button"
-                role="tab"
-                aria-selected={m.key === metric}
+                aria-pressed={m.key === metric}
                 data-active={m.key === metric}
                 className="api-value-card__switch-btn"
                 onClick={() => setMetric(m.key)}

--- a/apps/desktop-tauri/src/components/TotalApiValueCard.tsx
+++ b/apps/desktop-tauri/src/components/TotalApiValueCard.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useMemo, useState } from "react";
+import { getLocalApiValueTotals } from "../lib/tauri";
+import type { LocalApiValueProvider } from "../types/bridge";
+import { getProviderIcon } from "./providers/providerIcons";
+import {
+  buildApiValueCard,
+  ringSegments,
+  type ApiValueMetric,
+  type ApiValuePeriodKey,
+} from "../lib/apiValueCard";
+
+const PERIODS: { key: ApiValuePeriodKey; label: string }[] = [
+  { key: "today", label: "Today" },
+  { key: "yesterday", label: "Yesterday" },
+  { key: "thirtyDays", label: "30 days" },
+];
+
+const METRICS: { key: ApiValueMetric; label: string }[] = [
+  { key: "apiValue", label: "API value" },
+  { key: "tokens", label: "Tokens" },
+];
+
+const RING_RADIUS = 52;
+const RING_THICKNESS = 14;
+const CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+function formatUsd(value: number): string {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+}
+
+function formatTokens(value: number): string {
+  return new Intl.NumberFormat("en-US", { notation: "compact", maximumFractionDigits: 1 }).format(value);
+}
+
+function providerLabel(providerId: string): string {
+  return providerId.charAt(0).toUpperCase() + providerId.slice(1);
+}
+
+function providerColor(providerId: string): string {
+  return getProviderIcon(providerId).brandColor;
+}
+
+/**
+ * Aggregate "estimated API value" across providers, from local logs.
+ *
+ * Token-derived dollars are an API-equivalent estimate, never a bill. Providers
+ * with no data this period are omitted; an entirely empty period shows "No
+ * data". Pricing coverage is surfaced whenever any tokens are unpriced.
+ */
+export function TotalApiValueCard() {
+  const [providers, setProviders] = useState<LocalApiValueProvider[] | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [period, setPeriod] = useState<ApiValuePeriodKey>("today");
+  const [metric, setMetric] = useState<ApiValueMetric>("apiValue");
+
+  useEffect(() => {
+    let live = true;
+    getLocalApiValueTotals()
+      .then((rows) => live && setProviders(rows))
+      .catch(() => live && setFailed(true));
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  const model = useMemo(
+    () => (providers ? buildApiValueCard(providers, period, metric) : null),
+    [providers, period, metric],
+  );
+
+  const formatValue = (value: number) =>
+    metric === "apiValue" ? formatUsd(value) : formatTokens(value);
+
+  const periodLabel = PERIODS.find((p) => p.key === period)?.label ?? "";
+  const metricLabel = METRICS.find((m) => m.key === metric)?.label ?? "";
+
+  if (failed) {
+    return (
+      <section className="api-value-card" aria-label="Total API value">
+        <p className="api-value-card__status">Local API-value totals are unavailable right now.</p>
+      </section>
+    );
+  }
+
+  if (!model) {
+    return (
+      <section className="api-value-card" aria-label="Total API value">
+        <p className="api-value-card__status">Reading local usage…</p>
+      </section>
+    );
+  }
+
+  const segments = ringSegments(model.slices, CIRCUMFERENCE);
+  const coveragePercent =
+    model.coverage == null ? null : Math.round(model.coverage * 100);
+  const showCoverage = coveragePercent != null && coveragePercent < 100;
+
+  const ariaSummary = model.isEmpty
+    ? `No local ${metricLabel} data for ${periodLabel}.`
+    : `${metricLabel} for ${periodLabel}: ${formatValue(model.total)} across ${model.slices
+        .map((slice) => providerLabel(slice.providerId))
+        .join(", ")}.`;
+
+  return (
+    <section className="api-value-card" aria-label="Total API value">
+      <header className="api-value-card__header">
+        <div>
+          <h3 className="api-value-card__title">Estimated API value</h3>
+          <p className="api-value-card__subtitle">
+            API-equivalent estimate from local logs — not subscription spend.
+          </p>
+        </div>
+        <div className="api-value-card__switchers">
+          <div className="api-value-card__switch" role="tablist" aria-label="Period">
+            {PERIODS.map((p) => (
+              <button
+                key={p.key}
+                type="button"
+                role="tab"
+                aria-selected={p.key === period}
+                data-active={p.key === period}
+                className="api-value-card__switch-btn"
+                onClick={() => setPeriod(p.key)}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+          <div className="api-value-card__switch" role="tablist" aria-label="Metric">
+            {METRICS.map((m) => (
+              <button
+                key={m.key}
+                type="button"
+                role="tab"
+                aria-selected={m.key === metric}
+                data-active={m.key === metric}
+                className="api-value-card__switch-btn"
+                onClick={() => setMetric(m.key)}
+              >
+                {m.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      {model.isEmpty ? (
+        <p className="api-value-card__status" role="status">
+          No data for {periodLabel}.
+        </p>
+      ) : (
+        <div className="api-value-card__body">
+          <div className="api-value-card__ring" role="img" aria-label={ariaSummary}>
+            <svg viewBox="0 0 120 120" className="api-value-card__ring-svg">
+              <circle
+                cx="60"
+                cy="60"
+                r={RING_RADIUS}
+                fill="none"
+                stroke="var(--ceiling-glass-border)"
+                strokeWidth={RING_THICKNESS}
+                opacity={0.35}
+              />
+              <g transform="rotate(-90 60 60)">
+                {segments.map((segment) => (
+                  <circle
+                    key={segment.providerId}
+                    cx="60"
+                    cy="60"
+                    r={RING_RADIUS}
+                    fill="none"
+                    stroke={providerColor(segment.providerId)}
+                    strokeWidth={RING_THICKNESS}
+                    strokeDasharray={`${segment.dash} ${CIRCUMFERENCE - segment.dash}`}
+                    strokeDashoffset={segment.offset}
+                    strokeLinecap="butt"
+                  />
+                ))}
+              </g>
+            </svg>
+            <div className="api-value-card__ring-center">
+              <strong>{formatValue(model.total)}</strong>
+              <small>{periodLabel}</small>
+            </div>
+          </div>
+
+          <ul className="api-value-card__legend">
+            {model.slices.map((slice) => (
+              <li className="api-value-card__legend-row" key={slice.providerId}>
+                <span
+                  className="api-value-card__legend-dot"
+                  style={{ background: providerColor(slice.providerId) }}
+                  aria-hidden="true"
+                />
+                <span className="api-value-card__legend-name">
+                  {providerLabel(slice.providerId)}
+                </span>
+                <span className="api-value-card__legend-share">
+                  {Math.round(slice.share * 100)}%
+                </span>
+                <span className="api-value-card__legend-value">{formatValue(slice.value)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {!model.isEmpty && (
+        <p className="api-value-card__note">
+          <span className="api-value-card__estimate-marker" aria-hidden="true">
+            ~
+          </span>
+          Estimated API value.
+          {showCoverage && (
+            <>
+              {" "}
+              {coveragePercent}% of tokens priced
+              {model.unpricedProviderIds.length > 0 &&
+                ` (unpriced models in ${model.unpricedProviderIds
+                  .map(providerLabel)
+                  .join(", ")})`}
+              .
+            </>
+          )}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/desktop-tauri/src/lib/apiValueCard.test.ts
+++ b/apps/desktop-tauri/src/lib/apiValueCard.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import type { LocalApiValuePeriod, LocalApiValueProvider } from "../types/bridge";
+import { buildApiValueCard, ringSegments } from "./apiValueCard";
+
+function period(over: Partial<LocalApiValuePeriod>): LocalApiValuePeriod {
+  return {
+    apiValueUsd: 0,
+    tokens: 0,
+    pricedTokens: 0,
+    totalTokens: 0,
+    hasData: false,
+    ...over,
+  };
+}
+
+const empty = period({});
+
+function provider(
+  providerId: string,
+  periods: Partial<Record<"today" | "yesterday" | "thirtyDays", LocalApiValuePeriod>>,
+): LocalApiValueProvider {
+  return {
+    providerId,
+    today: periods.today ?? empty,
+    yesterday: periods.yesterday ?? empty,
+    thirtyDays: periods.thirtyDays ?? empty,
+  };
+}
+
+describe("buildApiValueCard", () => {
+  it("returns an empty model when no provider has data", () => {
+    const model = buildApiValueCard([provider("codex", {})], "today", "apiValue");
+    expect(model.isEmpty).toBe(true);
+    expect(model.slices).toHaveLength(0);
+    expect(model.total).toBe(0);
+    expect(model.coverage).toBeNull();
+  });
+
+  it("ranks a single provider at 100% share", () => {
+    const model = buildApiValueCard(
+      [
+        provider("codex", {
+          today: period({ apiValueUsd: 12, tokens: 1000, pricedTokens: 1000, totalTokens: 1000, hasData: true }),
+        }),
+      ],
+      "today",
+      "apiValue",
+    );
+    expect(model.isEmpty).toBe(false);
+    expect(model.slices).toEqual([{ providerId: "codex", value: 12, share: 1 }]);
+    expect(model.total).toBe(12);
+    expect(model.coverage).toBe(1);
+    expect(model.unpricedProviderIds).toHaveLength(0);
+  });
+
+  it("ranks multiple providers by value with shares summing to 1", () => {
+    const model = buildApiValueCard(
+      [
+        provider("claude", {
+          thirtyDays: period({ apiValueUsd: 30, tokens: 3000, pricedTokens: 3000, totalTokens: 3000, hasData: true }),
+        }),
+        provider("codex", {
+          thirtyDays: period({ apiValueUsd: 90, tokens: 9000, pricedTokens: 9000, totalTokens: 9000, hasData: true }),
+        }),
+      ],
+      "thirtyDays",
+      "apiValue",
+    );
+    expect(model.slices.map((s) => s.providerId)).toEqual(["codex", "claude"]);
+    expect(model.total).toBe(120);
+    expect(model.slices[0].share).toBeCloseTo(0.75);
+    expect(model.slices[1].share).toBeCloseTo(0.25);
+    expect(model.slices.reduce((sum, s) => sum + s.share, 0)).toBeCloseTo(1);
+  });
+
+  it("keeps a tiny share as a nonzero slice", () => {
+    const model = buildApiValueCard(
+      [
+        provider("codex", {
+          today: period({ apiValueUsd: 999.99, tokens: 1_000_000, pricedTokens: 1_000_000, totalTokens: 1_000_000, hasData: true }),
+        }),
+        provider("claude", {
+          today: period({ apiValueUsd: 0.01, tokens: 10, pricedTokens: 10, totalTokens: 10, hasData: true }),
+        }),
+      ],
+      "today",
+      "apiValue",
+    );
+    const tiny = model.slices.find((s) => s.providerId === "claude")!;
+    expect(tiny.value).toBe(0.01);
+    expect(tiny.share).toBeGreaterThan(0);
+  });
+
+  it("omits providers without data this period rather than counting zero", () => {
+    const model = buildApiValueCard(
+      [
+        provider("codex", {
+          today: period({ apiValueUsd: 5, tokens: 500, pricedTokens: 500, totalTokens: 500, hasData: true }),
+          yesterday: empty, // no data yesterday
+        }),
+      ],
+      "yesterday",
+      "apiValue",
+    );
+    expect(model.isEmpty).toBe(true);
+    expect(model.slices).toHaveLength(0);
+  });
+
+  it("reports partial pricing coverage and the affected providers", () => {
+    const model = buildApiValueCard(
+      [
+        provider("codex", {
+          thirtyDays: period({ apiValueUsd: 8, tokens: 1000, pricedTokens: 750, totalTokens: 1000, hasData: true }),
+        }),
+        provider("claude", {
+          thirtyDays: period({ apiValueUsd: 4, tokens: 1000, pricedTokens: 1000, totalTokens: 1000, hasData: true }),
+        }),
+      ],
+      "thirtyDays",
+      "apiValue",
+    );
+    // 1750 priced of 2000 total = 87.5%.
+    expect(model.coverage).toBeCloseTo(0.875);
+    expect(model.unpricedProviderIds).toEqual(["codex"]);
+  });
+
+  it("keeps coverage on the tokens metric too (all-unpriced period)", () => {
+    const model = buildApiValueCard(
+      [
+        provider("codex", {
+          today: period({ apiValueUsd: 0, tokens: 1000, pricedTokens: 0, totalTokens: 1000, hasData: true }),
+        }),
+      ],
+      "today",
+      "tokens",
+    );
+    // Not empty (there is token data), but zero dollars and zero coverage.
+    expect(model.isEmpty).toBe(false);
+    expect(model.total).toBe(1000);
+    expect(model.coverage).toBe(0);
+    expect(model.unpricedProviderIds).toEqual(["codex"]);
+  });
+});
+
+describe("ringSegments", () => {
+  it("lays segments end to end with dash = share x circumference", () => {
+    const c = 100;
+    const segments = ringSegments(
+      [
+        { providerId: "codex", value: 75, share: 0.75 },
+        { providerId: "claude", value: 25, share: 0.25 },
+      ],
+      c,
+    );
+    expect(segments[0]).toEqual({ providerId: "codex", dash: 75, offset: -0 });
+    expect(segments[1]).toEqual({ providerId: "claude", dash: 25, offset: -75 });
+  });
+});

--- a/apps/desktop-tauri/src/lib/apiValueCard.ts
+++ b/apps/desktop-tauri/src/lib/apiValueCard.ts
@@ -1,0 +1,115 @@
+import type { LocalApiValuePeriod, LocalApiValueProvider } from "../types/bridge";
+
+/** Metric the aggregate card is showing. */
+export type ApiValueMetric = "apiValue" | "tokens";
+
+/** Which of the three periods is selected. */
+export type ApiValuePeriodKey = "today" | "yesterday" | "thirtyDays";
+
+export interface ApiValueSlice {
+  providerId: string;
+  /** Metric value for the provider (USD for apiValue, tokens for tokens). */
+  value: number;
+  /** Fraction of the period total, 0..1 (0 when the total is 0). */
+  share: number;
+}
+
+export interface ApiValueRingSegment {
+  providerId: string;
+  /** Length of the colored arc along the ring. */
+  dash: number;
+  /** SVG stroke-dashoffset placing this segment after the previous ones. */
+  offset: number;
+}
+
+export interface ApiValueCardModel {
+  /** Providers with data this period, sorted by value desc, with shares. */
+  slices: ApiValueSlice[];
+  /** Sum of the selected metric across contributing providers. */
+  total: number;
+  /** Priced model tokens summed across contributing providers. */
+  pricedTokens: number;
+  /** All model tokens (priced + unpriced) across contributing providers. */
+  totalTokens: number;
+  /** pricedTokens / totalTokens, or null when there are no model tokens. */
+  coverage: number | null;
+  /** Providers that have unpriced tokens this period (for the details note). */
+  unpricedProviderIds: string[];
+  /** True when no provider had any data this period ("No data" state). */
+  isEmpty: boolean;
+}
+
+function periodOf(
+  provider: LocalApiValueProvider,
+  key: ApiValuePeriodKey,
+): LocalApiValuePeriod {
+  if (key === "today") return provider.today;
+  if (key === "yesterday") return provider.yesterday;
+  return provider.thirtyDays;
+}
+
+function metricValue(period: LocalApiValuePeriod, metric: ApiValueMetric): number {
+  return metric === "apiValue" ? period.apiValueUsd : period.tokens;
+}
+
+/**
+ * Build the card model for one period + metric. Providers without data this
+ * period are omitted (never counted as zero); shares are of the metric total.
+ * Pricing coverage is always computed from model tokens, independent of the
+ * selected metric, so the transparency note is consistent across metrics.
+ */
+export function buildApiValueCard(
+  providers: LocalApiValueProvider[],
+  periodKey: ApiValuePeriodKey,
+  metric: ApiValueMetric,
+): ApiValueCardModel {
+  const rows = providers
+    .map((provider) => ({ provider, period: periodOf(provider, periodKey) }))
+    .filter(({ period }) => period.hasData);
+
+  const total = rows.reduce((sum, { period }) => sum + metricValue(period, metric), 0);
+  const slices: ApiValueSlice[] = rows
+    .map(({ provider, period }) => ({
+      providerId: provider.providerId,
+      value: metricValue(period, metric),
+    }))
+    .sort((a, b) => b.value - a.value || a.providerId.localeCompare(b.providerId))
+    .map((slice) => ({ ...slice, share: total > 0 ? slice.value / total : 0 }));
+
+  const pricedTokens = rows.reduce((sum, { period }) => sum + period.pricedTokens, 0);
+  const totalTokens = rows.reduce((sum, { period }) => sum + period.totalTokens, 0);
+  const unpricedProviderIds = rows
+    .filter(({ period }) => period.totalTokens > period.pricedTokens)
+    .map(({ provider }) => provider.providerId);
+
+  return {
+    slices,
+    total,
+    pricedTokens,
+    totalTokens,
+    coverage: totalTokens > 0 ? pricedTokens / totalTokens : null,
+    unpricedProviderIds,
+    isEmpty: rows.length === 0,
+  };
+}
+
+/**
+ * Turn slice shares into SVG ring segments (the stroke-dasharray donut
+ * technique): each segment's `dash` is its arc length and `offset` places it
+ * after the previous segments around the circumference.
+ */
+export function ringSegments(
+  slices: ApiValueSlice[],
+  circumference: number,
+): ApiValueRingSegment[] {
+  let cumulative = 0;
+  return slices.map((slice) => {
+    const segment: ApiValueRingSegment = {
+      providerId: slice.providerId,
+      dash: slice.share * circumference,
+      offset: -cumulative * circumference,
+    };
+    cumulative += slice.share;
+    return segment;
+  });
+}

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -7868,6 +7868,154 @@ body:has(.dashboard-shell) #root {
   font-size: 9.5px;
   line-height: 1.4;
 }
+.api-value-card {
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--ceiling-glass-border) 75%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--text-primary) 2.5%, transparent);
+}
+.api-value-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.api-value-card__title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+}
+.api-value-card__subtitle {
+  margin: 2px 0 0;
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 1.4;
+}
+.api-value-card__switchers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.api-value-card__switch {
+  display: inline-flex;
+  padding: 2px;
+  border: 1px solid color-mix(in srgb, var(--ceiling-glass-border) 70%, transparent);
+  border-radius: 8px;
+  gap: 2px;
+}
+.api-value-card__switch-btn {
+  padding: 3px 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.api-value-card__switch-btn[data-active="true"] {
+  background: color-mix(in srgb, var(--text-primary) 12%, transparent);
+  color: var(--text-primary);
+}
+.api-value-card__body {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+}
+.api-value-card__ring {
+  position: relative;
+  flex: 0 0 auto;
+  width: 132px;
+  height: 132px;
+}
+.api-value-card__ring-svg {
+  width: 100%;
+  height: 100%;
+}
+.api-value-card__ring-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  pointer-events: none;
+}
+.api-value-card__ring-center strong {
+  color: var(--text-primary);
+  font-size: 17px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.api-value-card__ring-center small {
+  margin-top: 1px;
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+.api-value-card__legend {
+  flex: 1 1 160px;
+  min-width: 150px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 6px;
+}
+.api-value-card__legend-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: baseline;
+  gap: 8px;
+}
+.api-value-card__legend-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 3px;
+  align-self: center;
+}
+.api-value-card__legend-name {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.api-value-card__legend-share {
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+}
+.api-value-card__legend-value {
+  color: var(--text-primary);
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.api-value-card__note {
+  margin: 12px 0 0;
+  color: var(--text-secondary);
+  font-size: 9.5px;
+  line-height: 1.4;
+}
+.api-value-card__estimate-marker {
+  margin-right: 3px;
+  font-weight: 700;
+}
+.api-value-card__status {
+  margin: 8px 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+@media (max-width: 420px) {
+  .api-value-card__body {
+    justify-content: center;
+  }
+}
 .quota-history {
   display: grid;
   gap: 12px;

--- a/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
@@ -5,6 +5,7 @@ import { ProviderIcon } from "../components/providers/ProviderIcon";
 import { providerSupportsChartData } from "../lib/providerCharts";
 import { ChartsSection } from "./settings/providers/sections/charts/ChartsSection";
 import ProviderComparison from "./ProviderComparison";
+import { TotalApiValueCard } from "../components/TotalApiValueCard";
 
 const COMPARE_ID = "compare";
 
@@ -69,6 +70,7 @@ export default function ChartsPanel({
 
   return (
     <div className="charts-panel">
+      <TotalApiValueCard />
       {tabCount > 1 && (
         <div className="charts-provider-tabs" role="tablist" aria-label="Provider">
           {comparisonProviders && (

--- a/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
@@ -55,11 +55,16 @@ export default function ChartsPanel({
   }, [supported, comparisonProviders]);
 
   if (supported.length === 0) {
+    // The API-value card loads its own local totals, so keep it visible even
+    // when no provider reports chart-series data (or a snapshot errored).
     return (
-      <div className="charts-empty">
-        <strong>No charts yet</strong>
-        Limits and local usage history shows up here for providers that report it —
-        Codex, Claude, and OpenAI.
+      <div className="charts-panel">
+        <TotalApiValueCard />
+        <div className="charts-empty">
+          <strong>No charts yet</strong>
+          Limits and local usage history shows up here for providers that report it —
+          Codex, Claude, and OpenAI.
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## What

The aggregate "estimated API value" card from SOU-265, consuming the pass-3a backend (#57). Completes the SOU-262 dollar-analytics epic's UI.

## Changes

- **lib/apiValueCard.ts** - pure, unit-tested model + ring geometry. `buildApiValueCard` omits providers with no data (never counts zero), computes per-provider shares and pricing coverage; `ringSegments` turns shares into stroke-dasharray donut segments.
- **components/TotalApiValueCard.tsx** - period switcher (Today / Yesterday / 30 days) + metric switcher (API value / Tokens), an SVG donut coloured by provider brand colors, a ranked legend (share + value), and transparency copy: an estimate marker plus "N% of tokens priced (unpriced models in ...)" whenever coverage is below 100%. Empty periods show **No data**; a failed command shows an unavailable state. `role="img"` on the ring carries an a11y summary of metric, period, total, and providers.
- Mounted at the top of **ChartsPanel**; styling is responsive and theme-aware, reusing existing design tokens.

## Terminology (per SOU-265)

Dollars are labelled **Estimated API value**, never a bill or subscription spend. Providers with no source data are omitted; coverage is surfaced whenever any tokens are unpriced.

## Tests

- 8 pure-logic cases: single / multiple / tiny-share / missing-data / partial-pricing / all-unpriced, plus ring geometry.
- 3 render cases: aggregate total + ranked legend + coverage note, "No data" on switching to an empty period, unavailable state on command failure.

Frontend 258 / `tsc` clean.

**Note:** the donut was verified via the geometry unit tests and the standard stroke-dasharray technique - the in-app browser preview was unavailable for a live screenshot this session, so a visual pass on the rendered ring is worth a glance before release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API value card to the charts panel, always shown at the top.
  * Lets you switch between periods (today, yesterday, past 30 days) and metrics (API value vs tokens).
  * Visualizes provider contributions with a ring breakdown and legend, including token-pricing coverage where available.
  * Shows clear “no data” and “unavailable right now” states.
* **Tests**
  * Added UI and calculation test coverage, including pricing coverage, empty-period behavior, and error handling.
* **Style**
  * Added responsive styling for the API value card (including small-screen layout).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->