### PR TITLE
Prepare Ceiling 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Ceiling] 1.5.0 - 2026-07-22
+
+### Added
+- Track more than one Codex or Claude account and switch between which one Ceiling watches, from a new Accounts tab. An account is a config directory (`CODEX_HOME` for Codex, `CLAUDE_CONFIG_DIR` for Claude) rather than a token you paste, because each CLI refreshes its own sign-in in place and a copy would stop working within hours. Sign a second account in with `CODEX_HOME=<path> codex login`, point Ceiling at that folder, and it reads the name and plan off the folder itself so there is nothing to type. Adding an account checks the folder first and tells you whose account is in it before you commit.
+- Name the account each provider card is reporting, with an optional color so several accounts stay easy to tell apart at a glance.
+- Ceiling keeps following whichever account your CLI is signed in as until you add accounts yourself, so nothing changes if you only have one.
+
+### Fixed
+- Tell you about a reset that happened while Ceiling was closed. Resets found on the first check after starting up were being absorbed silently to avoid announcing stale news as if it had just happened, which meant an overnight reset was never mentioned at all. These now say when they actually happened, for example "This happened at 2:00 AM, while Ceiling was closed".
+- Read the right Claude sign-in when `CLAUDE_CONFIG_DIR` is set. Ceiling already read that folder's history but always took credentials from the default location, so anyone using a second Claude profile was seeing the wrong account's numbers.
+- Stop two accounts on one provider sharing a single usage baseline. Codex and Claude readings did not record which account they came from, so switching accounts would have carried the previous one's history across.
+- Stop the usage chart falling back to another account's history. A newly added account has nothing recorded yet, and the chart filled that gap with whichever account had data most recently.
+- Keep both accounts' sign-ins cached when tracking more than one Codex account, instead of each check evicting the other.
+
 ## [Ceiling] 1.4.0 - 2026-07-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,7 +664,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexbar"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "codexbar-desktop-tauri"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop-tauri",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.5.0",
   "packageManager": "pnpm@10.18.1",
   "type": "module",
   "scripts": {

--- a/apps/desktop-tauri/src-tauri/Cargo.toml
+++ b/apps/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexbar-desktop-tauri"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 publish = false
 

--- a/apps/desktop-tauri/src-tauri/tauri.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ceiling",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "identifier": "io.github.tsouth89.ceiling",
   "build": {
     "beforeDevCommand": "pnpm run dev",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexbar"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 authors = ["Ceiling Contributors"]
 description = "Local-first Windows companion for monitoring AI capacity and reset times"


### PR DESCRIPTION
Version bump and changelog for 1.5.0.

Ships three merged changes:
- **#103** — multi-account switching for Codex and Claude (SOU-285 phase 1), plus the attribution ledger (SOU-297)
- **#105** — report resets that happened while Ceiling was closed (SOU-307)
- **#106** — stop the quota chart falling back to another account's history

## Not verified before release

Two things a human should check, because I could not:

1. **The Accounts tab has never been looked at.** Layout was verified by measuring computed styles and geometry (the browser pane hangs on screenshot in this environment), so spacing, color and whether the check-then-add flow reads clearly are unconfirmed.
2. **The multi-account path has not been run end to end.** Creating a second `CODEX_HOME`, signing in, and switching is the one flow that exercises cache eviction, re-baselining and the ledger together.

## Deliberately not in this release

Per-account grouping for local token and cost totals is [SOU-308](https://linear.app/southforge-ai/issue/SOU-308/group-local-activity-tokens-and-cost-by-account-in-charts). The ledger only started recording when #103 merged, so every existing record attributes to "Before tracking" and the chart would render one bucket. It needs accumulated data before the UI can be judged.

Quota history is already per-account and does ship here.