### PR TITLE
Add Star on GitHub button with live star count

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -196,6 +196,21 @@
       .button--quiet { border-color: transparent; background: transparent; color: #b2bec7; }
       .button--quiet:hover { border-color: transparent; background: transparent; color: var(--text); }
 
+      .star-mark { color: #f5c451; flex: none; }
+
+      .star-count {
+        display: inline-flex;
+        align-items: center;
+        padding: 1px 8px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.09);
+        font-size: 12px;
+        font-weight: 650;
+        font-variant-numeric: tabular-nums;
+        color: var(--text);
+      }
+      .star-count[hidden] { display: none; }
+
       .windows-mark {
         width: 15px;
         height: 15px;
@@ -469,6 +484,11 @@
               <span class="windows-mark" aria-hidden="true"><span></span><span></span><span></span><span></span></span>
               Download for Windows
             </a>
+            <a class="button button--star" href="https://github.com/tsouth89/ceiling" data-analytics="github_clicked" data-asset="star-hero">
+              <svg class="star-mark" width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2.5l2.9 6.06 6.66.86-4.9 4.54 1.26 6.58L12 17.9l-5.92 3.15 1.26-6.58-4.9-4.54 6.66-.86z"/></svg>
+              Star on GitHub
+              <span class="star-count" data-star-count hidden></span>
+            </a>
             <a class="button button--quiet" href="#how-it-works">See how it works</a>
           </div>
           <a class="release" href="https://github.com/tsouth89/ceiling/releases/latest">Free and open source · Windows 10 / 11 · Signed builds</a>
@@ -611,6 +631,20 @@
         };
 
         send("$pageview");
+
+        const formatStars = (n) => (n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, "") + "k" : String(n));
+        fetch("/api/stars")
+          .then((response) => (response.ok ? response.json() : null))
+          .then((data) => {
+            const stars = data && Number(data.stars);
+            if (!Number.isFinite(stars)) return;
+            document.querySelectorAll("[data-star-count]").forEach((el) => {
+              el.textContent = formatStars(stars);
+              el.hidden = false;
+            });
+          })
+          .catch(() => {});
+
         document.addEventListener("click", (event) => {
           const link = event.target.closest("[data-analytics]");
           if (!link) return;

--- a/worker.mjs
+++ b/worker.mjs
@@ -18,6 +18,11 @@ export default {
       return captureEvent(request, env, ctx);
     }
 
+    if (url.pathname === "/api/stars") {
+      if (request.method !== "GET") return methodNotAllowed();
+      return starCountResponse(env, ctx);
+    }
+
     if (url.pathname === "/admin/session" && request.method === "POST") {
       return createSession(request, env);
     }
@@ -82,6 +87,42 @@ async function latestAssetUrl(pattern, env, ctx) {
   const asset = (data.assets || []).find((a) => pattern.test(a.name));
   if (!asset) throw new Error("no matching asset");
   return asset.browser_download_url;
+}
+
+// Public star count for the "Star on GitHub" button. Edge-cached so the button
+// stays fast and never hammers the GitHub API; a fetch failure returns a null
+// count (uncached) so the client simply hides the badge and shows the plain button.
+async function starCountResponse(env, ctx) {
+  const cache = caches.default;
+  const cacheKey = new Request("https://ceiling.internal/star-count-v1");
+  const cached = await cache.match(cacheKey);
+  if (cached) return cached;
+
+  let stars = null;
+  try {
+    const headers = { "User-Agent": "ceiling-site", Accept: "application/vnd.github+json" };
+    if (env.GITHUB_TOKEN) headers.Authorization = `Bearer ${env.GITHUB_TOKEN}`;
+    const res = await fetch(`https://api.github.com/repos/${REPO}`, {
+      headers,
+      signal: AbortSignal.timeout(3000),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      const parsed = numberValue(data.stargazers_count);
+      if (Number.isFinite(parsed)) stars = parsed;
+    }
+  } catch {
+    stars = null;
+  }
+
+  const response = new Response(JSON.stringify({ stars }), {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": stars === null ? "no-store" : `public, max-age=${CACHE_SECONDS}`,
+    },
+  });
+  if (stars !== null) ctx.waitUntil(cache.put(cacheKey, response.clone()));
+  return response;
 }
 
 async function captureEvent(request, env, ctx) {

--- a/worker.test.mjs
+++ b/worker.test.mjs
@@ -116,6 +116,38 @@ test("admin routes reject cross-origin login and direct private assets", async (
   assert.equal(privateAsset.status, 404);
 });
 
+test("star count endpoint returns a number and degrades to null on failure", async () => {
+  const store = new Map();
+  const originalCaches = globalThis.caches;
+  const originalFetch = globalThis.fetch;
+  globalThis.caches = {
+    default: {
+      match: async (request) => store.get(request.url),
+      put: async (request, response) => { store.set(request.url, response); },
+    },
+  };
+  const ctx = { waitUntil(promise) { return promise; } };
+
+  try {
+    globalThis.fetch = async () => new Response(JSON.stringify({ stargazers_count: 42 }), { status: 200 });
+    const ok = await worker.fetch(new Request("https://ceiling.win/api/stars"), {}, ctx);
+    assert.equal(ok.status, 200);
+    assert.deepEqual(await ok.json(), { stars: 42 });
+
+    store.clear();
+    globalThis.fetch = async () => { throw new Error("network down"); };
+    const degraded = await worker.fetch(new Request("https://ceiling.win/api/stars"), {}, ctx);
+    assert.deepEqual(await degraded.json(), { stars: null });
+    assert.equal(degraded.headers.get("Cache-Control"), "no-store");
+
+    const rejected = await worker.fetch(new Request("https://ceiling.win/api/stars", { method: "POST" }), {}, ctx);
+    assert.equal(rejected.status, 405);
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.caches = originalCaches;
+  }
+});
+
 test("event capture is a no-op when analytics is not configured", async () => {
   const response = await worker.fetch(new Request("https://ceiling.win/api/events", {
     method: "POST",


### PR DESCRIPTION
## What
Adds a secondary **Star on GitHub** button next to the hero download CTA to convert download traffic (200+ downloads / 5 days) into stars.

- Bordered secondary button (Download stays primary by position), gold star icon.
- Live star-count badge from a new edge-cached `/api/stars` worker endpoint. If the count can't be fetched the badge stays hidden and the button shows a plain "Star on GitHub".
- Reuses the existing `github_clicked` analytics event (`data-asset=star-hero`).

## Endpoint
`GET /api/stars` returns `{ stars: <number|null> }`, edge-cached 5 min using the existing `GITHUB_TOKEN`; degrades to `{ stars: null }` with `no-store` on any failure.

## Tests
`node --test worker.test.mjs` — added a case covering the success, graceful-null, and 405 (non-GET) paths. All 8 green locally. Rendered the hero headlessly to confirm layout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Star on GitHub” call-to-action to the hero section.
  * Displays the repository’s current star count with compact formatting for large numbers.

* **Bug Fixes**
  * Star count loading now degrades gracefully when the data is unavailable.
  * Unsupported requests to the star-count endpoint are rejected appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->