### PR TITLE
Learn the plan before the zero-delta exit, and stop implying account count

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -91,7 +91,8 @@ pub struct ProviderLocalUsageSummary {
     #[serde(default)]
     pub effort_breakdown: Vec<LocalEffortCost>,
     /// Plans observed in local logs for the 30-day period, largest first.
-    /// More than one entry means the total spans multiple accounts.
+    /// More than one entry means the total is not account-scoped; it spans
+    /// several plans, which may or may not be several accounts.
     #[serde(default)]
     pub plan_breakdown: Vec<LocalPlanUsage>,
     /// Per-project/repo spend over the 30-day period, sorted by cost then
@@ -237,7 +238,7 @@ pub struct LocalEffortCost {
 /// Codex emits, and it is imperfect: two accounts on the same plan look
 /// identical, and one account changing plans looks like two. It exists so the
 /// UI can disclose that a total is not account-scoped, never to silently
-/// filter one out.
+/// filter one out and never to assert how many accounts produced it.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct LocalPlanUsage {

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -120,27 +120,41 @@ function formatUsd(value: number): string {
   }).format(value);
 }
 
+/** Backend bucket for records whose rollout never declared a plan. */
+const UNATTRIBUTED_PLAN = "unattributed";
+
 /**
- * Disclose when local activity spans more than one subscription plan.
+ * Disclose that these totals are not account-scoped.
  *
- * Local logs carry no account identity for any provider, so a machine's totals
- * can cover several accounts with no way to separate them. The plan is the only
- * proxy Codex emits, and it is imperfect in both directions: two accounts on one
- * plan look identical, and one account changing plans looks like two. So this
- * states what was observed and does not filter anything out.
+ * Local logs record the plan but never the account, for any provider. So more
+ * than one plan proves the totals cover more than one plan - NOT that they came
+ * from someone else's account. One account changing plans looks exactly the
+ * same. The copy therefore states the limitation and what was observed, and
+ * stops short of naming accounts.
+ *
+ * `unattributed` is a bucket, not a plan, so it can never trigger this on its
+ * own: one plan plus some unlabeled records is still one plan.
  */
 function MultiPlanNotice({ plans }: { plans?: LocalPlanUsage[] | null }) {
-  if (!plans || plans.length < 2) return null;
+  if (!plans || plans.length === 0) return null;
+  const named = plans.filter((plan) => plan.plan !== UNATTRIBUTED_PLAN);
+  if (named.length < 2) return null;
+
   const total = plans.reduce((sum, plan) => sum + plan.tokens, 0);
   if (total <= 0) return null;
-  const share = (tokens: number) => Math.round((tokens / total) * 100);
+  const share = (tokens: number) => {
+    const percent = (tokens / total) * 100;
+    return percent < 1 ? "<1%" : `${Math.round(percent)}%`;
+  };
+  const unlabeled = plans.find((plan) => plan.plan === UNATTRIBUTED_PLAN);
+
   return (
     <p className="usage-periods__note usage-periods__note--warn" role="note">
       <span>
-        These totals cover <strong>{plans.length} plans</strong> seen on this
-        machine ({plans.map((p) => `${p.plan} ${share(p.tokens)}%`).join(", ")}),
-        not just the signed-in account. Local logs do not record which account
-        produced them.
+        These totals are <strong>not account-scoped</strong>. Local logs record
+        the plan but not the account, and this machine shows{" "}
+        {named.length} plans ({named.map((p) => `${p.plan} ${share(p.tokens)}`).join(", ")}
+        {unlabeled ? `, unlabeled ${share(unlabeled.tokens)}` : ""}).
       </span>
     </p>
   );

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -635,7 +635,8 @@ export interface ProviderLocalUsageSummary {
   topModel: string | null;
   modelBreakdown?: LocalModelCost[];
   effortBreakdown?: LocalEffortCost[];
-  /** Plans seen in local logs. More than one means the total spans accounts. */
+  /** Plans seen in local logs. More than one means the total is not
+   *  account-scoped; it spans several plans, not necessarily several accounts. */
   planBreakdown?: LocalPlanUsage[];
   projectBreakdown?: LocalProjectCost[];
   estimateNote: string;

--- a/rust/src/core/jsonl_scanner.rs
+++ b/rust/src/core/jsonl_scanner.rs
@@ -239,6 +239,10 @@ enum CodexFastEvent<'a> {
 }
 
 impl CodexParserState {
+    /// Note for anyone enabling incremental (non-zero offset) parsing here:
+    /// the plan would need seeding alongside the model and totals, or a resumed
+    /// parse would attribute its first records to `unattributed` until the next
+    /// line that restates `rate_limits`. Every caller passes offset 0 today.
     fn new(initial_model: Option<String>, initial_totals: Option<CodexTotals>) -> Self {
         Self {
             current_model: initial_model,
@@ -377,13 +381,11 @@ impl CodexParserState {
         if self.replay_gate.is_some() {
             return;
         }
-        if delta_input == 0 && delta_cached == 0 && delta_output == 0 {
-            return;
-        }
-        let Some(day_key) = codex_line_day_key(obj, range) else {
-            return;
-        };
-
+        // Learn the plan before the zero-delta and range exits below. A
+        // token_count can announce a new plan while billing nothing, and
+        // returning first would attribute the next billed record to the
+        // previous plan. Kept after the replay gate so a child's replayed
+        // parent history cannot install a stale plan.
         if let Some(plan) = payload
             .get("rate_limits")
             .and_then(|limits| limits.get("plan_type"))
@@ -392,6 +394,13 @@ impl CodexParserState {
         {
             self.current_plan = Some(plan.to_string());
         }
+        if delta_input == 0 && delta_cached == 0 && delta_output == 0 {
+            return;
+        }
+        let Some(day_key) = codex_line_day_key(obj, range) else {
+            return;
+        };
+
         let info = payload.get("info");
         let model = self.token_model(info, payload, obj);
         let timestamp = obj
@@ -424,9 +433,7 @@ impl CodexParserState {
         if self.replay_gate.is_some() {
             return;
         }
-        if delta_input == 0 && delta_cached == 0 && delta_output == 0 {
-            return;
-        }
+        // See the slow path: a zero-delta line can still announce the plan.
         if let Some(plan) = payload
             .rate_limits
             .as_ref()
@@ -434,6 +441,9 @@ impl CodexParserState {
             .filter(|plan| !plan.trim().is_empty())
         {
             self.current_plan = Some(plan.to_string());
+        }
+        if delta_input == 0 && delta_cached == 0 && delta_output == 0 {
+            return;
         }
         let Some(day_key) = codex_timestamp_day_key(timestamp) else {
             return;
@@ -1186,6 +1196,49 @@ mod tests {
         assert_eq!(record.day_key, "2026-05-31");
         assert_eq!(record.model, "gpt-5.5");
         assert_eq!((record.input, record.cached, record.output), (45, 12, 8));
+    }
+
+    /// SOU-297: a `token_count` can announce a new plan while billing nothing.
+    /// If the plan is only read after the zero-delta exit, the next billed
+    /// record inherits the previous plan and the switch is invisible.
+    #[test]
+    fn zero_delta_plan_switch_still_attributes_the_next_billed_record() {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        // `total_token_usage` is cumulative, so an unchanged total is a line
+        // that reports state without billing anything. That is how a plan
+        // switch can be announced with no usage attached.
+        writeln!(
+            file,
+            r#"{{"timestamp":"2026-05-31T10:00:00.000Z","type":"event_msg","payload":{{"type":"token_count","rate_limits":{{"plan_type":"plus"}},"info":{{"total_token_usage":{{"input_tokens":100,"cached_input_tokens":0,"output_tokens":10}}}}}}}}"#
+        )
+        .unwrap();
+        // Announces the switch; totals unchanged, so it bills nothing.
+        writeln!(
+            file,
+            r#"{{"timestamp":"2026-05-31T10:00:01.000Z","type":"event_msg","payload":{{"type":"token_count","rate_limits":{{"plan_type":"team"}},"info":{{"total_token_usage":{{"input_tokens":100,"cached_input_tokens":0,"output_tokens":10}}}}}}}}"#
+        )
+        .unwrap();
+        // Bills again, carrying no rate_limits of its own.
+        writeln!(
+            file,
+            r#"{{"timestamp":"2026-05-31T10:00:02.000Z","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":250,"cached_input_tokens":0,"output_tokens":30}}}}}}}}"#
+        )
+        .unwrap();
+
+        let range = CostUsageDayRange::new(
+            NaiveDate::from_ymd_opt(2026, 5, 31).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 5, 31).unwrap(),
+        );
+        let parsed =
+            JsonlScanner::parse_codex_file(file.path(), &range, 0, None, None).expect("parse");
+
+        assert_eq!(parsed.records.len(), 2, "the zero-delta line bills nothing");
+        assert_eq!(parsed.records[0].plan.as_deref(), Some("plus"));
+        assert_eq!(
+            parsed.records[1].plan.as_deref(),
+            Some("team"),
+            "the plan announced by the zero-delta line must carry forward"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Addresses both CodeRabbit findings on #97. Both were legitimate.

## 1. Data integrity: plan lost on a zero-delta line (Major)

A `token_count` can announce a new plan while billing nothing. The plan was read **after** the zero-delta and day-range returns, so such a line exited first and the next billed record inherited the **previous** plan.

Capture now happens in **both** parse paths immediately after the replay gate, before any early return. Deliberately still after the gate, so a child session's replayed parent history cannot install a stale plan.

Regression test `zero_delta_plan_switch_still_attributes_the_next_billed_record`: a line that announces `team` with unchanged cumulative totals, followed by a billed delta carrying no `rate_limits`, must attribute to `team`.

My first attempt at that fixture was wrong — I used `last_token_usage` (a per-request delta) where the zero-delta case needs `total_token_usage` (cumulative). The test failed loudly, which is what it's for.

## 2. Correctness: the notice inferred account identity (Minor)

The copy said "not just the signed-in account", which infers accounts from plan buckets — the exact overclaim this work exists to prevent. Several plans prove several **plans**. One account changing plans looks identical, as on this machine where `prolite` and `plus` are one account after an upgrade.

Now reads: *These totals are **not account-scoped**. Local logs record the plan but not the account, and this machine shows 3 plans (…).* Backend and bridge docs aligned.

## Two edge cases found while checking the rest

- **`unattributed` could falsely trigger the notice.** It's a bucket, not a plan, so one plan plus unlabeled records would have rendered "2 plans". It can no longer trigger alone, and shows as "unlabeled" when it accompanies a real split. Sub-1% shares render "<1%" instead of "0%".
- **Incremental parsing would drop the plan on resume** — state seeds model and totals but not plan. Every caller passes offset 0 today so nothing is broken; noted at the seam so enabling it later doesn't silently lose attribution.

Verified both notice states render against the real stylesheet. Shared 660 passed, desktop 395, frontend 278. Clippy `-D warnings`, fmt, tsc all clean.