### PR TITLE
Collapse long project cost list behind a show-more toggle

### DIFF
--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -7877,6 +7877,21 @@ body:has(.dashboard-shell) #root {
   font-size: 9.5px;
   line-height: 1.4;
 }
+.usage-model-costs__more {
+  margin: 6px 0 0;
+  padding: 4px 8px;
+  background: transparent;
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.12));
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.usage-model-costs__more:hover {
+  color: var(--text-primary);
+  border-color: var(--border-strong, rgba(255, 255, 255, 0.24));
+}
 .usage-export {
   grid-column: 1 / -1;
   display: flex;

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
@@ -213,6 +213,37 @@ describe("ChartsSection local usage summary", () => {
     expect(queryByText("History unavailable")).toBeNull();
   });
 
+  it("collapses a long project list behind a show-more toggle", async () => {
+    const manyProjects = Array.from({ length: 12 }, (_, index) => ({
+      project: `project-${index}`,
+      cost: 1000 - index * 10,
+      tokens: 1_000_000,
+    }));
+    tauriMocks.getProviderChartData.mockResolvedValue({
+      ...enrichedData,
+      localUsage: { ...enrichedData.localUsage, projectBreakdown: manyProjects },
+    });
+
+    const { getByLabelText, getByRole } = render(
+      <ChartsSection providerId="claude" accountEmail={null} t={(key) => key} />,
+    );
+
+    const card = await waitFor(() => getByLabelText("Cost by project over 30 days"));
+    // Collapsed: only the first 8 rows are shown.
+    expect(card.querySelectorAll(".usage-model-costs__row")).toHaveLength(8);
+    expect(card.textContent).toContain("project-0");
+    expect(card.textContent).not.toContain("project-8");
+
+    const toggle = getByRole("button", { name: "Show all 12 projects" });
+    toggle.click();
+
+    await waitFor(() =>
+      expect(card.querySelectorAll(".usage-model-costs__row")).toHaveLength(12),
+    );
+    expect(card.textContent).toContain("project-11");
+    expect(getByRole("button", { name: "Show fewer" })).toBeTruthy();
+  });
+
   it("exports spend to CSV and shows the saved path", async () => {
     const { getByText, findByText } = render(
       <ChartsSection providerId="claude" accountEmail={null} t={(key) => key} />,

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -251,9 +251,14 @@ function ExportCsvButton({ providerId }: { providerId: string }) {
   );
 }
 
+const PROJECT_COLLAPSED_COUNT = 8;
+
 function ProjectBreakdown({ projects }: { projects: LocalProjectCost[] }) {
+  const [expanded, setExpanded] = useState(false);
   const priced = projects.reduce((sum, project) => sum + (project.cost ?? 0), 0);
   const hasUnpriced = projects.some((project) => project.cost == null);
+  const hasMore = projects.length > PROJECT_COLLAPSED_COUNT;
+  const visible = expanded ? projects : projects.slice(0, PROJECT_COLLAPSED_COUNT);
   return (
     <div className="usage-model-costs" aria-label="Cost by project over 30 days">
       <div className="usage-model-costs__header">
@@ -261,7 +266,7 @@ function ProjectBreakdown({ projects }: { projects: LocalProjectCost[] }) {
         <span className="usage-model-costs__total">{formatUsd(priced)}</span>
       </div>
       <ul className="usage-model-costs__rows">
-        {projects.map((project) => (
+        {visible.map((project) => (
           <li className="usage-model-costs__row" key={project.project}>
             <span className="usage-model-costs__name" title={project.project}>
               {projectLabel(project.project)}
@@ -273,6 +278,16 @@ function ProjectBreakdown({ projects }: { projects: LocalProjectCost[] }) {
           </li>
         ))}
       </ul>
+      {hasMore && (
+        <button
+          type="button"
+          className="usage-model-costs__more"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((open) => !open)}
+        >
+          {expanded ? "Show fewer" : `Show all ${projects.length} projects`}
+        </button>
+      )}
       {hasUnpriced && (
         <p className="usage-model-costs__note">
           Not priced · tokens counted, but the models used have no public rate.


### PR DESCRIPTION
The **Cost by project** breakdown can run 30+ rows (heavy multi-repo users), pushing the charts far below the fold. This caps it at the top 8 projects and adds a **Show all N projects** / **Show fewer** toggle.

- Projects are already sorted priced-first, so the top 8 are the ones that matter.
- The header total still reflects all projects, not just the visible 8.
- Model and effort breakdowns are naturally short (a handful of rows) and are left unchanged.

Test: renders 12 projects, asserts 8 rows while collapsed, expands to 12 and collapses back. Frontend 264 passing; tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project cost breakdowns now show up to 8 projects by default.
  * Added “Show all” and “Show fewer” controls to expand or collapse the full project list.

* **Style**
  * Added button styling and hover states for the project list controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->