### PR TITLE
Add MCP usage server and richer spend analytics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "portable-pty",
  "regex-lite",
  "reqwest 0.12.28",
+ "rmcp",
  "rusqlite",
  "serde",
  "serde_json",
@@ -2209,7 +2210,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3280,6 +3281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4089,6 +4096,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4194,7 +4236,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -4219,8 +4261,10 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -4230,6 +4274,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -570,10 +570,11 @@ fn load_local_api_value_totals(now: DateTime<Local>) -> Vec<LocalApiValueProvide
     let today = now.date_naive();
     let (yesterday_start, yesterday_end) = local_yesterday_window_utc(now);
     // Exact [start, end) windows so thirty-day and prior-thirty stay adjacent
-    // even when the scan covers 60 days for the prior window.
-    let thirty_start = local_midnight_utc(today - chrono::Duration::days(30));
+    // and each spans exactly 30 calendar days (including today for "thirty").
+    // [today-29, tomorrow) = today-29 … today; [today-59, today-29) = prior 30.
+    let thirty_start = local_midnight_utc(today - chrono::Duration::days(29));
     let thirty_end = local_midnight_utc(today + chrono::Duration::days(1));
-    let prior_start = local_midnight_utc(today - chrono::Duration::days(60));
+    let prior_start = local_midnight_utc(today - chrono::Duration::days(59));
     API_VALUE_PROVIDERS
         .iter()
         .filter_map(|provider_id| {

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -150,6 +150,13 @@ pub struct LocalModelCost {
     pub model: String,
     pub cost: Option<f64>,
     pub tokens: u64,
+    /// Cache-read share of processed tokens (0–100), when any tokens exist.
+    pub cache_read_percent: Option<f64>,
+    /// Estimated USD per usage record, when cost and calls are both present.
+    pub cost_per_call: Option<f64>,
+    /// Output tokens per usage record, when calls > 0.
+    pub output_tokens_per_call: Option<f64>,
+    pub calls: u64,
 }
 
 /// Per-reasoning-effort local spend for a period (Codex only: "high"/"xhigh"/
@@ -191,7 +198,7 @@ pub struct LocalApiValuePeriod {
     pub has_data: bool,
 }
 
-/// One provider's local usage across the card's three periods.
+/// One provider's local usage across the card's periods.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct LocalApiValueProvider {
@@ -199,6 +206,8 @@ pub struct LocalApiValueProvider {
     pub today: LocalApiValuePeriod,
     pub yesterday: LocalApiValuePeriod,
     pub thirty_days: LocalApiValuePeriod,
+    /// Calendar days [today-60, today-30) for dollar period-over-period on 30d.
+    pub prior_thirty_days: LocalApiValuePeriod,
 }
 
 /// Full chart data bundle for one provider.
@@ -558,31 +567,61 @@ pub async fn get_local_api_value_totals() -> Result<Vec<LocalApiValueProvider>, 
 }
 
 fn load_local_api_value_totals(now: DateTime<Local>) -> Vec<LocalApiValueProvider> {
-    let (start, end) = local_yesterday_window_utc(now);
+    let today = now.date_naive();
+    let (yesterday_start, yesterday_end) = local_yesterday_window_utc(now);
+    // Exact [start, end) windows so thirty-day and prior-thirty stay adjacent
+    // even when the scan covers 60 days for the prior window.
+    let thirty_start = local_midnight_utc(today - chrono::Duration::days(30));
+    let thirty_end = local_midnight_utc(today + chrono::Duration::days(1));
+    let prior_start = local_midnight_utc(today - chrono::Duration::days(60));
     API_VALUE_PROVIDERS
         .iter()
         .filter_map(|provider_id| {
-            let windows = vec![CurrentUsageWindow {
-                id: "yesterday".to_string(),
-                starts_at: start,
-                ends_at: end,
-            }];
-            let report = get_cost_usage_report_with_windows(provider_id, 30, &windows)?;
+            let windows = vec![
+                CurrentUsageWindow {
+                    id: "yesterday".to_string(),
+                    starts_at: yesterday_start,
+                    ends_at: yesterday_end,
+                },
+                CurrentUsageWindow {
+                    id: "thirty".to_string(),
+                    starts_at: thirty_start,
+                    ends_at: thirty_end,
+                },
+                CurrentUsageWindow {
+                    id: "prior_thirty".to_string(),
+                    starts_at: prior_start,
+                    ends_at: thirty_start,
+                },
+            ];
+            let report = get_cost_usage_report_with_windows(provider_id, 60, &windows)?;
             let yesterday = report
                 .current_windows
                 .get("yesterday")
+                .cloned()
+                .unwrap_or_default();
+            let thirty_days = report
+                .current_windows
+                .get("thirty")
+                .cloned()
+                .unwrap_or_default();
+            let prior_thirty_days = report
+                .current_windows
+                .get("prior_thirty")
                 .cloned()
                 .unwrap_or_default();
             let provider = LocalApiValueProvider {
                 provider_id: provider_id.to_string(),
                 today: api_value_period(provider_id, &report.today),
                 yesterday: api_value_period(provider_id, &yesterday),
-                thirty_days: api_value_period(provider_id, &report.thirty_days),
+                thirty_days: api_value_period(provider_id, &thirty_days),
+                prior_thirty_days: api_value_period(provider_id, &prior_thirty_days),
             };
             // Omit providers with no source data in any period.
             (provider.today.has_data
                 || provider.yesterday.has_data
-                || provider.thirty_days.has_data)
+                || provider.thirty_days.has_data
+                || provider.prior_thirty_days.has_data)
                 .then_some(provider)
         })
         .collect()
@@ -1170,10 +1209,26 @@ fn model_breakdown(summary: &CostSummary) -> Vec<LocalModelCost> {
     let mut rows: Vec<LocalModelCost> = summary
         .by_model_tokens
         .iter()
-        .map(|(model, counts)| LocalModelCost {
-            model: model.clone(),
-            cost: summary.by_model.get(model).copied(),
-            tokens: counts.total(),
+        .map(|(model, counts)| {
+            let cost = summary.by_model.get(model).copied();
+            let processed = counts.processed();
+            let cache_read_percent = (processed > 0)
+                .then_some((counts.cache_read_tokens as f64 / processed as f64) * 100.0);
+            let cost_per_call = match (cost, counts.calls) {
+                (Some(usd), calls) if calls > 0 => Some(usd / calls as f64),
+                _ => None,
+            };
+            let output_tokens_per_call =
+                (counts.calls > 0).then_some(counts.output_tokens as f64 / counts.calls as f64);
+            LocalModelCost {
+                model: model.clone(),
+                cost,
+                tokens: counts.total(),
+                cache_read_percent,
+                cost_per_call,
+                output_tokens_per_call,
+                calls: counts.calls,
+            }
         })
         .collect();
     rows.sort_by(|a, b| {
@@ -1371,6 +1426,10 @@ mod tests {
                 model: "gpt-5".to_string(),
                 cost: Some(2.0),
                 tokens: 300,
+                cache_read_percent: None,
+                cost_per_call: None,
+                output_tokens_per_call: None,
+                calls: 0,
             }],
             effort_breakdown: vec![LocalEffortCost {
                 effort: "high".to_string(),
@@ -1423,7 +1482,7 @@ mod tests {
             ModelTokenCounts {
                 input_tokens: 1,
                 output_tokens: 1,
-                cached_tokens: 0,
+                ..Default::default()
             },
         );
         summary.by_model_tokens.insert(
@@ -1431,7 +1490,7 @@ mod tests {
             ModelTokenCounts {
                 input_tokens: 100,
                 output_tokens: 100,
-                cached_tokens: 0,
+                ..Default::default()
             },
         );
         summary.by_model_tokens.insert(
@@ -1439,7 +1498,7 @@ mod tests {
             ModelTokenCounts {
                 input_tokens: 10,
                 output_tokens: 10,
-                cached_tokens: 0,
+                ..Default::default()
             },
         );
         summary.by_model_tokens.insert(
@@ -1447,7 +1506,7 @@ mod tests {
             ModelTokenCounts {
                 input_tokens: 500,
                 output_tokens: 500,
-                cached_tokens: 0,
+                ..Default::default()
             },
         );
 
@@ -1460,23 +1519,39 @@ mod tests {
                     model: "pricey".to_string(),
                     cost: Some(9.0),
                     tokens: 20,
+                    cache_read_percent: Some(0.0),
+                    cost_per_call: None,
+                    output_tokens_per_call: None,
+                    calls: 0,
                 },
                 LocalModelCost {
                     model: "cheap".to_string(),
                     cost: Some(1.0),
                     tokens: 200,
+                    cache_read_percent: Some(0.0),
+                    cost_per_call: None,
+                    output_tokens_per_call: None,
+                    calls: 0,
                 },
                 // Priced $0.00 still leads the unpriced model despite fewer tokens.
                 LocalModelCost {
                     model: "free".to_string(),
                     cost: Some(0.0),
                     tokens: 2,
+                    cache_read_percent: Some(0.0),
+                    cost_per_call: None,
+                    output_tokens_per_call: None,
+                    calls: 0,
                 },
                 // Unpriced model keeps its tokens but sorts last with no dollars.
                 LocalModelCost {
                     model: "unpriced".to_string(),
                     cost: None,
                     tokens: 1000,
+                    cache_read_percent: Some(0.0),
+                    cost_per_call: None,
+                    output_tokens_per_call: None,
+                    calls: 0,
                 },
             ]
         );
@@ -1495,7 +1570,7 @@ mod tests {
             ModelTokenCounts {
                 input_tokens: 50,
                 output_tokens: 50,
-                cached_tokens: 0,
+                ..Default::default()
             },
         );
         summary.by_effort_tokens.insert(
@@ -1503,7 +1578,7 @@ mod tests {
             ModelTokenCounts {
                 input_tokens: 200,
                 output_tokens: 200,
-                cached_tokens: 0,
+                ..Default::default()
             },
         );
         // Unknown-effort usage with no price sorts last.
@@ -1512,7 +1587,7 @@ mod tests {
             ModelTokenCounts {
                 input_tokens: 900,
                 output_tokens: 900,
-                cached_tokens: 0,
+                ..Default::default()
             },
         );
 
@@ -1553,7 +1628,7 @@ mod tests {
                 ModelTokenCounts {
                     input_tokens: input,
                     output_tokens: input,
-                    cached_tokens: 0,
+                    ..Default::default()
                 },
             );
         }
@@ -1599,7 +1674,7 @@ mod tests {
             ModelTokenCounts {
                 input_tokens: 300,
                 output_tokens: 100,
-                cached_tokens: 0,
+                ..Default::default()
             },
         );
         summary.by_model_tokens.insert(
@@ -1607,7 +1682,7 @@ mod tests {
             ModelTokenCounts {
                 input_tokens: 100,
                 output_tokens: 0,
-                cached_tokens: 0,
+                ..Default::default()
             },
         );
         summary.unknown_models.insert("gpt-mystery".to_string());
@@ -1645,7 +1720,7 @@ mod tests {
             ModelTokenCounts {
                 input_tokens: 200,
                 output_tokens: 50,
-                cached_tokens: 0,
+                ..Default::default()
             },
         );
 

--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -188,6 +188,7 @@ async fn do_refresh_providers_with_policy(
 
     let error_count = finish_provider_refresh(&state)?;
     update_tray_and_notifications(app, &state, &inputs.settings, &inputs.token_accounts)?;
+    persist_widget_snapshot_from_cache(&state, &inputs.enabled_ids);
     if let Ok(mut guard) = state.lock() {
         guard.notification_manager.arm_after_startup_baseline();
     }
@@ -498,6 +499,81 @@ fn finish_provider_refresh(state: &tauri::State<'_, Mutex<AppState>>) -> Result<
         .iter()
         .filter(|s| s.error.is_some())
         .count())
+}
+
+/// Persist the in-memory provider cache as `widget-snapshot.json` so
+/// `codexbar statusline` / `codexbar mcp` can read quota without networking.
+fn persist_widget_snapshot_from_cache(
+    state: &tauri::State<'_, Mutex<AppState>>,
+    enabled_ids: &[ProviderId],
+) {
+    let cached = match state.lock() {
+        Ok(guard) => guard.provider_cache.clone(),
+        Err(error) => {
+            tracing::warn!("failed to lock app state for widget snapshot: {error}");
+            return;
+        }
+    };
+
+    let entries: Vec<_> = cached
+        .iter()
+        .filter(|snap| snap.error.is_none())
+        .filter_map(widget_entry_from_usage_snapshot)
+        .collect();
+    if entries.is_empty() {
+        return;
+    }
+
+    let snapshot = codexbar::core::WidgetSnapshot::new(entries, chrono::Utc::now())
+        .with_enabled_providers(enabled_ids.to_vec());
+    if let Err(error) = codexbar::core::WidgetSnapshotStore::save(&snapshot) {
+        tracing::warn!("failed to save widget snapshot for MCP/statusline: {error}");
+    }
+}
+
+fn widget_entry_from_usage_snapshot(
+    snap: &ProviderUsageSnapshot,
+) -> Option<codexbar::core::WidgetProviderEntry> {
+    let provider = ProviderId::from_cli_name(&snap.provider_id)?;
+    let updated_at = chrono::DateTime::parse_from_rfc3339(&snap.updated_at)
+        .ok()
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .unwrap_or_else(chrono::Utc::now);
+
+    let mut entry = codexbar::core::WidgetProviderEntry::new(provider, updated_at)
+        .with_primary(rate_window_from_snapshot(&snap.primary));
+    if let Some(secondary) = snap.secondary.as_ref() {
+        entry = entry.with_secondary(rate_window_from_snapshot(secondary));
+    }
+    if let Some(tertiary) = snap.tertiary.as_ref() {
+        entry = entry.with_tertiary(rate_window_from_snapshot(tertiary));
+    }
+    if let Some(email) = snap.account_email.clone() {
+        entry = entry.with_account_email(email);
+    }
+    if let Some(plan) = snap.plan_name.clone() {
+        entry = entry.with_login_method(plan);
+    }
+    if let Some(cost) = snap.cost.as_ref()
+        && let Some(remaining) = cost.remaining
+    {
+        entry = entry.with_credits_remaining(remaining);
+    }
+    Some(entry)
+}
+
+fn rate_window_from_snapshot(window: &RateWindowSnapshot) -> RateWindow {
+    let resets_at = window.resets_at.as_deref().and_then(|raw| {
+        chrono::DateTime::parse_from_rfc3339(raw)
+            .ok()
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+    });
+    RateWindow::with_details(
+        window.used_percent,
+        window.window_minutes,
+        resets_at,
+        window.reset_description.clone(),
+    )
 }
 
 fn update_tray_and_notifications(

--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -554,10 +554,14 @@ fn widget_entry_from_usage_snapshot(
     if let Some(plan) = snap.plan_name.clone() {
         entry = entry.with_login_method(plan);
     }
-    if let Some(cost) = snap.cost.as_ref()
-        && let Some(remaining) = cost.remaining
-    {
-        entry = entry.with_credits_remaining(remaining);
+    if let Some(cost) = snap.cost.as_ref() {
+        if let Some(remaining) = cost.remaining {
+            entry = entry.with_credits_remaining(remaining);
+        }
+        // Statusline / MCP read session_cost_usd from token_usage; provider
+        // CostSnapshot.used is the billed/period dollar figure we have.
+        entry = entry
+            .with_token_usage(codexbar::core::TokenUsageSummary::new().with_session(cost.used, 0));
     }
     Some(entry)
 }

--- a/apps/desktop-tauri/src/components/TotalApiValueCard.test.tsx
+++ b/apps/desktop-tauri/src/components/TotalApiValueCard.test.tsx
@@ -26,12 +26,14 @@ const twoProviders = [
     today: period({ apiValueUsd: 90, tokens: 9000, pricedTokens: 8000, totalTokens: 9000, hasData: true }),
     yesterday: period({}),
     thirtyDays: period({ apiValueUsd: 300, tokens: 30000, pricedTokens: 30000, totalTokens: 30000, hasData: true }),
+    priorThirtyDays: period({}),
   },
   {
     providerId: "claude",
     today: period({ apiValueUsd: 30, tokens: 3000, pricedTokens: 3000, totalTokens: 3000, hasData: true }),
     yesterday: period({}),
     thirtyDays: period({ apiValueUsd: 100, tokens: 10000, pricedTokens: 10000, totalTokens: 10000, hasData: true }),
+    priorThirtyDays: period({}),
   },
 ];
 
@@ -65,6 +67,7 @@ describe("TotalApiValueCard", () => {
         today: period({ apiValueUsd: 5, tokens: 500, pricedTokens: 500, totalTokens: 500, hasData: true }),
         yesterday: period({}),
         thirtyDays: period({ apiValueUsd: 5, tokens: 500, pricedTokens: 500, totalTokens: 500, hasData: true }),
+        priorThirtyDays: period({}),
       },
     ]);
     const { getByText, getAllByText, findByText } = render(<TotalApiValueCard />);

--- a/apps/desktop-tauri/src/components/TotalApiValueCard.tsx
+++ b/apps/desktop-tauri/src/components/TotalApiValueCard.tsx
@@ -4,6 +4,7 @@ import type { LocalApiValueProvider } from "../types/bridge";
 import { getProviderIcon } from "./providers/providerIcons";
 import {
   buildApiValueCard,
+  formatPeriodChange,
   ringSegments,
   type ApiValueMetric,
   type ApiValuePeriodKey,
@@ -96,6 +97,10 @@ export function TotalApiValueCard() {
   // Compare the raw ratio so 99.6% (rounds to 100) still shows the coverage
   // note when any tokens are unpriced.
   const showCoverage = model.coverage != null && model.coverage < 1;
+  const periodChangeLabel =
+    model.periodChange && metric === "apiValue"
+      ? formatPeriodChange(model.periodChange)
+      : null;
 
   const ariaSummary = model.isEmpty
     ? `No local ${metricLabel} data for ${periodLabel}.`
@@ -181,6 +186,9 @@ export function TotalApiValueCard() {
             <div className="api-value-card__ring-center">
               <strong>{formatValue(model.total)}</strong>
               <small>{periodLabel}</small>
+              {periodChangeLabel && (
+                <small className="api-value-card__period-change">{periodChangeLabel}</small>
+              )}
             </div>
           </div>
 

--- a/apps/desktop-tauri/src/lib/apiValueCard.test.ts
+++ b/apps/desktop-tauri/src/lib/apiValueCard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { LocalApiValuePeriod, LocalApiValueProvider } from "../types/bridge";
-import { buildApiValueCard, ringSegments } from "./apiValueCard";
+import { buildApiValueCard, formatPeriodChange, ringSegments } from "./apiValueCard";
 
 function period(over: Partial<LocalApiValuePeriod>): LocalApiValuePeriod {
   return {
@@ -17,13 +17,16 @@ const empty = period({});
 
 function provider(
   providerId: string,
-  periods: Partial<Record<"today" | "yesterday" | "thirtyDays", LocalApiValuePeriod>>,
+  periods: Partial<
+    Record<"today" | "yesterday" | "thirtyDays" | "priorThirtyDays", LocalApiValuePeriod>
+  >,
 ): LocalApiValueProvider {
   return {
     providerId,
     today: periods.today ?? empty,
     yesterday: periods.yesterday ?? empty,
     thirtyDays: periods.thirtyDays ?? empty,
+    priorThirtyDays: periods.priorThirtyDays ?? empty,
   };
 }
 
@@ -139,6 +142,80 @@ describe("buildApiValueCard", () => {
     expect(model.total).toBe(1000);
     expect(model.coverage).toBe(0);
     expect(model.unpricedProviderIds).toEqual(["codex"]);
+  });
+
+  it("reports dollar period-over-period for today vs yesterday", () => {
+    const model = buildApiValueCard(
+      [
+        provider("codex", {
+          today: period({
+            apiValueUsd: 12,
+            tokens: 1000,
+            pricedTokens: 1000,
+            totalTokens: 1000,
+            hasData: true,
+          }),
+          yesterday: period({
+            apiValueUsd: 10,
+            tokens: 800,
+            pricedTokens: 800,
+            totalTokens: 800,
+            hasData: true,
+          }),
+        }),
+      ],
+      "today",
+      "apiValue",
+    );
+    expect(model.periodChange).toEqual({
+      versusLabel: "vs yesterday",
+      hasPrior: true,
+      percent: 20,
+    });
+  });
+
+  it("reports 30d vs prior 30d dollar change", () => {
+    const model = buildApiValueCard(
+      [
+        provider("codex", {
+          thirtyDays: period({
+            apiValueUsd: 118,
+            tokens: 1,
+            pricedTokens: 1,
+            totalTokens: 1,
+            hasData: true,
+          }),
+          priorThirtyDays: period({
+            apiValueUsd: 100,
+            tokens: 1,
+            pricedTokens: 1,
+            totalTokens: 1,
+            hasData: true,
+          }),
+        }),
+      ],
+      "thirtyDays",
+      "apiValue",
+    );
+    expect(model.periodChange?.versusLabel).toBe("vs prior 30d");
+    expect(model.periodChange?.percent).toBeCloseTo(18);
+  });
+});
+
+describe("formatPeriodChange", () => {
+  it("formats signed percent labels", () => {
+    expect(
+      formatPeriodChange({ versusLabel: "vs prior 30d", hasPrior: true, percent: 18.4 }),
+    ).toBe("+18% vs prior 30d");
+    expect(
+      formatPeriodChange({ versusLabel: "vs yesterday", hasPrior: true, percent: -5 }),
+    ).toBe("-5% vs yesterday");
+    expect(
+      formatPeriodChange({ versusLabel: "vs yesterday", hasPrior: true, percent: null }),
+    ).toBe("New activity vs yesterday");
+    expect(
+      formatPeriodChange({ versusLabel: "vs yesterday", hasPrior: false, percent: null }),
+    ).toBeNull();
   });
 });
 

--- a/apps/desktop-tauri/src/lib/apiValueCard.ts
+++ b/apps/desktop-tauri/src/lib/apiValueCard.ts
@@ -22,6 +22,16 @@ export interface ApiValueRingSegment {
   offset: number;
 }
 
+/** Dollar (or token) change vs the comparable prior window. */
+export interface ApiValuePeriodChange {
+  /** Percent change vs prior; null when prior had no data. */
+  percent: number | null;
+  /** Short label, e.g. "vs yesterday" or "vs prior 30d". */
+  versusLabel: string;
+  /** True when prior window had data so a % is meaningful. */
+  hasPrior: boolean;
+}
+
 export interface ApiValueCardModel {
   /** Providers with data this period, sorted by value desc, with shares. */
   slices: ApiValueSlice[];
@@ -37,6 +47,8 @@ export interface ApiValueCardModel {
   unpricedProviderIds: string[];
   /** True when no provider had any data this period ("No data" state). */
   isEmpty: boolean;
+  /** Period-over-period delta for the selected metric (apiValue or tokens). */
+  periodChange: ApiValuePeriodChange | null;
 }
 
 function periodOf(
@@ -48,8 +60,38 @@ function periodOf(
   return provider.thirtyDays;
 }
 
+function priorPeriodOf(
+  provider: LocalApiValueProvider,
+  key: ApiValuePeriodKey,
+): { period: LocalApiValuePeriod; versusLabel: string } | null {
+  if (key === "today") {
+    return { period: provider.yesterday, versusLabel: "vs yesterday" };
+  }
+  if (key === "thirtyDays") {
+    return { period: provider.priorThirtyDays, versusLabel: "vs prior 30d" };
+  }
+  // Yesterday has no stable prior on this card.
+  return null;
+}
+
 function metricValue(period: LocalApiValuePeriod, metric: ApiValueMetric): number {
   return metric === "apiValue" ? period.apiValueUsd : period.tokens;
+}
+
+function sumMetric(
+  providers: LocalApiValueProvider[],
+  pick: (provider: LocalApiValueProvider) => LocalApiValuePeriod,
+  metric: ApiValueMetric,
+): { total: number; hasData: boolean } {
+  let total = 0;
+  let hasData = false;
+  for (const provider of providers) {
+    const period = pick(provider);
+    if (!period.hasData) continue;
+    hasData = true;
+    total += metricValue(period, metric);
+  }
+  return { total, hasData };
 }
 
 /**
@@ -82,6 +124,35 @@ export function buildApiValueCard(
     .filter(({ period }) => period.totalTokens > period.pricedTokens)
     .map(({ provider }) => provider.providerId);
 
+  const priorMeta = rows.length > 0 ? priorPeriodOf(providers[0], periodKey) : null;
+  let periodChange: ApiValuePeriodChange | null = null;
+  if (priorMeta) {
+    const priorSum = sumMetric(
+      providers,
+      (provider) => priorPeriodOf(provider, periodKey)!.period,
+      metric,
+    );
+    if (!priorSum.hasData) {
+      periodChange = {
+        versusLabel: priorMeta.versusLabel,
+        hasPrior: false,
+        percent: null,
+      };
+    } else if (priorSum.total <= 0) {
+      periodChange = {
+        versusLabel: priorMeta.versusLabel,
+        hasPrior: true,
+        percent: total > 0 ? null : 0,
+      };
+    } else {
+      periodChange = {
+        versusLabel: priorMeta.versusLabel,
+        hasPrior: true,
+        percent: ((total - priorSum.total) / priorSum.total) * 100,
+      };
+    }
+  }
+
   return {
     slices,
     total,
@@ -90,6 +161,7 @@ export function buildApiValueCard(
     coverage: totalTokens > 0 ? pricedTokens / totalTokens : null,
     unpricedProviderIds,
     isEmpty: rows.length === 0,
+    periodChange: rows.length === 0 ? null : periodChange,
   };
 }
 
@@ -112,4 +184,13 @@ export function ringSegments(
     cumulative += slice.share;
     return segment;
   });
+}
+
+/** Format a period-change for the donut center caption. */
+export function formatPeriodChange(change: ApiValuePeriodChange): string | null {
+  if (!change.hasPrior) return null;
+  if (change.percent == null) return `New activity ${change.versusLabel}`;
+  const rounded = Math.round(change.percent);
+  const sign = rounded > 0 ? "+" : "";
+  return `${sign}${rounded}% ${change.versusLabel}`;
 }

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -7845,6 +7845,11 @@ body:has(.dashboard-shell) #root {
   list-style: none;
 }
 .usage-model-costs__row {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.usage-model-costs__main {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto auto;
   gap: 10px;
@@ -7870,6 +7875,14 @@ body:has(.dashboard-shell) #root {
   font-variant-numeric: tabular-nums;
   text-align: right;
   white-space: nowrap;
+}
+.usage-model-costs__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 9.5px;
+  font-variant-numeric: tabular-nums;
 }
 .usage-model-costs__note {
   margin: 7px 0 0;
@@ -8090,6 +8103,12 @@ body:has(.dashboard-shell) #root {
   margin-top: 1px;
   color: var(--text-secondary);
   font-size: 10px;
+}
+.api-value-card__period-change {
+  margin-top: 2px;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
 }
 .api-value-card__legend {
   flex: 1 1 160px;

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -131,13 +131,26 @@ function ModelBreakdown({ models }: { models: LocalModelCost[] }) {
       <ul className="usage-model-costs__rows">
         {models.map((model) => (
           <li className="usage-model-costs__row" key={model.model}>
-            <span className="usage-model-costs__name" title={model.model}>
-              {model.model}
-            </span>
-            <span className="usage-model-costs__tokens">{formatTokens(model.tokens)}</span>
-            <span className="usage-model-costs__cost">
-              {model.cost == null ? "Not priced" : formatUsd(model.cost)}
-            </span>
+            <div className="usage-model-costs__main">
+              <span className="usage-model-costs__name" title={model.model}>
+                {model.model}
+              </span>
+              <span className="usage-model-costs__tokens">{formatTokens(model.tokens)}</span>
+              <span className="usage-model-costs__cost">
+                {model.cost == null ? "Not priced" : formatUsd(model.cost)}
+              </span>
+            </div>
+            <div className="usage-model-costs__metrics">
+              {model.cacheReadPercent != null && (
+                <span>{model.cacheReadPercent.toFixed(0)}% cache read</span>
+              )}
+              {model.costPerCall != null && (
+                <span>{formatUsd(model.costPerCall)}/call</span>
+              )}
+              {model.outputTokensPerCall != null && (
+                <span>{formatTokens(Math.round(model.outputTokensPerCall))} out/call</span>
+              )}
+            </div>
           </li>
         ))}
       </ul>

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -645,6 +645,13 @@ export interface LocalModelCost {
   /** Dollar cost for the period, or null when the model has no canonical price. */
   cost: number | null;
   tokens: number;
+  /** Cache-read share of processed tokens (0–100), when any tokens exist. */
+  cacheReadPercent?: number | null;
+  /** Estimated USD per usage record, when cost and calls are both present. */
+  costPerCall?: number | null;
+  /** Output tokens per usage record, when calls > 0. */
+  outputTokensPerCall?: number | null;
+  calls?: number;
 }
 
 export interface LocalEffortCost {
@@ -681,6 +688,8 @@ export interface LocalApiValueProvider {
   today: LocalApiValuePeriod;
   yesterday: LocalApiValuePeriod;
   thirtyDays: LocalApiValuePeriod;
+  /** Calendar days [today-60, today-30) for 30d dollar period-over-period. */
+  priorThirtyDays: LocalApiValuePeriod;
 }
 
 export interface CursorModelActivity {

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -84,6 +84,7 @@ dirs = "6"
 open = "5"
 fluent-templates = "0.13"
 unic-langid = "0.9"
+rmcp = { version = "2.2.0", features = ["server", "transport-io"] }
 
 # Windows-only
 [target.'cfg(windows)'.dependencies]

--- a/rust/src/cli/mcp.rs
+++ b/rust/src/cli/mcp.rs
@@ -1,0 +1,401 @@
+//! `codexbar mcp` — local-first MCP server for usage and spend.
+//!
+//! Speaks Model Context Protocol over stdio so Claude Code / Codex can query
+//! remaining quota and estimated spend mid-conversation. Quota comes from the
+//! desktop widget snapshot (cache-only, no network). Spend comes from local
+//! Codex/Claude JSONL logs via [`crate::cost_scanner`].
+
+use clap::Args;
+use rmcp::{
+    ErrorData as McpError, ServerHandler, ServiceExt,
+    handler::server::wrapper::Parameters,
+    model::{
+        CallToolResult, ContentBlock, Implementation, ProtocolVersion, ServerCapabilities,
+        ServerInfo,
+    },
+    schemars, tool, tool_handler, tool_router,
+    transport::stdio,
+};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::core::{
+    ProviderId, RateWindow, WidgetProviderEntry, WidgetSnapshot, WidgetSnapshotStore,
+};
+use crate::cost_scanner::{CostSummary, get_cost_usage_report};
+
+const COST_SUPPORTED: &[&str] = &["codex", "claude"];
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct McpArgs {}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ProviderFilter {
+    /// Optional provider id (`claude`, `codex`, `cursor`, …). Omit for all.
+    #[serde(default)]
+    provider: Option<String>,
+}
+
+#[derive(Clone)]
+struct CeilingMcp {
+    tool_router: rmcp::handler::server::router::tool::ToolRouter<CeilingMcp>,
+}
+
+#[tool_router]
+impl CeilingMcp {
+    fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    #[tool(
+        description = "List providers with cached quota and whether local spend scanning is supported (Codex/Claude)."
+    )]
+    fn list_providers(&self) -> Result<CallToolResult, McpError> {
+        Ok(json_tool_result(list_providers_payload(
+            WidgetSnapshotStore::load().as_ref(),
+        )))
+    }
+
+    #[tool(
+        description = "Get remaining quota windows from the desktop widget snapshot (cache-only, no network). Requires Ceiling desktop to have refreshed recently."
+    )]
+    fn get_usage(
+        &self,
+        Parameters(ProviderFilter { provider }): Parameters<ProviderFilter>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(json_tool_result(usage_payload(
+            WidgetSnapshotStore::load().as_ref(),
+            provider.as_deref(),
+        )))
+    }
+
+    #[tool(
+        description = "Get estimated API-value spend from local Codex/Claude logs for today, 7 days, and 30 days. Local-only; not a bill."
+    )]
+    fn get_spend(
+        &self,
+        Parameters(ProviderFilter { provider }): Parameters<ProviderFilter>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(json_tool_result(spend_payload(provider.as_deref())))
+    }
+
+    #[tool(
+        description = "Compact status: remaining quota + today's estimated spend for one provider (or the best available). Good for 'am I about to hit my cap?' checks."
+    )]
+    fn get_status(
+        &self,
+        Parameters(ProviderFilter { provider }): Parameters<ProviderFilter>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(json_tool_result(status_payload(
+            WidgetSnapshotStore::load().as_ref(),
+            provider.as_deref(),
+        )))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for CeilingMcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("ceiling", env!("CARGO_PKG_VERSION")))
+            .with_protocol_version(ProtocolVersion::V_2024_11_05)
+            .with_instructions(
+                "Ceiling local usage/spend tools. get_usage reads the desktop widget snapshot \
+(cache-only). get_spend scans local Codex/Claude logs. Prefer get_status for a quick \
+remaining-quota + today-$ check before starting a large job. Values are estimated API \
+value, never a billed invoice."
+                    .to_string(),
+            )
+    }
+}
+
+pub async fn run(_args: McpArgs) -> anyhow::Result<()> {
+    tracing::info!("Starting Ceiling MCP server (stdio)");
+    let service = CeilingMcp::new().serve(stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}
+
+fn json_tool_result(value: serde_json::Value) -> CallToolResult {
+    CallToolResult::success(vec![ContentBlock::text(value.to_string())])
+}
+
+fn list_providers_payload(snapshot: Option<&WidgetSnapshot>) -> serde_json::Value {
+    let snapshot_providers: Vec<String> = snapshot
+        .map(|s| {
+            s.entries
+                .iter()
+                .map(|e| e.provider.cli_name().to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut providers = Vec::new();
+    for id in ProviderId::all() {
+        let cli = id.cli_name();
+        let in_snapshot = snapshot_providers.iter().any(|p| p == cli);
+        providers.push(json!({
+            "id": cli,
+            "display_name": id.display_name(),
+            "has_quota_snapshot": in_snapshot,
+            "local_spend_supported": COST_SUPPORTED.contains(&cli),
+        }));
+    }
+
+    json!({
+        "snapshot_present": snapshot.is_some(),
+        "snapshot_generated_at": snapshot.map(|s| s.generated_at.to_rfc3339()),
+        "providers": providers,
+    })
+}
+
+fn usage_payload(snapshot: Option<&WidgetSnapshot>, provider: Option<&str>) -> serde_json::Value {
+    let Some(snapshot) = snapshot else {
+        return json!({
+            "ok": false,
+            "error": "No widget snapshot found. Open Ceiling desktop so it can refresh and persist quota.",
+            "providers": []
+        });
+    };
+
+    let entries: Vec<&WidgetProviderEntry> = match provider {
+        Some(name) => match ProviderId::from_cli_name(name) {
+            Some(id) => snapshot.entry_for(id).into_iter().collect(),
+            None => {
+                return json!({
+                    "ok": false,
+                    "error": format!("Unknown provider '{name}'"),
+                    "providers": []
+                });
+            }
+        },
+        None => snapshot.entries.iter().collect(),
+    };
+
+    let providers: Vec<_> = entries.iter().map(|e| entry_usage_json(e)).collect();
+    json!({
+        "ok": true,
+        "source": "widget-snapshot",
+        "generated_at": snapshot.generated_at.to_rfc3339(),
+        "providers": providers,
+    })
+}
+
+fn entry_usage_json(entry: &WidgetProviderEntry) -> serde_json::Value {
+    json!({
+        "provider": entry.provider.cli_name(),
+        "display_name": entry.provider.display_name(),
+        "updated_at": entry.updated_at.to_rfc3339(),
+        "account_email": entry.account_email,
+        "login_method": entry.login_method,
+        "credits_remaining": entry.credits_remaining,
+        "primary": window_json(entry.primary.as_ref()),
+        "secondary": window_json(entry.secondary.as_ref()),
+        "tertiary": window_json(entry.tertiary.as_ref()),
+        "session_cost_usd": entry.token_usage.as_ref().and_then(|t| t.session_cost_usd),
+    })
+}
+
+fn window_json(window: Option<&RateWindow>) -> serde_json::Value {
+    let Some(window) = window else {
+        return serde_json::Value::Null;
+    };
+    json!({
+        "used_percent": window.used_percent,
+        "remaining_percent": window.remaining_percent(),
+        "window_minutes": window.window_minutes,
+        "resets_at": window.resets_at.map(|dt| dt.to_rfc3339()),
+        "reset_countdown": window.format_countdown(),
+        "is_exhausted": window.is_exhausted(),
+    })
+}
+
+fn spend_payload(provider: Option<&str>) -> serde_json::Value {
+    let targets: Vec<&str> = match provider {
+        Some(name) => {
+            let cli = ProviderId::from_cli_name(name)
+                .map(|id| id.cli_name())
+                .unwrap_or(name);
+            if !COST_SUPPORTED.contains(&cli) {
+                return json!({
+                    "ok": false,
+                    "error": format!(
+                        "Local spend scanning is only available for Codex and Claude (got '{cli}')"
+                    ),
+                    "providers": []
+                });
+            }
+            vec![cli]
+        }
+        None => COST_SUPPORTED.to_vec(),
+    };
+
+    let mut providers = Vec::new();
+    for cli in targets {
+        match get_cost_usage_report(cli, 30) {
+            Some(report) => providers.push(json!({
+                "provider": cli,
+                "supported": true,
+                "note": "Estimated API-rate value from local logs, not a bill.",
+                "today": summary_json(&report.today),
+                "seven_days": summary_json(&report.seven_days),
+                "thirty_days": summary_json(&report.thirty_days),
+            })),
+            None => providers.push(json!({
+                "provider": cli,
+                "supported": false,
+                "error": "Local cost scanning not available for this provider",
+            })),
+        }
+    }
+
+    json!({
+        "ok": true,
+        "source": "local-logs",
+        "providers": providers,
+    })
+}
+
+fn summary_json(summary: &CostSummary) -> serde_json::Value {
+    let total_tokens = summary.input_tokens
+        + summary.output_tokens
+        + summary.cache_read_tokens
+        + summary.cache_write_tokens;
+    json!({
+        "total_usd": summary.total_cost_usd,
+        "input_tokens": summary.input_tokens,
+        "output_tokens": summary.output_tokens,
+        "cache_read_tokens": summary.cache_read_tokens,
+        "cache_write_tokens": summary.cache_write_tokens,
+        "total_tokens": total_tokens,
+        "sessions_count": summary.sessions_count,
+        "by_model": summary.by_model,
+        "unknown_models": summary.unknown_models.iter().cloned().collect::<Vec<_>>(),
+        "has_data": summary.sessions_count > 0
+            || summary.total_cost_usd > 0.0
+            || total_tokens > 0,
+    })
+}
+
+fn status_payload(snapshot: Option<&WidgetSnapshot>, provider: Option<&str>) -> serde_json::Value {
+    let chosen = choose_status_provider(snapshot, provider);
+    let usage = match (&chosen, snapshot) {
+        (Some(id), Some(snap)) => snap.entry_for(*id).map(entry_usage_json),
+        _ => None,
+    };
+
+    let spend = chosen.and_then(|id| {
+        let cli = id.cli_name();
+        if !COST_SUPPORTED.contains(&cli) {
+            return None;
+        }
+        get_cost_usage_report(cli, 30).map(|report| summary_json(&report.today))
+    });
+
+    let remaining = usage
+        .as_ref()
+        .and_then(|u| u.get("primary"))
+        .and_then(|p| p.get("remaining_percent"))
+        .cloned();
+
+    json!({
+        "ok": usage.is_some() || spend.is_some(),
+        "provider": chosen.map(|id| id.cli_name()),
+        "remaining_percent": remaining,
+        "usage": usage,
+        "today_spend": spend,
+        "hint": if snapshot.is_none() {
+            Some("Open Ceiling desktop to refresh quota snapshot.")
+        } else {
+            None
+        },
+    })
+}
+
+fn choose_status_provider(
+    snapshot: Option<&WidgetSnapshot>,
+    provider: Option<&str>,
+) -> Option<ProviderId> {
+    if let Some(name) = provider {
+        return ProviderId::from_cli_name(name);
+    }
+    let snapshot = snapshot?;
+    for preferred in [ProviderId::Claude, ProviderId::Codex] {
+        if snapshot.entry_for(preferred).is_some() {
+            return Some(preferred);
+        }
+    }
+    snapshot.entries.first().map(|e| e.provider)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::RateWindow;
+    use chrono::Utc;
+
+    fn sample_snapshot() -> WidgetSnapshot {
+        let entry = WidgetProviderEntry::new(ProviderId::Claude, Utc::now())
+            .with_primary(RateWindow::with_details(
+                42.0,
+                Some(300),
+                Some(Utc::now() + chrono::Duration::hours(3)),
+                Some("in 3h".into()),
+            ))
+            .with_login_method("Claude Pro");
+        WidgetSnapshot::new(vec![entry], Utc::now())
+    }
+
+    #[test]
+    fn list_providers_marks_snapshot_and_spend_support() {
+        let payload = list_providers_payload(Some(&sample_snapshot()));
+        assert_eq!(payload["snapshot_present"], true);
+        let providers = payload["providers"].as_array().unwrap();
+        let claude = providers
+            .iter()
+            .find(|p| p["id"] == "claude")
+            .expect("claude");
+        assert_eq!(claude["has_quota_snapshot"], true);
+        assert_eq!(claude["local_spend_supported"], true);
+        let cursor = providers
+            .iter()
+            .find(|p| p["id"] == "cursor")
+            .expect("cursor");
+        assert_eq!(cursor["local_spend_supported"], false);
+    }
+
+    #[test]
+    fn usage_requires_snapshot() {
+        let payload = usage_payload(None, None);
+        assert_eq!(payload["ok"], false);
+    }
+
+    #[test]
+    fn usage_filters_provider() {
+        let snap = sample_snapshot();
+        let payload = usage_payload(Some(&snap), Some("claude"));
+        assert_eq!(payload["ok"], true);
+        assert_eq!(payload["providers"].as_array().unwrap().len(), 1);
+        assert_eq!(payload["providers"][0]["primary"]["used_percent"], 42.0);
+        assert_eq!(
+            payload["providers"][0]["primary"]["remaining_percent"],
+            58.0
+        );
+    }
+
+    #[test]
+    fn spend_rejects_unsupported_provider() {
+        let payload = spend_payload(Some("cursor"));
+        assert_eq!(payload["ok"], false);
+    }
+
+    #[test]
+    fn status_prefers_claude_when_present() {
+        let snap = sample_snapshot();
+        let payload = status_payload(Some(&snap), None);
+        assert_eq!(payload["provider"], "claude");
+        assert_eq!(payload["remaining_percent"], 58.0);
+    }
+}

--- a/rust/src/cli/mcp.rs
+++ b/rust/src/cli/mcp.rs
@@ -280,6 +280,15 @@ fn summary_json(summary: &CostSummary) -> serde_json::Value {
 }
 
 fn status_payload(snapshot: Option<&WidgetSnapshot>, provider: Option<&str>) -> serde_json::Value {
+    if let Some(name) = provider
+        && ProviderId::from_cli_name(name).is_none()
+    {
+        return json!({
+            "ok": false,
+            "error": format!("Unknown provider '{name}'"),
+        });
+    }
+
     let chosen = choose_status_provider(snapshot, provider);
     let usage = match (&chosen, snapshot) {
         (Some(id), Some(snap)) => snap.entry_for(*id).map(entry_usage_json),
@@ -389,6 +398,19 @@ mod tests {
     fn spend_rejects_unsupported_provider() {
         let payload = spend_payload(Some("cursor"));
         assert_eq!(payload["ok"], false);
+    }
+
+    #[test]
+    fn status_rejects_unknown_provider() {
+        let payload = status_payload(Some(&sample_snapshot()), Some("not-a-provider"));
+        assert_eq!(payload["ok"], false);
+        assert!(
+            payload["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("Unknown provider"),
+            "payload: {payload}"
+        );
     }
 
     #[test]

--- a/rust/src/cli/mod.rs
+++ b/rust/src/cli/mod.rs
@@ -13,6 +13,7 @@ pub mod autostart;
 pub mod config;
 pub mod cost;
 pub mod diagnose;
+pub mod mcp;
 pub mod serve;
 pub mod sessions;
 pub mod statusline;
@@ -127,6 +128,9 @@ pub enum Commands {
 
     /// Print one compact usage line for an editor status bar (cache-only)
     Statusline(statusline::StatuslineArgs),
+
+    /// Expose usage and spend over MCP stdio (local-first, no network)
+    Mcp(mcp::McpArgs),
 
     /// Manage auto-start on Windows boot
     Autostart(autostart::AutostartArgs),

--- a/rust/src/codex_costs.rs
+++ b/rust/src/codex_costs.rs
@@ -115,6 +115,9 @@ fn add_tokens(summary: &mut ModelTokenCounts, tokens: CodexTokenCounts) {
     summary.input_tokens += tokens.input;
     summary.output_tokens += tokens.output;
     summary.cached_tokens += tokens.cached;
+    // Codex reports cache hits as `cached` input tokens (reads, not writes).
+    summary.cache_read_tokens += tokens.cached;
+    summary.calls += 1;
 }
 
 /// Add one Codex token delta to the summary.

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -118,6 +118,51 @@ impl ModelTokenCounts {
     }
 }
 
+#[cfg(test)]
+mod model_token_counts_tests {
+    use super::ModelTokenCounts;
+
+    #[test]
+    fn processed_sums_input_output_and_cache_buckets_not_legacy_cached() {
+        let counts = ModelTokenCounts {
+            input_tokens: 10,
+            output_tokens: 20,
+            cached_tokens: 999, // legacy aggregate; must not double-count
+            cache_read_tokens: 3,
+            cache_write_tokens: 4,
+            calls: 2,
+        };
+        assert_eq!(counts.processed(), 37);
+        assert_eq!(counts.total(), 30);
+    }
+
+    #[test]
+    fn merge_from_accumulates_all_buckets_and_calls() {
+        let mut left = ModelTokenCounts {
+            input_tokens: 1,
+            output_tokens: 2,
+            cached_tokens: 3,
+            cache_read_tokens: 4,
+            cache_write_tokens: 5,
+            calls: 6,
+        };
+        left.merge_from(&ModelTokenCounts {
+            input_tokens: 10,
+            output_tokens: 20,
+            cached_tokens: 30,
+            cache_read_tokens: 40,
+            cache_write_tokens: 50,
+            calls: 60,
+        });
+        assert_eq!(left.input_tokens, 11);
+        assert_eq!(left.output_tokens, 22);
+        assert_eq!(left.cached_tokens, 33);
+        assert_eq!(left.cache_read_tokens, 44);
+        assert_eq!(left.cache_write_tokens, 55);
+        assert_eq!(left.calls, 66);
+    }
+}
+
 impl CostSummary {
     pub fn format_total(&self) -> String {
         format!("${:.2}", self.total_cost_usd)

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -88,12 +88,33 @@ pub struct CurrentUsageWindow {
 pub struct ModelTokenCounts {
     pub input_tokens: u64,
     pub output_tokens: u64,
+    /// Cache read + write combined (legacy aggregate).
     pub cached_tokens: u64,
+    /// Cache-read tokens alone (for cache-hit rate).
+    pub cache_read_tokens: u64,
+    /// Cache-write / creation tokens alone.
+    pub cache_write_tokens: u64,
+    /// Number of usage records attributed to this model (for per-call averages).
+    pub calls: u64,
 }
 
 impl ModelTokenCounts {
     pub fn total(&self) -> u64 {
         self.input_tokens + self.output_tokens
+    }
+
+    /// Input + output + cache read + cache write (denominator for cache %).
+    pub fn processed(&self) -> u64 {
+        self.input_tokens + self.output_tokens + self.cache_read_tokens + self.cache_write_tokens
+    }
+
+    pub fn merge_from(&mut self, other: &Self) {
+        self.input_tokens += other.input_tokens;
+        self.output_tokens += other.output_tokens;
+        self.cached_tokens += other.cached_tokens;
+        self.cache_read_tokens += other.cache_read_tokens;
+        self.cache_write_tokens += other.cache_write_tokens;
+        self.calls += other.calls;
     }
 }
 
@@ -840,6 +861,9 @@ fn add_claude_record_to_summary(summary: &mut CostSummary, record: &ClaudeUsageR
     model_tokens.input_tokens += record.input;
     model_tokens.output_tokens += record.output;
     model_tokens.cached_tokens += record.cache_create + record.cache_read;
+    model_tokens.cache_read_tokens += record.cache_read;
+    model_tokens.cache_write_tokens += record.cache_create;
+    model_tokens.calls += 1;
 
     let project_bucket = crate::codex_costs::project_bucket(record.project.as_deref());
     *summary
@@ -850,6 +874,9 @@ fn add_claude_record_to_summary(summary: &mut CostSummary, record: &ClaudeUsageR
     project_tokens.input_tokens += record.input;
     project_tokens.output_tokens += record.output;
     project_tokens.cached_tokens += record.cache_create + record.cache_read;
+    project_tokens.cache_read_tokens += record.cache_read;
+    project_tokens.cache_write_tokens += record.cache_create;
+    project_tokens.calls += 1;
 }
 
 /// Add one usage record to the per-day cost buckets, keyed by the record's
@@ -957,28 +984,31 @@ fn merge_summary(target: &mut CostSummary, source: &CostSummary) {
         *target.by_model.entry(model.clone()).or_insert(0.0) += cost;
     }
     for (model, tokens) in &source.by_model_tokens {
-        let entry = target.by_model_tokens.entry(model.clone()).or_default();
-        entry.input_tokens += tokens.input_tokens;
-        entry.output_tokens += tokens.output_tokens;
-        entry.cached_tokens += tokens.cached_tokens;
+        target
+            .by_model_tokens
+            .entry(model.clone())
+            .or_default()
+            .merge_from(tokens);
     }
     for (effort, cost) in &source.by_effort {
         *target.by_effort.entry(effort.clone()).or_insert(0.0) += cost;
     }
     for (effort, tokens) in &source.by_effort_tokens {
-        let entry = target.by_effort_tokens.entry(effort.clone()).or_default();
-        entry.input_tokens += tokens.input_tokens;
-        entry.output_tokens += tokens.output_tokens;
-        entry.cached_tokens += tokens.cached_tokens;
+        target
+            .by_effort_tokens
+            .entry(effort.clone())
+            .or_default()
+            .merge_from(tokens);
     }
     for (project, cost) in &source.by_project {
         *target.by_project.entry(project.clone()).or_insert(0.0) += cost;
     }
     for (project, tokens) in &source.by_project_tokens {
-        let entry = target.by_project_tokens.entry(project.clone()).or_default();
-        entry.input_tokens += tokens.input_tokens;
-        entry.output_tokens += tokens.output_tokens;
-        entry.cached_tokens += tokens.cached_tokens;
+        target
+            .by_project_tokens
+            .entry(project.clone())
+            .or_default()
+            .merge_from(tokens);
     }
     target
         .unknown_models

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -99,6 +99,7 @@ fn dispatch_command(rt: &Runtime, command: Option<Commands>) -> i32 {
         Some(Commands::Sessions(args)) => run_categorized(rt, cli::sessions::run(args)),
         Some(Commands::Serve(args)) => run_unexpected(rt, cli::serve::run(args)),
         Some(Commands::Statusline(args)) => run_unexpected(rt, cli::statusline::run(args)),
+        Some(Commands::Mcp(args)) => run_unexpected(rt, cli::mcp::run(args)),
         Some(Commands::Autostart(args)) => run_unexpected(rt, cli::autostart::run(args)),
         Some(Commands::Account(args)) => run_unexpected(rt, cli::account::run(args)),
         Some(Commands::Config(args)) => run_unexpected(rt, cli::config::run(args)),


### PR DESCRIPTION
## Summary
- Add `codexbar mcp` stdio MCP server (`list_providers`, `get_usage`, `get_spend`, `get_status`) and persist widget snapshots on desktop refresh so cache-only quota tools work (SOU-276).
- Enrich per-model spend breakdown with cache-read %, cost/call, and output tokens/call (SOU-278).
- Show dollar period-over-period on the estimated API value card (Today vs yesterday, 30d vs prior 30d).

## Test plan
- [ ] `cargo test --manifest-path rust/Cargo.toml --lib cli::mcp`
- [ ] `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml model_breakdown`
- [ ] `pnpm --dir apps/desktop-tauri test -- run src/lib/apiValueCard.test.ts src/components/TotalApiValueCard.test.tsx`
- [ ] `codexbar mcp --help` then configure Claude Code/Cursor MCP to `codexbar mcp` and call `get_status`
- [ ] Open desktop app, refresh providers, confirm model breakdown metrics and API value card PoP labels
- [ ] CodeRabbit review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local MCP command exposing provider quotas, spend estimates, and combined status over stdio.
  * Added per-model usage metrics, including cache-read percentage, cost per call, output tokens per call, and call counts.
  * Added prior-30-day comparisons and period-change labels to API value cards.
  * Provider refreshes now save a local widget snapshot for offline usage data.

* **Improvements**
  * Expanded token accounting to include cache activity and usage calls.
  * Updated usage breakdown layouts and styling for improved metric readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->