### PR TITLE
Make README release badge auto-update from latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>AI usage. One elegant view.</strong></p>
 
 <p align="center">
-  <a href="https://github.com/tsouth89/ceiling/releases/latest"><img src="https://img.shields.io/badge/release-v1.1.0-2ea44f" alt="Latest release"></a>
+  <a href="https://github.com/tsouth89/ceiling/releases/latest"><img src="https://img.shields.io/github/v/release/tsouth89/ceiling?sort=semver&display_name=tag&label=release&color=2ea44f" alt="Latest release"></a>
   <img src="https://img.shields.io/badge/platform-Windows%2010%20%2F%2011-0078D6?logo=windows&logoColor=white" alt="Windows 10 and 11">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT license"></a>
   <img src="https://img.shields.io/badge/local--first-yes-6f42c1" alt="Local-first">


### PR DESCRIPTION
The release badge was pinned to a static `release-v1.1.0` (I froze it when shields.io's dynamic github endpoints were 5xx-ing). That defeats its purpose and it's now stale against v1.2.1.

Switched back to `img.shields.io/github/v/release/tsouth89/ceiling`, which tracks the latest GitHub release automatically. Verified healthy: 200 across repeated requests, renders `release | v1.2.1`.

Platform, license, and local-first badges stay static since they don't change per release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the GitHub release badge to automatically display the latest published release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->