### PR TITLE
Align charts with provider reset boundaries

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -129,48 +129,6 @@ pub struct LocalUsageComparisonPeriod {
     pub previous_breakdown: LocalTokenBreakdown,
 }
 
-#[derive(Debug, Clone)]
-struct ComparisonPeriodSpec {
-    id: &'static str,
-    label: &'static str,
-    current_window_id: String,
-    previous_window_id: String,
-}
-
-fn comparison_period_specs(
-    now: DateTime<Utc>,
-) -> (Vec<ComparisonPeriodSpec>, Vec<CurrentUsageWindow>) {
-    let periods = [
-        ("five-hours", "Last 5 hours", chrono::Duration::hours(5)),
-        ("seven-days", "Last 7 days", chrono::Duration::days(7)),
-    ];
-    let mut specs = Vec::with_capacity(periods.len());
-    let mut windows = Vec::with_capacity(periods.len() * 2);
-    for (id, label, duration) in periods {
-        let current_window_id = format!("compare-{id}-current");
-        let previous_window_id = format!("compare-{id}-previous");
-        let current_start = now - duration;
-        let previous_start = current_start - duration;
-        windows.push(CurrentUsageWindow {
-            id: current_window_id.clone(),
-            starts_at: current_start,
-            ends_at: now,
-        });
-        windows.push(CurrentUsageWindow {
-            id: previous_window_id.clone(),
-            starts_at: previous_start,
-            ends_at: current_start,
-        });
-        specs.push(ComparisonPeriodSpec {
-            id,
-            label,
-            current_window_id,
-            previous_window_id,
-        });
-    }
-    (specs, windows)
-}
-
 /// Provider-normalized token categories. Codex reports cached input as a
 /// subset of input, while Claude reports cache reads and writes separately;
 /// this shape makes the frontend comparison consistent.
@@ -274,10 +232,16 @@ struct PersistedChartCache {
 pub async fn get_provider_chart_data(
     provider_id: String,
     account_email: Option<String>,
+    source_label: Option<String>,
     usage_windows: Option<Vec<LocalUsageWindowRequest>>,
 ) -> ProviderChartData {
     let usage_windows = usage_windows.unwrap_or_default();
-    let cache_key = chart_cache_key(&provider_id, account_email.as_deref(), &usage_windows);
+    let cache_key = chart_cache_key(
+        &provider_id,
+        account_email.as_deref(),
+        source_label.as_deref(),
+        &usage_windows,
+    );
     if let Some(mut cached) = cached_chart_data(&cache_key) {
         cached.data.quota_history =
             crate::usage_history::provider_history(&provider_id, account_email.as_deref());
@@ -379,6 +343,7 @@ fn schedule_chart_cache_refresh(
 fn chart_cache_key(
     provider_id: &str,
     account_email: Option<&str>,
+    source_label: Option<&str>,
     usage_windows: &[LocalUsageWindowRequest],
 ) -> String {
     let identity = account_email
@@ -391,10 +356,16 @@ fn chart_cache_key(
         .map(|window| format!("{}:{}:{}", window.id, window.starts_at, window.ends_at))
         .collect::<Vec<_>>()
         .join("|");
+    let source = source_label
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("unknown")
+        .to_ascii_lowercase();
     format!(
-        "{}:{:016x}:{:016x}",
+        "{}:{:016x}:{:016x}:{:016x}",
         provider_id.to_ascii_lowercase(),
         fnv1a64(identity.as_bytes()),
+        fnv1a64(source.as_bytes()),
         fnv1a64(windows.as_bytes()),
     )
 }
@@ -747,7 +718,7 @@ fn build_provider_chart_data_with_cancel(
     usage_window_requests: Vec<LocalUsageWindowRequest>,
     cancel: Option<Arc<AtomicBool>>,
 ) -> ProviderChartData {
-    let mut usage_windows = usage_window_requests
+    let usage_windows = usage_window_requests
         .iter()
         .filter_map(|window| {
             let starts_at = DateTime::parse_from_rfc3339(&window.starts_at)
@@ -763,8 +734,6 @@ fn build_provider_chart_data_with_cancel(
             })
         })
         .collect::<Vec<_>>();
-    let (comparison_specs, comparison_windows) = comparison_period_specs(Utc::now());
-    usage_windows.extend(comparison_windows);
     let report = get_cost_usage_report_with_windows(&provider_id, 30, &usage_windows);
     let cost_history: Vec<DailyCostPoint> = report
         .as_ref()
@@ -791,12 +760,7 @@ fn build_provider_chart_data_with_cancel(
         report
             .as_ref()
             .and_then(|report| {
-                local_usage_summary_from_report(
-                    &provider_id,
-                    report,
-                    &usage_window_requests,
-                    &comparison_specs,
-                )
+                local_usage_summary_from_report(&provider_id, report, &usage_window_requests)
             })
             .or_else(|| load_local_usage_summary_cached(&provider_id, cancel.as_deref()))
     };
@@ -818,17 +782,11 @@ fn local_usage_summary_from_report(
     provider_id: &str,
     report: &CostUsageReport,
     usage_window_requests: &[LocalUsageWindowRequest],
-    comparison_specs: &[ComparisonPeriodSpec],
 ) -> Option<ProviderLocalUsageSummary> {
     let thirty_day_breakdown = token_breakdown(provider_id, &report.thirty_days);
-    // Compare uses an exact rolling 168-hour window. Reuse that same aggregate
-    // for the provider summary so two surfaces labelled "Last 7 days" cannot
-    // disagree with calendar-day versus rolling-window semantics.
-    let seven_day_summary = comparison_specs
-        .iter()
-        .find(|period| period.id == "seven-days")
-        .and_then(|period| report.current_windows.get(&period.current_window_id))
-        .unwrap_or(&report.seven_days);
+    // Calendar summaries stay calendar summaries. Provider reset windows are
+    // supplied explicitly above, never inferred from rolling durations.
+    let seven_day_summary = &report.seven_days;
     let seven_day_breakdown = token_breakdown(provider_id, seven_day_summary);
     let last_session_breakdown = report
         .latest_session
@@ -863,23 +821,6 @@ fn local_usage_summary_from_report(
             })
         })
         .collect();
-    let comparison_periods = comparison_specs
-        .iter()
-        .filter_map(|period| {
-            let current = report.current_windows.get(&period.current_window_id)?;
-            let previous = report.current_windows.get(&period.previous_window_id)?;
-            let current_breakdown = token_breakdown(provider_id, current);
-            let previous_breakdown = token_breakdown(provider_id, previous);
-            Some(LocalUsageComparisonPeriod {
-                id: period.id.to_string(),
-                label: period.label.to_string(),
-                current_tokens: current_breakdown.processed_tokens,
-                current_breakdown,
-                previous_tokens: previous_breakdown.processed_tokens,
-                previous_breakdown,
-            })
-        })
-        .collect();
     Some(ProviderLocalUsageSummary {
         today_cost: non_zero_f64(report.today.total_cost_usd),
         last_session_cost: report
@@ -895,7 +836,7 @@ fn local_usage_summary_from_report(
         thirty_day_tokens: non_zero_u64(thirty_day_tokens),
         thirty_day_token_breakdown: Some(thirty_day_breakdown),
         current_windows,
-        comparison_periods,
+        comparison_periods: Vec::new(),
         latest_tokens: non_zero_u64(last_session_tokens),
         top_model: top_model(&report.thirty_days),
         model_breakdown: model_breakdown(&report.thirty_days),
@@ -1372,11 +1313,10 @@ fn load_openai_dashboard_chart_data(
 mod tests {
     use super::{
         CostFetchFailure, LocalEffortCost, LocalModelCost, LocalProjectCost, LocalTokenBreakdown,
-        ProviderLocalUsageSummary, api_value_period, comparison_period_specs,
-        cost_fetch_failure_allows_early_retry, effort_breakdown, format_cost_csv,
-        local_midnight_in_tz, local_usage_summary_from_report, local_yesterday_window_utc,
-        localized_estimate_note, model_breakdown, project_breakdown, spend_budget_period_details,
-        token_breakdown, token_cost_cache_is_fresh,
+        ProviderLocalUsageSummary, api_value_period, cost_fetch_failure_allows_early_retry,
+        effort_breakdown, format_cost_csv, local_midnight_in_tz, local_usage_summary_from_report,
+        local_yesterday_window_utc, localized_estimate_note, model_breakdown, project_breakdown,
+        spend_budget_period_details, token_breakdown, token_cost_cache_is_fresh,
     };
     use crate::commands::is_provider_cache_fresh;
     use chrono::{Local, LocalResult, NaiveDate, NaiveTime, TimeZone, Utc};
@@ -1789,13 +1729,8 @@ mod tests {
     }
 
     #[test]
-    fn seven_day_summary_uses_the_same_rolling_window_as_comparison() {
-        let (comparison_specs, _) = comparison_period_specs(Utc::now());
-        let seven_days = comparison_specs
-            .iter()
-            .find(|period| period.id == "seven-days")
-            .expect("seven-day comparison period");
-        let mut report = CostUsageReport {
+    fn seven_day_summary_stays_a_calendar_period_without_rolling_comparison() {
+        let report = CostUsageReport {
             seven_days: CostSummary {
                 cache_read_tokens: 4_500_000_000,
                 ..CostSummary::default()
@@ -1806,33 +1741,12 @@ mod tests {
             },
             ..CostUsageReport::default()
         };
-        report.current_windows.insert(
-            seven_days.current_window_id.clone(),
-            CostSummary {
-                cache_read_tokens: 5_600_000_000,
-                ..CostSummary::default()
-            },
-        );
-        report.current_windows.insert(
-            seven_days.previous_window_id.clone(),
-            CostSummary {
-                cache_read_tokens: 3_000_000_000,
-                ..CostSummary::default()
-            },
-        );
 
-        let summary = local_usage_summary_from_report("claude", &report, &[], &comparison_specs)
-            .expect("local usage summary");
+        let summary =
+            local_usage_summary_from_report("claude", &report, &[]).expect("local usage summary");
 
-        assert_eq!(summary.seven_day_tokens, Some(5_600_000_000));
-        assert_eq!(
-            summary
-                .comparison_periods
-                .iter()
-                .find(|period| period.id == "seven-days")
-                .map(|period| period.current_tokens),
-            Some(5_600_000_000)
-        );
+        assert_eq!(summary.seven_day_tokens, Some(4_500_000_000));
+        assert!(summary.comparison_periods.is_empty());
     }
 
     #[test]

--- a/apps/desktop-tauri/src/lib/providerCharts.test.ts
+++ b/apps/desktop-tauri/src/lib/providerCharts.test.ts
@@ -73,4 +73,11 @@ describe("providerLocalUsageWindows", () => {
     expect(providerLocalUsageWindows(snapshot)).toEqual([]);
     expect(providerHasUnavailableResetBoundary(snapshot)).toBe(true);
   });
+
+  it("reports a malformed reset timestamp as an unavailable boundary", () => {
+    const snapshot = provider("not-a-timestamp");
+
+    expect(providerLocalUsageWindows(snapshot)).toEqual([]);
+    expect(providerHasUnavailableResetBoundary(snapshot)).toBe(true);
+  });
 });

--- a/apps/desktop-tauri/src/lib/providerCharts.test.ts
+++ b/apps/desktop-tauri/src/lib/providerCharts.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { providerLocalUsageWindows, providerSupportsChartData } from "./providerCharts";
+import {
+  providerHasUnavailableResetBoundary,
+  providerLocalUsageWindows,
+  providerSupportsChartData,
+} from "./providerCharts";
 import type { ProviderUsageSnapshot, RateWindowSnapshot } from "../types/bridge";
 
 describe("providerSupportsChartData", () => {
@@ -60,5 +64,13 @@ describe("providerLocalUsageWindows", () => {
       startsAt: "2026-07-15T16:20:00.000Z",
       endsAt: "2026-07-15T21:20:00.000Z",
     });
+  });
+
+  it("reports an unavailable boundary instead of creating a rolling window", () => {
+    const snapshot = provider("2026-07-15T21:20:00.000Z");
+    snapshot.primary = { ...snapshot.primary, resetsAt: null };
+
+    expect(providerLocalUsageWindows(snapshot)).toEqual([]);
+    expect(providerHasUnavailableResetBoundary(snapshot)).toBe(true);
   });
 });

--- a/apps/desktop-tauri/src/lib/providerCharts.ts
+++ b/apps/desktop-tauri/src/lib/providerCharts.ts
@@ -14,10 +14,14 @@ export function providerSupportsChartData(providerId: string): boolean {
 function currentWindowLabel(label: string): string {
   const normalized = label.toLowerCase();
   if (normalized.includes("5h") || normalized.includes("5-hour")) {
-    return "Current 5h window";
+    return "5-hour window";
   }
-  if (normalized.includes("week")) return "Current weekly window";
-  return `Current ${label.toLowerCase()} window`;
+  if (normalized.includes("week")) return "Weekly window";
+  return `${label.trim() || "Provider"} window`;
+}
+
+function hasUnavailableResetBoundary(window: RateWindowSnapshot | null | undefined): boolean {
+  return window != null && (!window.resetsAt || !window.windowMinutes || window.windowMinutes <= 0);
 }
 
 function usageWindowRequest(
@@ -65,4 +69,15 @@ export function providerLocalUsageWindows(
       provider.secondary,
     ),
   ].filter((window): window is LocalUsageWindowRequest => window !== null);
+}
+
+/** Whether an active Codex/Claude limit cannot be tied to a provider reset boundary. */
+export function providerHasUnavailableResetBoundary(
+  provider: ProviderUsageSnapshot | null | undefined,
+): boolean {
+  if (!provider || !["codex", "claude"].includes(provider.providerId.toLowerCase())) {
+    return false;
+  }
+  return hasUnavailableResetBoundary(provider.primary)
+    || hasUnavailableResetBoundary(provider.secondary);
 }

--- a/apps/desktop-tauri/src/lib/providerCharts.ts
+++ b/apps/desktop-tauri/src/lib/providerCharts.ts
@@ -21,7 +21,11 @@ function currentWindowLabel(label: string): string {
 }
 
 function hasUnavailableResetBoundary(window: RateWindowSnapshot | null | undefined): boolean {
-  return window != null && (!window.resetsAt || !window.windowMinutes || window.windowMinutes <= 0);
+  return window != null
+    && (!window.resetsAt
+      || !Number.isFinite(Date.parse(window.resetsAt))
+      || !window.windowMinutes
+      || window.windowMinutes <= 0);
 }
 
 function usageWindowRequest(

--- a/apps/desktop-tauri/src/lib/tauri.ts
+++ b/apps/desktop-tauri/src/lib/tauri.ts
@@ -252,11 +252,13 @@ export function getProviderChartData(
   providerId: string,
   accountEmail?: string,
   usageWindows?: import("../types/bridge").LocalUsageWindowRequest[],
+  sourceLabel?: string,
 ): Promise<ProviderChartData> {
   return invoke<ProviderChartData>("get_provider_chart_data", {
     providerId,
     accountEmail,
     usageWindows,
+    sourceLabel,
   });
 }
 

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
@@ -172,6 +172,16 @@ describe("ChartsSection local usage summary", () => {
   });
 
   it("does not substitute a rolling period when the provider reset is unavailable", async () => {
+    tauriMocks.getProviderChartData.mockResolvedValue({
+      ...enrichedData,
+      localUsage: null,
+      quotaHistory: [
+        {
+          recordedAt: "2026-07-19T12:00:00.000Z",
+          windows: [{ id: "primary", label: "Session", usedPercent: 20 }],
+        },
+      ],
+    });
     const providerSnapshot: ProviderUsageSnapshot = {
       providerId: "claude",
       displayName: "Claude",

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
@@ -11,6 +11,7 @@ const tauriMocks = vi.hoisted(() => ({
 vi.mock("../../../../../lib/tauri", () => tauriMocks);
 
 import { ChartsSection } from "./ChartsSection";
+import type { ProviderUsageSnapshot } from "../../../../../types/bridge";
 
 const enrichedData = {
   providerId: "claude",
@@ -29,7 +30,7 @@ const enrichedData = {
     currentWindows: [
       {
         id: "primary",
-        label: "Current 5h window",
+        label: "5-hour window",
         startsAt: new Date().toISOString(),
         endsAt: new Date(Date.now() + 3_600_000).toISOString(),
         tokens: 18_400_000,
@@ -43,7 +44,7 @@ const enrichedData = {
       },
       {
         id: "secondary",
-        label: "Current weekly window",
+        label: "Weekly window",
         startsAt: new Date(Date.now() - 4 * 24 * 3_600_000).toISOString(),
         endsAt: new Date(Date.now() + 3 * 24 * 3_600_000).toISOString(),
         tokens: 843_400_000,
@@ -102,8 +103,8 @@ describe("ChartsSection local usage summary", () => {
 
     await waitFor(() => expect(getByText("4.9B")).toBeTruthy());
     expect(getByText("23.6B")).toBeTruthy();
-    expect(getByText("Current 5h window")).toBeTruthy();
-    expect(getByText("Current weekly window")).toBeTruthy();
+    expect(getByText("5-hour window")).toBeTruthy();
+    expect(getByText("Weekly window")).toBeTruthy();
     expect(getByText("18.4M")).toBeTruthy();
     expect(() => getByText("Last session")).toThrow();
     expect(getByText("99.7% cache traffic")).toBeTruthy();
@@ -168,6 +169,58 @@ describe("ChartsSection local usage summary", () => {
     await waitFor(() => expect(getByRole("status").textContent).toContain("Reading local token history"));
     await waitFor(() => expect(getByText("4.9B")).toBeTruthy(), { timeout: 2_500 });
     expect(tauriMocks.getProviderChartData).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not substitute a rolling period when the provider reset is unavailable", async () => {
+    const providerSnapshot: ProviderUsageSnapshot = {
+      providerId: "claude",
+      displayName: "Claude",
+      primary: {
+        usedPercent: 20,
+        remainingPercent: 80,
+        windowMinutes: 300,
+        resetsAt: null,
+        resetDescription: null,
+        isExhausted: false,
+        reservePercent: null,
+        reserveDescription: null,
+        reserveWillLastToReset: false,
+        reserveEtaSeconds: null,
+      },
+      primaryLabel: "Session",
+      secondary: null,
+      modelSpecific: null,
+      tertiary: null,
+      extraRateWindows: [],
+      cost: null,
+      planName: null,
+      accountEmail: null,
+      sourceLabel: "Claude CLI",
+      updatedAt: "2026-07-19T12:00:00.000Z",
+      error: null,
+      pace: null,
+      accountOrganization: null,
+      trayStatusLabel: null,
+    };
+
+    const { getByText } = render(
+      <ChartsSection
+        providerId="claude"
+        accountEmail={null}
+        providerSnapshot={providerSnapshot}
+        t={(key) => key}
+      />,
+    );
+
+    expect(
+      await waitFor(() => getByText("Reset boundary unavailable. Ceiling will not substitute a rolling period.")),
+    ).toBeTruthy();
+    expect(tauriMocks.getProviderChartData).toHaveBeenCalledWith(
+      "claude",
+      undefined,
+      [],
+      "Claude CLI",
+    );
   });
 
   it("shows a Cursor activity-by-model card with shares and Auto relabel", async () => {

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -515,7 +515,8 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
   const hasLimits = data.quotaHistory.length > 0;
   const hasLocalSummary = data.localUsage !== null;
 
-  if (!hasCredits && !hasUsage && !hasLimits && !hasLocalSummary && !hasCursorActivity) {
+  if (!hasCredits && !hasUsage && !hasLimits && !hasLocalSummary && !hasCursorActivity
+    && !resetBoundaryUnavailable) {
     return (
       <section className="provider-detail-section provider-detail-charts charts-data-empty">
         <strong>History starts here</strong>
@@ -589,11 +590,6 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
               <small>{period.detail}</small>
             </div>
           ))}
-          {resetBoundaryUnavailable && (
-            <div className="usage-periods__note" role="status">
-              Reset boundary unavailable. Ceiling will not substitute a rolling period.
-            </div>
-          )}
           {data.localUsage.sevenDayTokenBreakdown && (
             <TokenMix breakdown={data.localUsage.sevenDayTokenBreakdown} />
           )}
@@ -615,6 +611,11 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
             <ProjectBreakdown projects={data.localUsage.projectBreakdown} />
           )}
           <ExportCsvButton providerId={providerId} />
+        </div>
+      )}
+      {resetBoundaryUnavailable && (
+        <div className="usage-periods__note" role="status">
+          Reset boundary unavailable. Ceiling will not substitute a rolling period.
         </div>
       )}
       {available.length > 1 && (

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -6,6 +6,7 @@ import {
   getSettingsSnapshot,
 } from "../../../../../lib/tauri";
 import {
+  providerHasUnavailableResetBoundary,
   providerLocalUsageWindows,
   providerSupportsChartData,
 } from "../../../../../lib/providerCharts";
@@ -41,13 +42,29 @@ type TabKey = "limits" | "credits" | "usage";
 // of truth and maintains its own longer-lived disk cache.
 const chartDataCache = new Map<string, ProviderChartData>();
 
-function chartDataCacheKey(providerId: string, accountEmail: string | null, usageWindowsKey = ""): string {
-  return `${providerId.toLowerCase()}:${accountEmail?.trim().toLowerCase() ?? ""}:${usageWindowsKey}`;
+function chartDataCacheKey(
+  providerId: string,
+  accountEmail: string | null,
+  sourceLabel: string | undefined,
+  usageWindowsKey = "",
+): string {
+  return `${providerId.toLowerCase()}:${accountEmail?.trim().toLowerCase() ?? ""}:${sourceLabel?.trim().toLowerCase() ?? ""}:${usageWindowsKey}`;
 }
 
 function formatWindowStart(value: string): string {
   const date = new Date(value);
   if (!Number.isFinite(date.getTime())) return "current reset period";
+  const today = new Date();
+  const sameDay = date.toDateString() === today.toDateString();
+  return new Intl.DateTimeFormat(undefined, sameDay
+    ? { hour: "numeric", minute: "2-digit" }
+    : { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }
+  ).format(date);
+}
+
+function formatWindowReset(value: string): string {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return "at the provider-reported boundary";
   const today = new Date();
   const sameDay = date.toDateString() === today.toDateString();
   return new Intl.DateTimeFormat(undefined, sameDay
@@ -315,13 +332,15 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
   const [failed, setFailed] = useState(false);
   const [cursorActivity, setCursorActivity] = useState<CursorModelActivity[] | null>(null);
   const usageWindows = providerLocalUsageWindows(providerSnapshot);
+  const sourceLabel = providerSnapshot?.sourceLabel;
+  const resetBoundaryUnavailable = providerHasUnavailableResetBoundary(providerSnapshot);
   const usageWindowsKey = usageWindows
     .map((window) => `${window.id}:${window.startsAt}:${window.endsAt}`)
     .join("|");
 
   useEffect(() => {
     let cancelled = false;
-    const cacheKey = chartDataCacheKey(providerId, accountEmail, usageWindowsKey);
+    const cacheKey = chartDataCacheKey(providerId, accountEmail, sourceLabel, usageWindowsKey);
     const cached = chartDataCache.get(cacheKey) ?? null;
     setData(cached);
     setActive(null);
@@ -338,7 +357,7 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
         cancelled = true;
       };
     }
-    getProviderChartData(providerId, accountEmail ?? undefined, usageWindows)
+    getProviderChartData(providerId, accountEmail ?? undefined, usageWindows, sourceLabel)
       .then((d) => {
         if (!cancelled) {
           chartDataCache.set(cacheKey, d);
@@ -362,7 +381,7 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
     return () => {
       cancelled = true;
     };
-  }, [providerId, accountEmail, usageWindowsKey]);
+  }, [providerId, accountEmail, sourceLabel, usageWindowsKey]);
 
   useEffect(() => {
     let cancelled = false;
@@ -423,10 +442,11 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
           providerId,
           accountEmail ?? undefined,
           usageWindows,
+          sourceLabel,
         );
         if (cancelled) return;
         if (next.localUsage) {
-          chartDataCache.set(chartDataCacheKey(providerId, accountEmail, usageWindowsKey), next);
+          chartDataCache.set(chartDataCacheKey(providerId, accountEmail, sourceLabel, usageWindowsKey), next);
           setData(next);
           setEnriching(false);
           return;
@@ -451,7 +471,7 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
       cancelled = true;
       if (timer !== undefined) window.clearTimeout(timer);
     };
-  }, [data, providerId, accountEmail, usageWindowsKey]);
+  }, [data, providerId, accountEmail, sourceLabel, usageWindowsKey]);
 
   // Cursor activity is independent of chart history and only belongs to the
   // Cursor provider. Guard on the current provider so a stale fetch from a
@@ -523,7 +543,7 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
         ...(data.localUsage.currentWindows ?? []).map((window) => ({
           label: window.label,
           tokens: window.tokens,
-          detail: `Since ${formatWindowStart(window.startsAt)}`,
+          detail: `Usage since reset at ${formatWindowStart(window.startsAt)} · resets ${formatWindowReset(window.endsAt)}`,
           current: true,
         })),
         {
@@ -569,6 +589,11 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
               <small>{period.detail}</small>
             </div>
           ))}
+          {resetBoundaryUnavailable && (
+            <div className="usage-periods__note" role="status">
+              Reset boundary unavailable. Ceiling will not substitute a rolling period.
+            </div>
+          )}
           {data.localUsage.sevenDayTokenBreakdown && (
             <TokenMix breakdown={data.localUsage.sevenDayTokenBreakdown} />
           )}


### PR DESCRIPTION
## Summary

- remove synthetic rolling 5-hour and 7-day chart comparison scans
- calculate local current-window charts only from the live provider-reported reset boundaries
- keep calendar seven-day totals explicitly calendar based, and show an honest unavailable-boundary state instead of substituting a rolling period
- isolate frontend and disk chart caches by provider data source

## Why

The old comparison data could look like a provider reset window while actually representing a rolling duration. That made the charts misleading whenever the provider boundary differed or was unavailable.

## Validation

- pnpm --dir apps/desktop-tauri build`n- pnpm --dir apps/desktop-tauri test`n- cargo test --manifest-path rust/Cargo.toml`n- cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml`n- cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings`n- cargo clippy --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all-targets -- -D warnings`n
Linear: SOU-264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reset-boundary status messaging when provider usage windows lack valid reset information.
  * Added reset timing details to usage period displays.
  * Improved chart cache separation for data from different sources.

* **Improvements**
  * Simplified usage window labels, such as “5-hour window” and “Weekly window.”
  * Updated local usage summaries to use calendar-based seven-day data.

* **Bug Fixes**
  * Prevented usage windows from being shown when reset boundaries are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->