### PR TITLE
Resolve Claude utilization units per response (fixes false 100% after reset)

### DIFF
--- a/rust/src/providers/claude/mod.rs
+++ b/rust/src/providers/claude/mod.rs
@@ -72,6 +72,48 @@ impl Default for ClaudeProvider {
     }
 }
 
+/// Which unit Anthropic used for `utilization` in a single usage response.
+///
+/// The API is inconsistent: some payloads report fractions of the limit
+/// (`0.23` = 23%) and others integer percentages (`23` = 23%). A lone `1.0` is
+/// ambiguous, because it means 100% as a fraction but 1% as a percentage.
+/// Resolving that per value is what made a freshly reset window (`1`, i.e. 1%
+/// used) render as 100%, so the unit is decided once per response instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UtilizationScale {
+    /// Values are already percentages: `23` means 23%.
+    Percent,
+    /// Values are fractions of the limit: `0.23` means 23%.
+    Fraction,
+}
+
+impl UtilizationScale {
+    /// Resolve the unit from every raw utilization in one response.
+    ///
+    /// A value above `1.0` can only be a percentage, since a fraction never
+    /// exceeds the limit, so one such window settles the whole response.
+    /// Otherwise the values are read as fractions, which keeps a genuine `1.0`
+    /// meaning 100%.
+    pub(crate) fn detect(values: impl IntoIterator<Item = f64>) -> Self {
+        if values
+            .into_iter()
+            .any(|value| value.is_finite() && value > 1.0)
+        {
+            Self::Percent
+        } else {
+            Self::Fraction
+        }
+    }
+
+    /// Convert one raw utilization into a 0-100 percentage.
+    pub(crate) fn to_percent(self, utilization: f64) -> f64 {
+        match self {
+            Self::Percent => utilization,
+            Self::Fraction => utilization * 100.0,
+        }
+    }
+}
+
 fn claude_plan_label(tier: &str) -> String {
     let normalized = tier.to_lowercase();
     if normalized.contains("claude_max_5x") || normalized.contains("claude_max_5") {

--- a/rust/src/providers/claude/oauth/mod.rs
+++ b/rust/src/providers/claude/oauth/mod.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
+use super::UtilizationScale;
 use crate::core::{NamedRateWindow, ProviderError, ProviderFetchResult, RateWindow, UsageSnapshot};
 
 mod credentials_store;
@@ -357,11 +358,15 @@ impl ClaudeOAuthFetcher {
         response: &OAuthUsageResponse,
         credentials: &ClaudeOAuthCredentials,
     ) -> UsageSnapshot {
+        // Anthropic mixes fractions and percentages between payloads, so settle
+        // the unit once from the whole response before reading any window.
+        let scale = response.utilization_scale();
+
         // Primary: 5-hour session window
         let primary = response
             .five_hour
             .as_ref()
-            .and_then(|w| Self::to_rate_window(w, Some(300)))
+            .and_then(|w| Self::to_rate_window(w, Some(300), scale))
             .unwrap_or_else(|| RateWindow::new(0.0));
 
         let mut usage = UsageSnapshot::new(primary);
@@ -370,7 +375,7 @@ impl ClaudeOAuthFetcher {
         if let Some(weekly) = response
             .seven_day
             .as_ref()
-            .and_then(|w| Self::to_rate_window(w, Some(10080)))
+            .and_then(|w| Self::to_rate_window(w, Some(10080), scale))
         {
             usage = usage.with_secondary(weekly);
         }
@@ -379,13 +384,13 @@ impl ClaudeOAuthFetcher {
         if let Some(opus) = response
             .seven_day_opus
             .as_ref()
-            .and_then(|w| Self::to_rate_window(w, Some(10080)))
+            .and_then(|w| Self::to_rate_window(w, Some(10080), scale))
         {
             usage = usage.with_model_specific(opus);
         } else if let Some(sonnet) = response
             .seven_day_sonnet
             .as_ref()
-            .and_then(|w| Self::to_rate_window(w, Some(10080)))
+            .and_then(|w| Self::to_rate_window(w, Some(10080), scale))
         {
             usage = usage.with_model_specific(sonnet);
         }
@@ -396,7 +401,7 @@ impl ClaudeOAuthFetcher {
             response
                 .seven_day_routines
                 .as_ref()
-                .and_then(|w| Self::to_rate_window(w, Some(10080))),
+                .and_then(|w| Self::to_rate_window(w, Some(10080), scale)),
         )];
         for (id, title, window) in extra_windows {
             if let Some(window) = window {
@@ -422,8 +427,12 @@ impl ClaudeOAuthFetcher {
     }
 
     /// Convert OAuth usage window to RateWindow
-    fn to_rate_window(window: &UsageWindow, window_minutes: Option<u32>) -> Option<RateWindow> {
-        let utilization = normalize_utilization(window.utilization?);
+    fn to_rate_window(
+        window: &UsageWindow,
+        window_minutes: Option<u32>,
+        scale: UtilizationScale,
+    ) -> Option<RateWindow> {
+        let utilization = scale.to_percent(window.utilization?);
 
         let resets_at = window
             .resets_at
@@ -447,11 +456,22 @@ impl Default for ClaudeOAuthFetcher {
     }
 }
 
-fn normalize_utilization(utilization: f64) -> f64 {
-    if utilization > 0.0 && utilization <= 1.0 {
-        utilization * 100.0
-    } else {
-        utilization
+impl OAuthUsageResponse {
+    /// Decide the utilization unit from every window this response carries.
+    fn utilization_scale(&self) -> UtilizationScale {
+        UtilizationScale::detect(
+            [
+                self.five_hour.as_ref(),
+                self.seven_day.as_ref(),
+                self.seven_day_sonnet.as_ref(),
+                self.seven_day_opus.as_ref(),
+                self.seven_day_design.as_ref(),
+                self.seven_day_routines.as_ref(),
+            ]
+            .into_iter()
+            .flatten()
+            .filter_map(|window| window.utilization),
+        )
     }
 }
 
@@ -476,9 +496,22 @@ fn format_reset_date(date: DateTime<Utc>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{ClaudeOAuthCredentials, ClaudeOAuthFetcher, OAuthUsageResponse, UsageWindow};
+    use super::{
+        ClaudeOAuthCredentials, ClaudeOAuthFetcher, OAuthUsageResponse, UsageWindow,
+        UtilizationScale,
+    };
     use reqwest::header::HeaderValue;
     use std::time::Duration;
+
+    fn test_credentials() -> ClaudeOAuthCredentials {
+        ClaudeOAuthCredentials {
+            access_token: "token".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            scopes: vec!["user:profile".to_string()],
+            rate_limit_tier: Some("default_claude_ai".to_string()),
+        }
+    }
 
     #[test]
     fn converts_fractional_utilization_to_percent() {
@@ -487,7 +520,9 @@ mod tests {
             resets_at: None,
         };
 
-        let rate = ClaudeOAuthFetcher::to_rate_window(&window, Some(300)).expect("rate window");
+        let rate =
+            ClaudeOAuthFetcher::to_rate_window(&window, Some(300), UtilizationScale::Fraction)
+                .expect("rate window");
 
         assert!((rate.used_percent - 23.0).abs() < f64::EPSILON);
     }
@@ -499,9 +534,71 @@ mod tests {
             resets_at: None,
         };
 
-        let rate = ClaudeOAuthFetcher::to_rate_window(&window, Some(300)).expect("rate window");
+        let rate =
+            ClaudeOAuthFetcher::to_rate_window(&window, Some(300), UtilizationScale::Percent)
+                .expect("rate window");
 
         assert!((rate.used_percent - 23.0).abs() < f64::EPSILON);
+    }
+
+    /// SOU-286: a freshly reset window reports `1` (1% used). Read per value it
+    /// resolved to 100%, which also fired a false "limit reached" notification.
+    #[test]
+    fn freshly_reset_window_reporting_one_percent_is_not_full() {
+        let response: OAuthUsageResponse = serde_json::from_str(
+            r#"{
+                "five_hour": {"utilization": 28, "resets_at": "2026-07-21T04:00:00Z"},
+                "seven_day": {"utilization": 1, "resets_at": "2026-07-28T02:00:00Z"},
+                "seven_day_oauth_apps": {"utilization": 0}
+            }"#,
+        )
+        .expect("percentage OAuth response should parse");
+
+        let usage = ClaudeOAuthFetcher::new().build_usage_snapshot(&response, &test_credentials());
+
+        assert_eq!(response.utilization_scale(), UtilizationScale::Percent);
+        assert!((usage.primary.used_percent - 28.0).abs() < 0.001);
+        assert!(
+            (usage.secondary.expect("weekly").used_percent - 1.0).abs() < 0.001,
+            "a weekly window one hour past its reset must not read as full"
+        );
+    }
+
+    /// The same `1` still means 100% when the response is genuinely fractional.
+    #[test]
+    fn fractional_response_keeps_a_full_window_at_one_hundred() {
+        let response: OAuthUsageResponse = serde_json::from_str(
+            r#"{
+                "five_hour": {"utilization": 0.28, "resets_at": "2026-07-21T04:00:00Z"},
+                "seven_day": {"utilization": 1.0, "resets_at": "2026-07-28T02:00:00Z"}
+            }"#,
+        )
+        .expect("fractional OAuth response should parse");
+
+        let usage = ClaudeOAuthFetcher::new().build_usage_snapshot(&response, &test_credentials());
+
+        assert_eq!(response.utilization_scale(), UtilizationScale::Fraction);
+        assert!((usage.primary.used_percent - 28.0).abs() < 0.001);
+        assert!((usage.secondary.expect("weekly").used_percent - 100.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn utilization_scale_detects_unit_from_the_whole_response() {
+        assert_eq!(
+            UtilizationScale::detect([0.0, 1.0, 95.0]),
+            UtilizationScale::Percent,
+            "any value above 1.0 can only be a percentage"
+        );
+        assert_eq!(
+            UtilizationScale::detect([0.0, 0.14, 1.0]),
+            UtilizationScale::Fraction
+        );
+        // Nothing disambiguates an all zero/one response, so 1.0 stays 100%.
+        assert_eq!(
+            UtilizationScale::detect([0.0, 1.0]),
+            UtilizationScale::Fraction
+        );
+        assert_eq!(UtilizationScale::detect([]), UtilizationScale::Fraction);
     }
 
     #[test]

--- a/rust/src/providers/claude/web_api.rs
+++ b/rust/src/providers/claude/web_api.rs
@@ -5,6 +5,7 @@ use reqwest::{Client, header};
 use serde::Deserialize;
 use std::path::PathBuf;
 
+use super::UtilizationScale;
 use crate::browser::cookies::{get_cookie_header, get_cookie_header_from_browser};
 use crate::browser::detection::{BrowserProfile, BrowserType, DetectedBrowser};
 use crate::core::{
@@ -428,22 +429,25 @@ impl ClaudeWebApiFetcher {
         // Step 4: Fetch account info - optional
         let account = self.get_account_info(&headers).await.ok();
 
-        // Build the result
+        // Build the result. Anthropic mixes fractions and percentages between
+        // payloads, so settle the unit once from the whole response first.
+        let scale = usage.utilization_scale();
+
         let primary = usage
             .five_hour
             .as_ref()
-            .map(|w| self.to_rate_window(w, Some(300))) // 5 hours = 300 minutes
+            .map(|w| self.to_rate_window(w, Some(300), scale)) // 5 hours = 300 minutes
             .unwrap_or_else(|| RateWindow::new(0.0));
 
         let secondary = usage
             .seven_day
             .as_ref()
-            .map(|w| self.to_rate_window(w, Some(10080))); // 7 days = 10080 minutes
+            .map(|w| self.to_rate_window(w, Some(10080), scale)); // 7 days = 10080 minutes
 
         let model_specific = usage
             .seven_day_opus
             .as_ref()
-            .map(|w| self.to_rate_window(w, Some(10080)));
+            .map(|w| self.to_rate_window(w, Some(10080), scale));
 
         let mut snapshot = UsageSnapshot::new(primary);
 
@@ -462,7 +466,7 @@ impl ClaudeWebApiFetcher {
                 usage
                     .seven_day_oauth_apps
                     .as_ref()
-                    .map(|w| self.to_rate_window(w, Some(10080))),
+                    .map(|w| self.to_rate_window(w, Some(10080), scale)),
             ),
             (
                 "claude-routines",
@@ -470,7 +474,7 @@ impl ClaudeWebApiFetcher {
                 usage
                     .seven_day_routines
                     .as_ref()
-                    .map(|w| self.to_rate_window(w, Some(10080))),
+                    .map(|w| self.to_rate_window(w, Some(10080), scale)),
             ),
             (
                 "claude-design",
@@ -478,7 +482,7 @@ impl ClaudeWebApiFetcher {
                 usage
                     .seven_day_design
                     .as_ref()
-                    .map(|w| self.to_rate_window(w, Some(10080))),
+                    .map(|w| self.to_rate_window(w, Some(10080), scale)),
             ),
             (
                 "claude-weekly-promo",
@@ -486,7 +490,7 @@ impl ClaudeWebApiFetcher {
                 usage
                     .seven_day_promotional
                     .as_ref()
-                    .map(|w| self.to_rate_window(w, Some(10080))),
+                    .map(|w| self.to_rate_window(w, Some(10080), scale)),
             ),
         ] {
             if let Some(window) = window {
@@ -722,8 +726,13 @@ impl ClaudeWebApiFetcher {
     }
 
     /// Convert a usage window to a RateWindow
-    fn to_rate_window(&self, window: &UsageWindow, window_minutes: Option<u32>) -> RateWindow {
-        let used_percent = normalize_utilization(window.utilization.unwrap_or(0.0));
+    fn to_rate_window(
+        &self,
+        window: &UsageWindow,
+        window_minutes: Option<u32>,
+        scale: UtilizationScale,
+    ) -> RateWindow {
+        let used_percent = scale.to_percent(window.utilization.unwrap_or(0.0));
 
         let resets_at = window
             .resets_at
@@ -764,11 +773,24 @@ impl Default for ClaudeWebApiFetcher {
     }
 }
 
-fn normalize_utilization(utilization: f64) -> f64 {
-    if utilization > 0.0 && utilization <= 1.0 {
-        utilization * 100.0
-    } else {
-        utilization
+impl UsageResponse {
+    /// Decide the utilization unit from every window this response carries.
+    fn utilization_scale(&self) -> UtilizationScale {
+        UtilizationScale::detect(
+            [
+                self.five_hour.as_ref(),
+                self.seven_day.as_ref(),
+                self.seven_day_opus.as_ref(),
+                self.seven_day_sonnet.as_ref(),
+                self.seven_day_oauth_apps.as_ref(),
+                self.seven_day_design.as_ref(),
+                self.seven_day_promotional.as_ref(),
+                self.seven_day_routines.as_ref(),
+            ]
+            .into_iter()
+            .flatten()
+            .filter_map(|window| window.utilization),
+        )
     }
 }
 
@@ -790,8 +812,8 @@ fn cookie_value(cookie_header: &str, name: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        AccountResponse, ClaudeWebApiFetcher, UsageWindow, claude_desktop_data_dirs_from,
-        cookie_value,
+        AccountResponse, ClaudeWebApiFetcher, UsageWindow, UtilizationScale,
+        claude_desktop_data_dirs_from, cookie_value,
     };
     use reqwest::header;
     use std::path::PathBuf;
@@ -809,7 +831,11 @@ mod tests {
             resets_at: None,
         };
 
-        let rate = ClaudeWebApiFetcher::new().to_rate_window(&window, Some(300));
+        let rate = ClaudeWebApiFetcher::new().to_rate_window(
+            &window,
+            Some(300),
+            UtilizationScale::Fraction,
+        );
 
         assert!((rate.used_percent - 23.0).abs() < f64::EPSILON);
     }
@@ -821,7 +847,11 @@ mod tests {
             resets_at: None,
         };
 
-        let rate = ClaudeWebApiFetcher::new().to_rate_window(&window, Some(300));
+        let rate = ClaudeWebApiFetcher::new().to_rate_window(
+            &window,
+            Some(300),
+            UtilizationScale::Percent,
+        );
 
         assert!((rate.used_percent - 23.0).abs() < f64::EPSILON);
     }
@@ -976,17 +1006,17 @@ mod tests {
         let design = usage
             .seven_day_design
             .as_ref()
-            .map(|w| fetcher.to_rate_window(w, Some(10080)))
+            .map(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
             .expect("design window");
         let promo = usage
             .seven_day_promotional
             .as_ref()
-            .map(|w| fetcher.to_rate_window(w, Some(10080)))
+            .map(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
             .expect("promotional omelette window");
         let routines = usage
             .seven_day_routines
             .as_ref()
-            .map(|w| fetcher.to_rate_window(w, Some(10080)))
+            .map(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
             .expect("routines window");
 
         assert!((design.used_percent - 31.0).abs() < f64::EPSILON);
@@ -1032,12 +1062,12 @@ mod tests {
         let design = usage
             .seven_day_design
             .as_ref()
-            .map(|w| fetcher.to_rate_window(w, Some(10080)))
+            .map(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
             .expect("design window");
         let routines = usage
             .seven_day_routines
             .as_ref()
-            .map(|w| fetcher.to_rate_window(w, Some(10080)))
+            .map(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
             .expect("routines window");
 
         assert!((design.used_percent - 31.0).abs() < f64::EPSILON);
@@ -1064,7 +1094,7 @@ mod tests {
         let oauth_apps = usage
             .seven_day_oauth_apps
             .as_ref()
-            .map(|w| fetcher.to_rate_window(w, Some(10080)))
+            .map(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
             .expect("oauth apps window");
         let extra = usage.extra_usage.expect("extra usage");
 


### PR DESCRIPTION
Fixes SOU-286.

## The bug
Anthropic reports `utilization` inconsistently: some payloads use fractions of the limit (`0.23` = 23%), others integer percentages (`23` = 23%). `normalize_utilization` guessed **per value**, mapping anything in `(0, 1]` to a fraction:

```rust
if utilization > 0.0 && utilization <= 1.0 { utilization * 100.0 } else { utilization }
```

That makes `1.0` ambiguous — 100% as a fraction, 1% as a percentage — and it always resolved to 100%. So a window one hour past its reset reports `1` (1% used) and rendered as **100%**, then "fixed itself" on the next poll once usage reached `2`.

Worse than a display glitch: the bogus 100% feeds the capacity-event path, so it fired a false **"weekly is 100% full"** notification with a full week of capacity remaining. Observed on the 5-hour session window, then again on the weekly window.

## The fix
Decide the unit **once per response** instead of per value:

- Any value above `1.0` can only be a percentage (a fraction never exceeds the limit), so one such window settles the whole payload.
- Otherwise the values are read as fractions, which keeps a genuine `1.0` meaning 100%.

Both fetchers (`oauth/mod.rs`, `web_api.rs`) now resolve the scale from every window they parse and apply it uniformly, via a shared `UtilizationScale` in `claude/mod.rs`. The duplicated `normalize_utilization` is gone.

In the reported incident the same response carried the 5-hour window at `28`, which proves percentages, so the weekly `1` correctly reads as 1%.

## Residual case
If a response's values are *all* exactly `0.0` or `1.0`, nothing disambiguates it and it's read as fractions (so `1.0` stays 100%). That preserves correct reporting of a genuinely exhausted window; a real 100% is almost always accompanied by another window that isn't exactly 0 or 1. Covered by a test.

## Tests
- `freshly_reset_window_reporting_one_percent_is_not_full` — the exact incident (5h `28`, weekly `1` → 28% / 1%).
- `fractional_response_keeps_a_full_window_at_one_hundred` — `1.0` still means 100% in a fractional payload.
- `utilization_scale_detects_unit_from_the_whole_response` — detection rules incl. the ambiguous all-`{0,1}` case.
- Existing coverage updated to pass the scale explicitly; web-api tests now exercise the real detection path.

`cargo test` 655 passed / 0 failed. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
