### PR TITLE
Show reset-window dollars and label Compare as rolling

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -1375,10 +1375,10 @@ mod tests {
     use super::{
         CostFetchFailure, LocalEffortCost, LocalModelCost, LocalProjectCost, LocalTokenBreakdown,
         LocalUsageWindowRequest, ProviderLocalUsageSummary, api_value_period,
-        cost_fetch_failure_allows_early_retry, effort_breakdown, format_cost_csv, local_midnight_in_tz,
-        local_usage_summary_from_report, local_yesterday_window_utc, localized_estimate_note,
-        model_breakdown, project_breakdown, spend_budget_period_details, token_breakdown,
-        token_cost_cache_is_fresh,
+        cost_fetch_failure_allows_early_retry, effort_breakdown, format_cost_csv,
+        local_midnight_in_tz, local_usage_summary_from_report, local_yesterday_window_utc,
+        localized_estimate_note, model_breakdown, project_breakdown, spend_budget_period_details,
+        token_breakdown, token_cost_cache_is_fresh,
     };
     use crate::commands::is_provider_cache_fresh;
     use chrono::{Local, LocalResult, NaiveDate, NaiveTime, TimeZone, Utc};

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -116,6 +116,10 @@ pub struct LocalUsageWindowSummary {
     pub ends_at: String,
     pub tokens: u64,
     pub token_breakdown: LocalTokenBreakdown,
+    /// Estimated API-value dollars from priced models in this reset window.
+    /// `None` when there is no priced activity (unpriced models stay excluded).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -858,6 +862,7 @@ fn local_usage_summary_from_report(
                 ends_at: window.ends_at.clone(),
                 tokens: token_breakdown.processed_tokens,
                 token_breakdown,
+                cost: non_zero_f64(summary.total_cost_usd),
             })
         })
         .collect();
@@ -1369,10 +1374,11 @@ fn load_openai_dashboard_chart_data(
 mod tests {
     use super::{
         CostFetchFailure, LocalEffortCost, LocalModelCost, LocalProjectCost, LocalTokenBreakdown,
-        ProviderLocalUsageSummary, api_value_period, cost_fetch_failure_allows_early_retry,
-        effort_breakdown, format_cost_csv, local_midnight_in_tz, local_usage_summary_from_report,
-        local_yesterday_window_utc, localized_estimate_note, model_breakdown, project_breakdown,
-        spend_budget_period_details, token_breakdown, token_cost_cache_is_fresh,
+        LocalUsageWindowRequest, ProviderLocalUsageSummary, api_value_period,
+        cost_fetch_failure_allows_early_retry, effort_breakdown, format_cost_csv, local_midnight_in_tz,
+        local_usage_summary_from_report, local_yesterday_window_utc, localized_estimate_note,
+        model_breakdown, project_breakdown, spend_budget_period_details, token_breakdown,
+        token_cost_cache_is_fresh,
     };
     use crate::commands::is_provider_cache_fresh;
     use chrono::{Local, LocalResult, NaiveDate, NaiveTime, TimeZone, Utc};
@@ -1823,6 +1829,63 @@ mod tests {
 
         assert_eq!(summary.seven_day_tokens, Some(4_500_000_000));
         assert!(summary.comparison_periods.is_empty());
+    }
+
+    #[test]
+    fn reset_aligned_windows_include_priced_cost_from_report() {
+        let mut current_windows = std::collections::HashMap::new();
+        current_windows.insert(
+            "primary".to_string(),
+            CostSummary {
+                input_tokens: 1_000,
+                output_tokens: 500,
+                total_cost_usd: 12.4,
+                sessions_count: 1,
+                ..CostSummary::default()
+            },
+        );
+        current_windows.insert(
+            "secondary".to_string(),
+            CostSummary {
+                input_tokens: 10_000,
+                output_tokens: 2_000,
+                total_cost_usd: 0.0,
+                sessions_count: 1,
+                ..CostSummary::default()
+            },
+        );
+        let report = CostUsageReport {
+            thirty_days: CostSummary {
+                sessions_count: 1,
+                total_cost_usd: 12.4,
+                ..CostSummary::default()
+            },
+            current_windows,
+            ..CostUsageReport::default()
+        };
+        let requests = vec![
+            LocalUsageWindowRequest {
+                id: "primary".into(),
+                label: "5-hour window".into(),
+                starts_at: "2026-07-20T00:00:00Z".into(),
+                ends_at: "2026-07-20T05:00:00Z".into(),
+            },
+            LocalUsageWindowRequest {
+                id: "secondary".into(),
+                label: "Weekly window".into(),
+                starts_at: "2026-07-14T00:00:00Z".into(),
+                ends_at: "2026-07-21T00:00:00Z".into(),
+            },
+        ];
+
+        let summary = local_usage_summary_from_report("claude", &report, &requests)
+            .expect("local usage summary");
+
+        assert_eq!(summary.current_windows.len(), 2);
+        assert_eq!(summary.current_windows[0].id, "primary");
+        assert_eq!(summary.current_windows[0].cost, Some(12.4));
+        assert_eq!(summary.current_windows[1].id, "secondary");
+        assert_eq!(summary.current_windows[1].cost, None);
     }
 
     #[test]

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -7737,8 +7737,10 @@ body:has(.dashboard-shell) #root {
   margin: 4px 0 1px;
   color: var(--text-primary);
   font-size: 17px;
-  line-height: 1.1;
+  line-height: 1.15;
   font-variant-numeric: tabular-nums;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 .usage-periods__note {
   grid-column: 1 / -1;

--- a/apps/desktop-tauri/src/surfaces/ProviderComparison.tsx
+++ b/apps/desktop-tauri/src/surfaces/ProviderComparison.tsx
@@ -65,7 +65,7 @@ function ComparisonCard({ periodId, label, providers, data }: {
   return (
     <section className="provider-comparison-card">
       <header className="provider-comparison-card__header">
-        <div><strong>{label}</strong><span>Same rolling window</span></div>
+        <div><strong>{label}</strong><span>Identical rolling window for both</span></div>
         <span className="provider-comparison-card__summary">
           {comparisonSummary(complete[0].provider.displayName, complete[0].period.currentTokens, complete[1].provider.displayName, complete[1].period.currentTokens)}
         </span>
@@ -178,12 +178,18 @@ export default function ProviderComparison({ providers }: {
   return (
     <div className="provider-comparison">
       <div className="provider-comparison__intro">
-        <div><strong>Codex and Claude, on the same clock</strong><span>Processed tokens from local logs across every agent.</span></div>
+        <div>
+          <strong>Codex and Claude, on the same clock</strong>
+          <span>Rolling windows ending now so both providers are comparable. Reset-aligned dollars live in each provider's chart drill-in.</span>
+        </div>
         <span className="provider-comparison__source">Local logs</span>
       </div>
-      <ComparisonCard periodId="five-hours" label="Last 5 hours" providers={providers} data={data} />
-      <ComparisonCard periodId="seven-days" label="Last 7 days" providers={providers} data={data} />
-      <p className="provider-comparison__note">Processed tokens include fresh input, output, cache reads, and cache writes. They measure activity, not subscription allowance.</p>
+      <ComparisonCard periodId="five-hours" label="Last 5 hours (rolling)" providers={providers} data={data} />
+      <ComparisonCard periodId="seven-days" label="Last 7 days (rolling)" providers={providers} data={data} />
+      <p className="provider-comparison__note">
+        These cards use identical rolling clocks, not each provider's reset boundary.
+        Processed tokens include fresh input, output, cache reads, and cache writes. They measure activity, not subscription allowance.
+      </p>
     </div>
   );
 }

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
@@ -34,6 +34,7 @@ const enrichedData = {
         startsAt: new Date().toISOString(),
         endsAt: new Date(Date.now() + 3_600_000).toISOString(),
         tokens: 18_400_000,
+        cost: 12.4,
         tokenBreakdown: {
           processedTokens: 18_400_000,
           freshInputTokens: 100_000,
@@ -48,6 +49,7 @@ const enrichedData = {
         startsAt: new Date(Date.now() - 4 * 24 * 3_600_000).toISOString(),
         endsAt: new Date(Date.now() + 3 * 24 * 3_600_000).toISOString(),
         tokens: 843_400_000,
+        cost: 842.5,
         tokenBreakdown: {
           processedTokens: 843_400_000,
           freshInputTokens: 1_000_000,
@@ -105,10 +107,11 @@ describe("ChartsSection local usage summary", () => {
     expect(getByText("23.6B")).toBeTruthy();
     expect(getByText("5-hour window")).toBeTruthy();
     expect(getByText("Weekly window")).toBeTruthy();
-    expect(getByText("18.4M")).toBeTruthy();
+    expect(getByText("18.4M · $12.40")).toBeTruthy();
+    expect(getByText("843.4M · $842.50")).toBeTruthy();
     expect(() => getByText("Last session")).toThrow();
     expect(getByText("99.7% cache traffic")).toBeTruthy();
-    expect(getAllByText("processed tokens")).toHaveLength(2);
+    expect(getAllByText(/processed tokens · calendar window/)).toHaveLength(2);
     expect(() => getByText("$3,427.91")).toThrow();
     expect(getByLabelText("Local usage summary").getAttribute("data-card-count")).toBe("4");
 

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -557,19 +557,22 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
         ...(data.localUsage.currentWindows ?? []).map((window) => ({
           label: window.label,
           tokens: window.tokens,
+          cost: window.cost ?? null,
           detail: `Usage since reset at ${formatWindowStart(window.startsAt)} · resets ${formatWindowReset(window.endsAt)}`,
           current: true,
         })),
         {
           label: "Last 7 days",
           tokens: data.localUsage.sevenDayTokens,
-          detail: "processed tokens",
+          cost: null as number | null,
+          detail: "processed tokens · calendar window",
           current: false,
         },
         {
           label: "Last 30 days",
           tokens: data.localUsage.thirtyDayTokens,
-          detail: "processed tokens",
+          cost: null as number | null,
+          detail: "processed tokens · calendar window",
           current: false,
         },
       ]
@@ -599,7 +602,10 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
               key={period.label}
             >
               <span>{period.label}</span>
-              <strong>{formatTokens(period.tokens)}</strong>
+              <strong>
+                {formatTokens(period.tokens)}
+                {period.cost != null ? ` · ${formatUsd(period.cost)}` : ""}
+              </strong>
               <small>{period.detail}</small>
             </div>
           ))}

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -711,6 +711,8 @@ export interface LocalUsageWindowRequest {
 export interface LocalUsageWindowSummary extends LocalUsageWindowRequest {
   tokens: number;
   tokenBreakdown: LocalTokenBreakdown;
+  /** Estimated API-value USD for this reset window from priced models only. */
+  cost?: number | null;
 }
 
 export interface LocalUsageComparisonPeriod {


### PR DESCRIPTION
## Summary
- **SOU-289:** Reset-aligned usage windows now include estimated API-value dollars (priced models only) beside the token count in the provider chart drill-in.
- **SOU-290:** Compare cards are labeled "Last 5 hours (rolling)" / "Last 7 days (rolling)" with clearer copy that these are shared rolling clocks, not since-reset totals.

## Test plan
- [x] `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml reset_aligned_windows`
- [x] `cargo clippy --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all-targets -- -D warnings`
- [x] `npx vitest run src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx`
- [ ] Manual: open a provider with local logs — reset cards show `$` next to tokens when priced activity exists
- [ ] Manual: Compare tab labels read as rolling and point to per-provider drill-in for since-reset dollars


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added estimated API-value costs to reset-window usage summaries when pricing data is available.
  * Usage charts now display token counts alongside formatted USD costs for applicable periods.

* **Improvements**
  * Clarified rolling-window comparisons and provider chart alignment.
  * Improved wrapping for long usage values in constrained layouts.
  * Added clearer labels for calendar-window totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->