### PR TITLE
Hide star count until it clears a credibility floor

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -632,12 +632,16 @@
 
         send("$pageview");
 
+        // Hide the count below a credibility floor: a visible low number reads as
+        // anti-social-proof, while a growing counter builds momentum once it's past
+        // a threshold worth showing. Below this the button is a plain silent CTA.
+        const minStarsToShow = 50;
         const formatStars = (n) => (n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, "") + "k" : String(n));
         fetch("/api/stars")
           .then((response) => (response.ok ? response.json() : null))
           .then((data) => {
             const stars = data && Number(data.stars);
-            if (!Number.isFinite(stars)) return;
+            if (!Number.isFinite(stars) || stars < minStarsToShow) return;
             document.querySelectorAll("[data-star-count]").forEach((el) => {
               el.textContent = formatStars(stars);
               el.hidden = false;


### PR DESCRIPTION
## What
Gates the hero "Star on GitHub" count badge behind a credibility floor. A visible low count (e.g. "5") reads as anti-social-proof, so below the threshold the button is a plain silent CTA; at/above it the count badge appears and builds momentum.

- New `minStarsToShow = 50` constant in the page script. Change the number to retune.
- Below 50: badge stays hidden (button shows "★ Star on GitHub").
- At/above 50: badge shows the formatted count (e.g. "120", "1.2k").

No backend change — still reads the existing edge-cached `/api/stars`.

## Verified
Rendered the hero headlessly against a mocked `/api/stars` at 5 stars (badge hidden) and 120 stars (badge shows "120").
