### PR TITLE
Attribute Codex activity to its plan and disclose multi-account totals

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -90,6 +90,10 @@ pub struct ProviderLocalUsageSummary {
     /// for providers without an effort tier). Sorted by cost then tokens.
     #[serde(default)]
     pub effort_breakdown: Vec<LocalEffortCost>,
+    /// Plans observed in local logs for the 30-day period, largest first.
+    /// More than one entry means the total spans multiple accounts.
+    #[serde(default)]
+    pub plan_breakdown: Vec<LocalPlanUsage>,
     /// Per-project/repo spend over the 30-day period, sorted by cost then
     /// tokens. Priced and unpriced projects are both included.
     #[serde(default)]
@@ -223,6 +227,21 @@ pub struct LocalModelCost {
 pub struct LocalEffortCost {
     pub effort: String,
     pub cost: Option<f64>,
+    pub tokens: u64,
+}
+
+/// Locally observed activity attributed to one subscription plan.
+///
+/// Local logs carry no account identity, so a machine's activity can span
+/// several accounts with no way to tell them apart. The plan is the only proxy
+/// Codex emits, and it is imperfect: two accounts on the same plan look
+/// identical, and one account changing plans looks like two. It exists so the
+/// UI can disclose that a total is not account-scoped, never to silently
+/// filter one out.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalPlanUsage {
+    pub plan: String,
     pub tokens: u64,
 }
 
@@ -1008,6 +1027,7 @@ fn local_usage_summary_from_report(
         top_model: top_model(&report.thirty_days),
         model_breakdown: model_breakdown(provider_id, &report.thirty_days),
         effort_breakdown: effort_breakdown(&report.thirty_days),
+        plan_breakdown: plan_breakdown(provider_id, &report.thirty_days),
         project_breakdown: project_breakdown(&report.thirty_days),
         estimate_note: localized_estimate_note(provider_id, lang),
         token_cost_updated_at_ms: current_unix_ms(),
@@ -1095,6 +1115,7 @@ fn load_local_usage_summary_with_unknown_models(
             top_model: top_model(&thirty_day),
             model_breakdown: model_breakdown(provider_id, &thirty_day),
             effort_breakdown: effort_breakdown(&thirty_day),
+            plan_breakdown: plan_breakdown(provider_id, &thirty_day),
             project_breakdown: project_breakdown(&thirty_day),
             estimate_note: localized_estimate_note(provider_id, lang),
             token_cost_updated_at_ms: current_unix_ms(),
@@ -1361,6 +1382,23 @@ fn model_breakdown(provider_id: &str, summary: &CostSummary) -> Vec<LocalModelCo
 /// Per-reasoning-effort spend for a period, mirroring `model_breakdown`.
 /// Codex populates `by_effort` / `by_effort_tokens`; other providers leave
 /// them empty, so this returns an empty vec for them.
+/// Plans seen in local logs, largest first. Empty when the provider emits no
+/// plan signal at all (Claude), so the UI shows nothing rather than a
+/// misleading single-plan claim.
+fn plan_breakdown(provider_id: &str, summary: &CostSummary) -> Vec<LocalPlanUsage> {
+    let mut rows: Vec<LocalPlanUsage> = summary
+        .by_plan_tokens
+        .iter()
+        .map(|(plan, counts)| LocalPlanUsage {
+            plan: plan.clone(),
+            tokens: counts.normalized(provider_id).processed(),
+        })
+        .filter(|row| row.tokens > 0)
+        .collect();
+    rows.sort_by(|a, b| b.tokens.cmp(&a.tokens).then(a.plan.cmp(&b.plan)));
+    rows
+}
+
 fn effort_breakdown(summary: &CostSummary) -> Vec<LocalEffortCost> {
     let mut rows: Vec<LocalEffortCost> = summary
         .by_effort_tokens
@@ -1481,8 +1519,8 @@ fn load_openai_dashboard_chart_data(
 #[cfg(test)]
 mod tests {
     use super::{
-        CostFetchFailure, LocalEffortCost, LocalModelCost, LocalProjectCost, LocalTokenBreakdown,
-        LocalUsageWindowRequest, ProviderLocalUsageSummary, api_value_period,
+        CostFetchFailure, LocalEffortCost, LocalModelCost, LocalPlanUsage, LocalProjectCost,
+        LocalTokenBreakdown, LocalUsageWindowRequest, ProviderLocalUsageSummary, api_value_period,
         comparison_period_specs, cost_fetch_failure_allows_early_retry, effort_breakdown,
         format_cost_csv, local_midnight_in_tz, local_usage_summary_from_report,
         local_yesterday_window_utc, localized_estimate_note, model_breakdown, project_breakdown,
@@ -1549,6 +1587,10 @@ mod tests {
             effort_breakdown: vec![LocalEffortCost {
                 effort: "high".to_string(),
                 cost: Some(2.0),
+                tokens: 300,
+            }],
+            plan_breakdown: vec![LocalPlanUsage {
+                plan: "prolite".to_string(),
                 tokens: 300,
             }],
             project_breakdown: vec![LocalProjectCost {

--- a/apps/desktop-tauri/src-tauri/src/powertoys.rs
+++ b/apps/desktop-tauri/src-tauri/src/powertoys.rs
@@ -244,6 +244,7 @@ mod tests {
                 top_model: Some("gpt-5".to_string()),
                 model_breakdown: Vec::new(),
                 effort_breakdown: Vec::new(),
+                plan_breakdown: Vec::new(),
                 project_breakdown: Vec::new(),
                 estimate_note: "cached".to_string(),
                 token_cost_updated_at_ms: 1234,

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -7765,6 +7765,15 @@ body:has(.dashboard-shell) #root {
   font-size: 10.5px;
   flex-wrap: wrap;
 }
+/* A caveat, not decoration: the totals beside it are not account-scoped. */
+.usage-periods__note--warn {
+  margin: 8px 0 0;
+  padding: 7px 9px;
+  border: 1px solid color-mix(in srgb, var(--usage-bar-high) 28%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--usage-bar-high) 7%, transparent);
+  line-height: 1.45;
+}
 .usage-periods__note strong {
   color: var(--text-primary);
   font-weight: 600;

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -14,6 +14,7 @@ import type {
   CursorModelActivity,
   LocalEffortCost,
   LocalModelCost,
+  LocalPlanUsage,
   LocalProjectCost,
   LocalTokenBreakdown,
   ProviderChartData,
@@ -117,6 +118,32 @@ function formatUsd(value: number): string {
     style: "currency",
     currency: "USD",
   }).format(value);
+}
+
+/**
+ * Disclose when local activity spans more than one subscription plan.
+ *
+ * Local logs carry no account identity for any provider, so a machine's totals
+ * can cover several accounts with no way to separate them. The plan is the only
+ * proxy Codex emits, and it is imperfect in both directions: two accounts on one
+ * plan look identical, and one account changing plans looks like two. So this
+ * states what was observed and does not filter anything out.
+ */
+function MultiPlanNotice({ plans }: { plans?: LocalPlanUsage[] | null }) {
+  if (!plans || plans.length < 2) return null;
+  const total = plans.reduce((sum, plan) => sum + plan.tokens, 0);
+  if (total <= 0) return null;
+  const share = (tokens: number) => Math.round((tokens / total) * 100);
+  return (
+    <p className="usage-periods__note usage-periods__note--warn" role="note">
+      <span>
+        These totals cover <strong>{plans.length} plans</strong> seen on this
+        machine ({plans.map((p) => `${p.plan} ${share(p.tokens)}%`).join(", ")}),
+        not just the signed-in account. Local logs do not record which account
+        produced them.
+      </span>
+    </p>
+  );
 }
 
 function ModelBreakdown({ models }: { models: LocalModelCost[] }) {
@@ -631,6 +658,10 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
             )}
             <span>Processed includes fresh input, output, cache reads, and cache writes.</span>
           </div>
+          {/* Local logs carry no account identity, so these totals cover every
+              account that has used this machine. Disclose that rather than let
+              the figures read as belonging to the signed-in account. */}
+          <MultiPlanNotice plans={data.localUsage.planBreakdown} />
           {data.localUsage.modelBreakdown && data.localUsage.modelBreakdown.length > 0 && (
             <ModelBreakdown models={data.localUsage.modelBreakdown} />
           )}

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -635,6 +635,8 @@ export interface ProviderLocalUsageSummary {
   topModel: string | null;
   modelBreakdown?: LocalModelCost[];
   effortBreakdown?: LocalEffortCost[];
+  /** Plans seen in local logs. More than one means the total spans accounts. */
+  planBreakdown?: LocalPlanUsage[];
   projectBreakdown?: LocalProjectCost[];
   estimateNote: string;
   tokenCostUpdatedAtMs: number;
@@ -652,6 +654,12 @@ export interface LocalModelCost {
   /** Output tokens per usage record, when calls > 0. */
   outputTokensPerCall?: number | null;
   calls?: number;
+}
+
+/** Locally observed activity attributed to one subscription plan. */
+export interface LocalPlanUsage {
+  plan: string;
+  tokens: number;
 }
 
 export interface LocalEffortCost {

--- a/rust/src/codex_costs.rs
+++ b/rust/src/codex_costs.rs
@@ -44,6 +44,7 @@ pub(crate) fn add_codex_records_to_summary(
             &record.model,
             record.effort.as_deref(),
             record.project.as_deref(),
+            record.plan.as_deref(),
             tokens,
         ) {
             total_cost += cost;
@@ -69,6 +70,7 @@ pub(crate) fn add_codex_record_to_summary(
         &record.model,
         record.effort.as_deref(),
         record.project.as_deref(),
+        record.plan.as_deref(),
         tokens,
     )
 }
@@ -126,11 +128,16 @@ fn add_tokens(summary: &mut ModelTokenCounts, tokens: CodexTokenCounts) {
 /// (tokens are still recorded, but no dollars are fabricated), and `Some(cost)`
 /// when the model has canonical pricing. Unknown-model dollars are never added
 /// to the totals — a period of only-unpriced usage must not read as `$0.00`.
+/// Keyed when a rollout never declared a plan, so unattributed activity stays
+/// visible instead of silently landing on whichever account is displayed.
+pub(crate) const UNATTRIBUTED_PLAN: &str = "unattributed";
+
 fn add_codex_tokens_to_summary(
     summary: &mut CostSummary,
     model: &str,
     effort: Option<&str>,
     project: Option<&str>,
+    plan: Option<&str>,
     tokens: CodexTokenCounts,
 ) -> Option<f64> {
     if tokens.is_empty() {
@@ -162,6 +169,17 @@ fn add_codex_tokens_to_summary(
         summary
             .by_project_tokens
             .entry(project_bucket.clone())
+            .or_default(),
+        tokens,
+    );
+    let plan_bucket = plan
+        .map(str::trim)
+        .filter(|plan| !plan.is_empty())
+        .unwrap_or(UNATTRIBUTED_PLAN);
+    add_tokens(
+        summary
+            .by_plan_tokens
+            .entry(plan_bucket.to_string())
             .or_default(),
         tokens,
     );
@@ -243,6 +261,7 @@ mod tests {
                 model: "gpt-5.6-sol".to_string(),
                 effort: Some("high".to_string()),
                 project: None,
+                plan: None,
                 input: 200_000,
                 cached: 0,
                 output: 0,
@@ -254,6 +273,7 @@ mod tests {
                 model: "gpt-4o".to_string(),
                 effort: Some("medium".to_string()),
                 project: None,
+                plan: None,
                 input: 1_000_000,
                 cached: 0,
                 output: 1_000_000,
@@ -290,6 +310,7 @@ mod tests {
                 model: "gpt-5.6-sol".to_string(),
                 effort: Some("high".to_string()),
                 project: None,
+                plan: None,
                 input: 200_000,
                 cached: 0,
                 output: 0,
@@ -300,6 +321,7 @@ mod tests {
                 model: "gpt-5.6-sol".to_string(),
                 effort: Some("high".to_string()),
                 project: None,
+                plan: None,
                 input: 200_000,
                 cached: 0,
                 output: 0,
@@ -310,6 +332,7 @@ mod tests {
                 model: "gpt-5.6-sol".to_string(),
                 effort: Some("high".to_string()),
                 project: None,
+                plan: None,
                 input: 200_000,
                 cached: 0,
                 output: 0,
@@ -336,6 +359,7 @@ mod tests {
             model: "gpt-mystery".to_string(),
             effort: None,
             project: None,
+            plan: None,
             input: 1_000_000,
             cached: 0,
             output: 1_000_000,
@@ -361,6 +385,48 @@ mod tests {
         assert_eq!(codex_effort_bucket(Some("   ")), "unknown");
     }
 
+    /// SOU-297: local logs carry no account identity, so `plan_type` is the
+    /// only signal that a machine's activity spans more than one account. A
+    /// rollout can switch plan mid-session, so attribution is per record.
+    #[test]
+    fn summary_splits_tokens_by_plan_and_keeps_undeclared_visible() {
+        let target = NaiveDate::from_ymd_opt(2026, 5, 31).unwrap();
+        let range = CostUsageDayRange::new(target, target);
+        let record = |plan: Option<&str>| CodexUsageRecord {
+            day_key: "2026-05-31".to_string(),
+            timestamp: None,
+            model: "gpt-5.6-sol".to_string(),
+            effort: None,
+            project: None,
+            plan: plan.map(str::to_string),
+            input: 100_000,
+            cached: 0,
+            output: 0,
+        };
+        let records = vec![
+            record(Some("prolite")),
+            record(Some("team")),
+            record(Some("prolite")),
+            record(None),
+        ];
+
+        let mut summary = CostSummary::default();
+        add_codex_records_to_summary(&mut summary, &records, &range);
+
+        let by_plan = &summary.by_plan_tokens;
+        assert_eq!(by_plan["prolite"].input_tokens, 200_000);
+        assert_eq!(by_plan["team"].input_tokens, 100_000);
+        assert_eq!(
+            by_plan[UNATTRIBUTED_PLAN].input_tokens, 100_000,
+            "a record with no declared plan must stay visible, not fold into a plan"
+        );
+        assert_eq!(
+            by_plan.values().map(|t| t.input_tokens).sum::<u64>(),
+            summary.input_tokens,
+            "the plan split must reconcile with the period total"
+        );
+    }
+
     #[test]
     fn summary_splits_cost_and_tokens_by_project() {
         let target = NaiveDate::from_ymd_opt(2026, 5, 31).unwrap();
@@ -371,6 +437,7 @@ mod tests {
             model: "gpt-5.6-sol".to_string(),
             effort: None,
             project: project.map(str::to_string),
+            plan: None,
             input: 200_000,
             cached: 0,
             output: 0,
@@ -404,6 +471,7 @@ mod tests {
             model: "gpt-mystery".to_string(),
             effort: None,
             project: None,
+            plan: None,
             input: 1_000_000,
             cached: 0,
             output: 0,

--- a/rust/src/core/jsonl_scanner.rs
+++ b/rust/src/core/jsonl_scanner.rs
@@ -76,6 +76,12 @@ pub struct CodexUsageRecord {
     /// Project/repo the session ran in (basename of the `session_meta` cwd).
     /// `None` when the log never declared a working directory.
     pub project: Option<String>,
+    /// Subscription plan reported by the provider when this delta was billed
+    /// (Codex `rate_limits.plan_type`, e.g. "plus"/"prolite"/"team"). `None`
+    /// when the log never declared one. This is the closest thing the logs
+    /// carry to an account, and it is only a proxy: two accounts on the same
+    /// plan look identical, and one account changing plans looks like two.
+    pub plan: Option<String>,
     pub input: i32,
     pub cached: i32,
     pub output: i32,
@@ -141,6 +147,10 @@ struct CodexParserState {
     /// Project/repo from the session's `session_meta` cwd, attached to each
     /// token delta so cost can be split by project.
     current_project: Option<String>,
+    /// Plan from the most recent `rate_limits`, attached to each token delta.
+    /// Carried forward within a rollout because a session can span a plan or
+    /// account switch and only some lines restate it.
+    current_plan: Option<String>,
     previous_totals: Option<CodexTotals>,
     records: Vec<CodexUsageRecord>,
     /// `Some` while suppressing a child session's replayed parent history.
@@ -173,6 +183,8 @@ struct CodexFastPayload<'a> {
     effort: Option<&'a str>,
     #[serde(default, borrow)]
     info: Option<CodexFastInfo<'a>>,
+    #[serde(default, borrow)]
+    rate_limits: Option<CodexFastRateLimits<'a>>,
     #[serde(default)]
     input_tokens: Option<i32>,
     #[serde(default)]
@@ -181,6 +193,14 @@ struct CodexFastPayload<'a> {
     cache_read_input_tokens: Option<i32>,
     #[serde(default)]
     output_tokens: Option<i32>,
+}
+
+/// Only the plan is read here. It is the closest thing Codex logs carry to an
+/// account, and the fast path would otherwise drop it.
+#[derive(Debug, Deserialize)]
+struct CodexFastRateLimits<'a> {
+    #[serde(default, borrow)]
+    plan_type: Option<&'a str>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -224,6 +244,7 @@ impl CodexParserState {
             current_model: initial_model,
             current_effort: None,
             current_project: None,
+            current_plan: None,
             previous_totals: initial_totals,
             records: Vec::new(),
             replay_gate: None,
@@ -363,6 +384,14 @@ impl CodexParserState {
             return;
         };
 
+        if let Some(plan) = payload
+            .get("rate_limits")
+            .and_then(|limits| limits.get("plan_type"))
+            .and_then(|plan| plan.as_str())
+            .filter(|plan| !plan.trim().is_empty())
+        {
+            self.current_plan = Some(plan.to_string());
+        }
         let info = payload.get("info");
         let model = self.token_model(info, payload, obj);
         let timestamp = obj
@@ -397,6 +426,14 @@ impl CodexParserState {
         }
         if delta_input == 0 && delta_cached == 0 && delta_output == 0 {
             return;
+        }
+        if let Some(plan) = payload
+            .rate_limits
+            .as_ref()
+            .and_then(|limits| limits.plan_type)
+            .filter(|plan| !plan.trim().is_empty())
+        {
+            self.current_plan = Some(plan.to_string());
         }
         let Some(day_key) = codex_timestamp_day_key(timestamp) else {
             return;
@@ -441,6 +478,7 @@ impl CodexParserState {
             model: CostUsagePricing::normalize_codex_model(model),
             effort: self.current_effort.clone(),
             project: self.current_project.clone(),
+            plan: self.current_plan.clone(),
             input,
             cached: cached.min(input),
             output,

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -46,6 +46,11 @@ pub struct CostSummary {
     pub by_effort: HashMap<String, f64>,
     /// Codex token split by reasoning-effort tier, matching `by_effort`.
     pub by_effort_tokens: HashMap<String, ModelTokenCounts>,
+    /// Token split by the subscription plan in force when each delta was
+    /// billed, keyed "unattributed" when the log never declared one. Local
+    /// logs carry no account identity, so this is the only signal that a
+    /// machine's activity spans more than one account.
+    pub by_plan_tokens: HashMap<String, ModelTokenCounts>,
     /// Cost split by project/repo (basename of the session `cwd`); keyed
     /// "unknown" when the log has no usable working directory.
     pub by_project: HashMap<String, f64>,
@@ -1159,6 +1164,13 @@ fn merge_summary(target: &mut CostSummary, source: &CostSummary) {
     }
     for (effort, cost) in &source.by_effort {
         *target.by_effort.entry(effort.clone()).or_insert(0.0) += cost;
+    }
+    for (plan, tokens) in &source.by_plan_tokens {
+        target
+            .by_plan_tokens
+            .entry(plan.clone())
+            .or_default()
+            .merge_from(tokens);
     }
     for (effort, tokens) in &source.by_effort_tokens {
         target


### PR DESCRIPTION
Step 1 of the multi-account work (<issue>SOU-297</issue>, now a child of <issue>SOU-285</issue>).

## What the logs actually contain

Investigated 97 real Codex rollouts plus a Claude sample:

- **Codex** `session_meta`: `session_id`, `cwd`, `originator`, `cli_version`, `model_provider`, `git` — **no email, account id, or org**. The only `user`/`email` hits anywhere were GitHub MCP tool output embedded in conversations.
- **Claude** JSONL: `parentUuid`, `agentId`, `cwd`, `sessionId`, `gitBranch`, `userType` — also no identity, and **no plan field at all**.

So activity cannot be split by account from log content, for any provider. Pairing one account's quota with every log on the machine overstates it.

## What this does

Codex emits `rate_limits.plan_type` on `token_count` events — the only available proxy. Each token delta now carries the plan in force when it was billed, carried forward within a rollout (a session can span a switch — 3 of the 97 do), and bucketed `unattributed` when a rollout never declares one. The Charts page discloses when totals span more than one plan.

**Measured on the maintainer's machine: `prolite` 73.9%, `team` 19.1%, `plus` 7.0%** — about a quarter of what was presented as one account's usage was not.

## Why disclosure and not a filter

The plan is wrong in **both** directions, and the maintainer's own setup proves it: `prolite` and `plus` are the *same* account after a $20 → $100 upgrade, while `team` is genuinely different. Filtering to the current plan would silently delete their own history.

I tested both automatic ways to tell those apart and **both fail**:
- **Timing:** `plus` (Jul 7–13) and `prolite` (Jul 10–21) **overlap**, so "sequential = upgrade" is dead.
- **Path:** `C:\projects` is used by **all three** plans, so cwd can't separate work from personal.

Choosing for the user would be a guess. The totals stay whole and say what they contain.

## One thing worth knowing

Capture had to be added to the **fast parse path** as well as the full one. The fast path skips the `serde_json::Value` parse entirely and is what real logs take — declaring `rate_limits` only on the slow path left **100% of real records unattributed**. Caught by running the scanner against real logs; the unit test alone passed because it constructed records with the plan pre-set.

## Tests
- `summary_splits_tokens_by_plan_and_keeps_undeclared_visible` — per-record attribution, mid-rollout switch, `unattributed` stays visible, and the split reconciles with the period total.
- End-to-end validated against 97 real rollouts (throwaway harness, not committed).
- Disclosure rendered against the real stylesheet before shipping.

Shared 659 passed, desktop 395 passed, frontend 278 passed. Clippy `-D warnings` clean on both crates, fmt and `tsc --noEmit` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usage charts now show token activity grouped by subscription plan.
  * Added a warning when local usage includes multiple plans or accounts, clarifying that totals may not represent only the signed-in account.
  * Plan details are captured from usage records, including unattributed activity.

* **Style**
  * Added highlighted styling for the multi-plan usage notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->