### PR TITLE
Refresh on reset boundaries and rank floatbar windows by pressure

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/auto_refresh.rs
+++ b/apps/desktop-tauri/src-tauri/src/auto_refresh.rs
@@ -88,7 +88,12 @@ fn snapshot_reset_times(snapshot: &ProviderUsageSnapshot) -> Vec<DateTime<Utc>> 
     ]
     .into_iter()
     .flatten()
-    .chain(snapshot.extra_rate_windows.iter().map(|extra| &extra.window))
+    .chain(
+        snapshot
+            .extra_rate_windows
+            .iter()
+            .map(|extra| &extra.window),
+    )
     .filter_map(|window| window.resets_at.as_deref())
     .filter_map(parse_reset_time)
     .collect()

--- a/apps/desktop-tauri/src-tauri/src/auto_refresh.rs
+++ b/apps/desktop-tauri/src-tauri/src/auto_refresh.rs
@@ -1,9 +1,11 @@
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
+use chrono::{DateTime, Utc};
 use codexbar::settings::Settings;
 use tauri::Manager;
 
+use crate::commands::ProviderUsageSnapshot;
 use crate::state::AppState;
 
 const AUTO_REFRESH_POLL_INTERVAL: Duration = Duration::from_secs(15);
@@ -12,6 +14,7 @@ const PROVIDER_REFRESH_INTERVAL: Duration = Duration::from_secs(5 * 60);
 pub fn install(app: tauri::AppHandle) {
     tauri::async_runtime::spawn(async move {
         let mut schedule: Option<(Duration, Instant)> = None;
+        let mut next_reset: Option<DateTime<Utc>> = None;
         loop {
             let interval = PROVIDER_REFRESH_INTERVAL;
             let now = Instant::now();
@@ -19,18 +22,82 @@ pub fn install(app: tauri::AppHandle) {
                 .filter(|(scheduled_interval, _)| *scheduled_interval == interval)
                 .map(|(_, scheduled_at)| scheduled_at)
                 .unwrap_or(now);
-            if now >= scheduled_at {
-                if let Err(error) = crate::commands::do_refresh_providers_if_stale(&app).await {
+            // A window that just reset is the one moment a stale reading is most
+            // visible, and reset notifications are only produced inside a refresh.
+            // Waiting for the next fixed tick delayed them by minutes, so cross a
+            // known boundary and refresh on this wake instead.
+            let scheduled_due = now >= scheduled_at;
+            let reset_due = next_reset.is_some_and(|reset| Utc::now() >= reset);
+
+            if scheduled_due || reset_due {
+                // A crossed boundary must re-fetch even when the cache looks
+                // fresh, otherwise the staleness gate swallows the reset read.
+                let refreshed = if reset_due {
+                    crate::commands::do_refresh_providers(&app).await
+                } else {
+                    crate::commands::do_refresh_providers_if_stale(&app).await
+                };
+                if let Err(error) = refreshed {
                     tracing::warn!(%error, "Automatic provider refresh failed");
                 }
-                schedule = Some((
-                    interval,
-                    next_fixed_tick(scheduled_at, Instant::now(), interval),
-                ));
+                if scheduled_due {
+                    schedule = Some((
+                        interval,
+                        next_fixed_tick(scheduled_at, Instant::now(), interval),
+                    ));
+                }
+            }
+
+            // Only ever track a boundary that is still ahead of us. A provider
+            // that keeps reporting an already-passed reset therefore falls back
+            // to the fixed cadence instead of refreshing on every wake.
+            if reset_due || next_reset.is_none() {
+                next_reset = soonest_reset_after(&app, Utc::now());
             }
             tokio::time::sleep(AUTO_REFRESH_POLL_INTERVAL).await;
         }
     });
+}
+
+/// Earliest reset strictly after `after` across every enforced window we hold.
+fn soonest_reset_after(app: &tauri::AppHandle, after: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    let state = app.state::<Mutex<AppState>>();
+    let snapshots = match state.lock() {
+        Ok(guard) => guard.provider_cache.clone(),
+        Err(error) => {
+            tracing::warn!("failed to lock app state to read reset boundaries: {error}");
+            return None;
+        }
+    };
+    snapshots
+        .iter()
+        .flat_map(snapshot_reset_times)
+        .filter(|reset| *reset > after)
+        .min()
+}
+
+/// Reset instants for a provider's enforced windows. Inactive windows are
+/// skipped: they are not being enforced, so their boundaries should not wake
+/// an extra fetch.
+fn snapshot_reset_times(snapshot: &ProviderUsageSnapshot) -> Vec<DateTime<Utc>> {
+    [
+        Some(&snapshot.primary),
+        snapshot.secondary.as_ref(),
+        snapshot.model_specific.as_ref(),
+        snapshot.tertiary.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    .chain(snapshot.extra_rate_windows.iter().map(|extra| &extra.window))
+    .filter_map(|window| window.resets_at.as_deref())
+    .filter_map(parse_reset_time)
+    .collect()
+}
+
+fn parse_reset_time(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|parsed| parsed.with_timezone(&Utc))
 }
 
 fn next_fixed_tick(
@@ -141,6 +208,106 @@ mod tests {
         assert_eq!(
             next_fixed_tick(first_tick, first_tick + Duration::from_secs(260), interval),
             start + Duration::from_secs(400)
+        );
+    }
+
+    fn sample_snapshot() -> crate::commands::ProviderUsageSnapshot {
+        crate::commands::ProviderUsageSnapshot {
+            provider_id: "claude".into(),
+            display_name: "Claude".into(),
+            primary: window_resetting_at(None),
+            primary_label: Some("Session (5h)".into()),
+            secondary: None,
+            secondary_label: Some("Weekly".into()),
+            model_specific: None,
+            tertiary: None,
+            extra_rate_windows: Vec::new(),
+            inactive_rate_windows: Vec::new(),
+            promo_signals: Vec::new(),
+            reset_credits_available: None,
+            cost: None,
+            plan_name: None,
+            account_email: None,
+            source_label: "oauth".into(),
+            updated_at: "2026-07-21T00:00:00Z".into(),
+            error: None,
+            pace: None,
+            account_organization: None,
+            tray_status_label: None,
+            fetch_duration_ms: None,
+            wayfinder_usage: None,
+        }
+    }
+
+    fn window_resetting_at(resets_at: Option<&str>) -> crate::commands::RateWindowSnapshot {
+        crate::commands::RateWindowSnapshot {
+            used_percent: 10.0,
+            remaining_percent: 90.0,
+            window_minutes: Some(300),
+            resets_at: resets_at.map(str::to_string),
+            reset_description: None,
+            is_exhausted: false,
+            reserve_percent: None,
+            reserve_description: None,
+            reserve_will_last_to_reset: false,
+            reserve_eta_seconds: None,
+        }
+    }
+
+    #[test]
+    fn reset_times_cover_every_enforced_window_and_ignore_unparsable_ones() {
+        let mut snapshot = crate::commands::ProviderUsageSnapshot {
+            primary: window_resetting_at(Some("2026-07-21T05:00:00Z")),
+            secondary: Some(window_resetting_at(Some("2026-07-28T02:00:00Z"))),
+            tertiary: Some(window_resetting_at(None)),
+            model_specific: Some(window_resetting_at(Some("not-a-timestamp"))),
+            ..sample_snapshot()
+        };
+        snapshot
+            .extra_rate_windows
+            .push(crate::commands::NamedRateWindowSnapshot {
+                id: "claude-routines".to_string(),
+                title: "Daily Routines".to_string(),
+                window: window_resetting_at(Some("2026-07-21T03:00:00Z")),
+            });
+
+        let mut times = snapshot_reset_times(&snapshot);
+        times.sort();
+
+        assert_eq!(
+            times,
+            vec![
+                parse_reset_time("2026-07-21T03:00:00Z").unwrap(),
+                parse_reset_time("2026-07-21T05:00:00Z").unwrap(),
+                parse_reset_time("2026-07-28T02:00:00Z").unwrap(),
+            ],
+            "extra windows count, and missing or malformed timestamps are dropped"
+        );
+    }
+
+    /// The loop only ever arms a boundary still ahead of it, so a provider stuck
+    /// reporting a passed reset cannot force a refresh on every 15s wake.
+    #[test]
+    fn only_future_boundaries_are_armed() {
+        let snapshot = crate::commands::ProviderUsageSnapshot {
+            primary: window_resetting_at(Some("2026-07-21T05:00:00Z")),
+            secondary: Some(window_resetting_at(Some("2026-07-21T03:00:00Z"))),
+            ..sample_snapshot()
+        };
+        let times = snapshot_reset_times(&snapshot);
+
+        let before_both = parse_reset_time("2026-07-21T02:00:00Z").unwrap();
+        assert_eq!(
+            times.iter().copied().filter(|t| *t > before_both).min(),
+            parse_reset_time("2026-07-21T03:00:00Z"),
+            "the nearest upcoming boundary wins"
+        );
+
+        let after_both = parse_reset_time("2026-07-21T06:00:00Z").unwrap();
+        assert_eq!(
+            times.iter().copied().filter(|t| *t > after_both).min(),
+            None,
+            "nothing is armed once every known boundary has passed"
         );
     }
 

--- a/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
@@ -74,6 +74,64 @@ describe("capacityPresentation", () => {
     expect(constraining.window.usedPercent).toBe(55);
   });
 
+  it("surfaces a hot weekly over a freshly reset session (SOU-288)", () => {
+    const snap = provider({
+      providerId: "claude",
+      displayName: "Claude",
+      primary: window(2),
+      primaryLabel: "Session (5h)",
+      secondary: window(95),
+      secondaryLabel: "Weekly",
+    });
+
+    const constraining = constrainingWindow(snap);
+
+    expect(constraining.id).toBe("secondary");
+    expect(constraining.label).toBe("Weekly");
+    expect(constraining.window.usedPercent).toBe(95);
+  });
+
+  it("prefers a blocking window over a merely higher-pressure one", () => {
+    const exhausted = window(100);
+    const snap = provider({
+      primary: window(100),
+      primaryLabel: "Session",
+      secondary: { ...window(97), isExhausted: false },
+      secondaryLabel: "Weekly",
+    });
+    expect(exhausted.isExhausted).toBe(true);
+
+    // Primary is blocking at 100%, so it outranks the hotter-looking 97% lane.
+    expect(constrainingWindow(snap).id).toBe("primary");
+
+    // And a blocking non-primary wins even when primary reads higher.
+    const blockedExtra = provider({
+      primary: window(80),
+      primaryLabel: "Session",
+      extraRateWindows: [
+        {
+          id: "scoped",
+          title: "Fable only",
+          window: { ...window(40), isExhausted: true },
+        },
+      ],
+    });
+    expect(constrainingWindow(blockedExtra).id).toBe("extra-scoped");
+  });
+
+  it("breaks an exact tie toward the window that resets first", () => {
+    const soon = { ...window(60), resetsAt: "2026-07-21T04:00:00Z" };
+    const later = { ...window(60), resetsAt: "2026-07-28T04:00:00Z" };
+    const snap = provider({
+      primary: later,
+      primaryLabel: "Weekly",
+      secondary: soon,
+      secondaryLabel: "Session",
+    });
+
+    expect(constrainingWindow(snap).label).toBe("Session");
+  });
+
   it("keeps Cursor plan as hero and shows reported Auto and API companions", () => {
     const meters = glanceMeters(
       provider({

--- a/apps/desktop-tauri/src/lib/capacityPresentation.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.ts
@@ -31,7 +31,40 @@ const STALE_AFTER_MS = 10 * 60 * 1000;
 /** Companion lanes appear on overview when used reaches this share. */
 export const GLANCE_COMPANION_HOT_PERCENT = 70;
 
-/** Pick the measured window with the highest used percent (constraining). */
+/** A window you have already hit stops work no matter what the others read. */
+function isBlocking(window: RateWindowSnapshot): boolean {
+  return window.isExhausted || window.usedPercent >= 100;
+}
+
+/** Reset instant in ms; windows without a usable reset sort last. */
+function resetAtMs(window: RateWindowSnapshot): number {
+  const parsed = window.resetsAt ? Date.parse(window.resetsAt) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Whether `candidate` is a more relevant thing to surface than `best`.
+ *
+ * Blended priority, in order:
+ *  1. Blocking windows first, because an exhausted lane is what actually stops
+ *     you even when another lane reads higher pressure.
+ *  2. Then the highest used percent, i.e. closest to its ceiling.
+ *  3. Then the soonest reset, so a tie resolves toward the one that bites first.
+ */
+function outranks(
+  candidate: ConstrainingWindow,
+  best: ConstrainingWindow,
+): boolean {
+  const candidateBlocking = isBlocking(candidate.window);
+  const bestBlocking = isBlocking(best.window);
+  if (candidateBlocking !== bestBlocking) return candidateBlocking;
+  if (candidate.window.usedPercent !== best.window.usedPercent) {
+    return candidate.window.usedPercent > best.window.usedPercent;
+  }
+  return resetAtMs(candidate.window) < resetAtMs(best.window);
+}
+
+/** Pick the window actually constraining this provider (see `outranks`). */
 export function constrainingWindow(
   provider: ProviderUsageSnapshot,
 ): ConstrainingWindow {
@@ -42,7 +75,7 @@ export function constrainingWindow(
   };
 
   for (const candidate of nonPrimaryWindows(provider)) {
-    if (candidate.window.usedPercent > best.window.usedPercent) {
+    if (outranks(candidate, best)) {
       best = candidate;
     }
   }


### PR DESCRIPTION
Fixes SOU-287 and SOU-288.

## SOU-287 — reset notifications fired minutes late

Reset alerts are only produced inside a provider refresh (`observe()` → `capacity_event_notification`), and the reliable cadence is the **5-minute** backend tick. A window that reset just after a tick went unnoticed until the next one. The frontend fast-path meant to cover this is a webview `setTimeout` that Windows suspends while the floatbar is hidden — its usual state — so in practice the 5-minute loop was the trigger. Observed at ~5 min on a session reset and ~30 min on a weekly reset.

**Fix:** the auto-refresh loop already wakes every 15s. It now tracks the soonest upcoming reset across every *enforced* window and forces a refresh the moment that boundary passes, instead of waiting for the next fixed tick. Detection latency drops from up to 5 minutes to ~15s without raising the normal poll rate.

Details that matter:
- The boundary refresh **forces** the fetch, so the 30s staleness gate can't swallow the post-reset read.
- Only boundaries **still ahead** are armed. A provider stuck reporting an already-passed reset yields `None` and falls back to the fixed cadence, so it can't refetch on every 15s wake.
- Inactive (not-enforced) windows are skipped — they shouldn't wake an extra fetch.
- `begin_provider_refresh` already guards `is_refreshing`, so forcing cannot overlap a running refresh.

## SOU-288 — floatbar surfaced the wrong window

Selection was "highest used percent", which can't express that an already-exhausted lane is what actually stops work, and left exact ties to input order.

**Fix:** blended priority, in order:
1. **Blocking windows first** (`isExhausted` or ≥100%) — an exhausted lane stops you even when another reads higher pressure.
2. **Highest used percent** — closest to its ceiling.
3. **Soonest reset** — ties resolve toward the window that bites first.

This also feeds the overview tiles, which share the chooser.

**On the original report** (Session 2% shown over Weekly 95%): I could not find a code path that would pick the session there — `floatBarWindow` → `constrainingWindow` has preferred the higher percent since 0.43.0, only Cursor is hardcoded, and the enforcement annotator is additive and never removes a real window. So the ranking change alone may not explain that sighting; it is locked in a regression test now, and if it recurs it points at the floatbar holding a snapshot without `secondary`, which needs a runtime capture to confirm.

## Tests
- `reset_times_cover_every_enforced_window_and_ignore_unparsable_ones` — all enforced slots + extras counted; missing/malformed timestamps dropped.
- `only_future_boundaries_are_armed` — nearest upcoming boundary wins; nothing armed once all have passed (the re-fetch-loop guard).
- `surfaces a hot weekly over a freshly reset session (SOU-288)` — the exact reported scenario.
- `prefers a blocking window over a merely higher-pressure one`, `breaks an exact tie toward the window that resets first`.

Rust: 391 passed / 0 failed, clippy `-D warnings` clean. Frontend: 277 passed / 0 failed, `tsc --noEmit` clean.
