### PR TITLE
Add Discord community badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://github.com/tsouth89/ceiling/releases/latest"><img src="https://img.shields.io/github/v/release/tsouth89/ceiling?sort=semver&display_name=tag&label=release&color=2ea44f" alt="Latest release"></a>
   <img src="https://img.shields.io/badge/platform-Windows%2010%20%2F%2011-0078D6?logo=windows&logoColor=white" alt="Windows 10 and 11">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT license"></a>
+  <a href="https://discord.gg/Xsn27MxdBA"><img src="https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white" alt="Join the Discord community"></a>
   <img src="https://img.shields.io/badge/local--first-yes-6f42c1" alt="Local-first">
 </p>
 


### PR DESCRIPTION
Adds a Discord badge to the README header badge row, matching the pattern used on the toolport repo. Links to the community invite (`discord.gg/Xsn27MxdBA`) — swap the URL if Ceiling should point at a separate server.

Styled as a centered `<img>` badge to match Ceiling's existing badge block (release / platform / license / local-first).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Discord community join badge to the README header, with a direct invitation link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->