### PR TITLE
Allow the account commands through the ACL (1.5.0 blocker)

### DIFF
--- a/apps/desktop-tauri/src-tauri/permissions/commands.toml
+++ b/apps/desktop-tauri/src-tauri/permissions/commands.toml
@@ -49,6 +49,15 @@ commands.allow = [
   "add_token_account",
   "remove_token_account",
   "set_active_token_account",
+  # Config-directory accounts (SOU-285). Registering a command in the invoke
+  # handler is not enough; it must be allowed here too, or every call fails at
+  # runtime with "not allowed by ACL".
+  "get_directory_accounts",
+  "probe_account_directory",
+  "add_directory_account",
+  "remove_directory_account",
+  "set_active_directory_account",
+  "update_directory_account",
   "get_app_info",
   "get_provider_chart_data",
   "get_provider_local_usage_summary",

--- a/apps/desktop-tauri/src-tauri/src/main.rs
+++ b/apps/desktop-tauri/src-tauri/src/main.rs
@@ -404,6 +404,53 @@ fn main() {
 mod tests {
     use super::*;
 
+    /// Every command in `generate_handler!` must also be allowed in
+    /// `permissions/commands.toml`.
+    ///
+    /// Registering a command without allowlisting it compiles, passes every
+    /// other test, and then fails at runtime with "not allowed by ACL" the
+    /// moment a user opens the surface that calls it. That shipped once: all six
+    /// config-directory account commands were registered but not allowed, so the
+    /// entire Accounts tab rendered an error in 1.5.0.
+    #[test]
+    fn every_registered_command_is_allowed_by_the_acl() {
+        const MAIN_RS: &str = include_str!("main.rs");
+        const COMMANDS_TOML: &str = include_str!("../permissions/commands.toml");
+
+        let handler = MAIN_RS
+            .split_once("tauri::generate_handler![")
+            .expect("invoke handler")
+            .1
+            .split_once("])")
+            .expect("end of handler")
+            .0;
+
+        let registered: Vec<&str> = handler
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with("//"))
+            .filter_map(|line| line.trim_end_matches(',').rsplit("::").next())
+            .filter(|name| !name.is_empty())
+            .collect();
+
+        assert!(
+            registered.len() > 30,
+            "parsed too few commands ({}); the handler format probably changed              and this test is no longer checking anything",
+            registered.len()
+        );
+
+        let missing: Vec<&str> = registered
+            .iter()
+            .copied()
+            .filter(|name| !COMMANDS_TOML.contains(&format!("\"{name}\"")))
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "these commands are registered but not allowed in              permissions/commands.toml, so calling them fails at runtime: {missing:?}"
+        );
+    }
+
     #[test]
     fn close_request_hides_tray_first_surfaces() {
         assert!(should_hide_close_request(SurfaceMode::TrayPanel));

--- a/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.tsx
@@ -236,6 +236,12 @@ function ProviderAccounts({ provider, busy, onRun }: ProviderProps) {
         </ul>
       )}
 
+      <p className="settings-section__hint accounts-setup-hint">
+        {t("AccountsSetupHint")}{" "}
+        <code className="accounts-path">
+          {provider.envVar}=&lt;path&gt; {cli} login
+        </code>
+      </p>
       <div className="credential-add-form accounts-add">
         <input
           className="text-input"
@@ -287,12 +293,6 @@ function ProviderAccounts({ provider, busy, onRun }: ProviderProps) {
         )}
       </div>
 
-      <p className="settings-section__hint accounts-setup-hint">
-        {t("AccountsSetupHint")}{" "}
-        <code className="accounts-path">
-          {provider.envVar}=&lt;path&gt; {cli} login
-        </code>
-      </p>
     </div>
   );
 }


### PR DESCRIPTION
**The Accounts tab is dead in the 1.5.0 draft.** Found by installing the build and opening it:

> Command `get_directory_accounts` not allowed by ACL

All six config-directory account commands were registered in `generate_handler!` but never added to `permissions/commands.toml`, so every call is rejected and the panel renders only that error.

## Why nothing caught it

It compiles. All 1117 tests passed. Tauri's ACL is a separate allowlist from command registration, and nothing tied the two together.

So the second half of this PR is a test asserting **every command in `generate_handler!` is allowed in `commands.toml`**. I verified it fails without the fix and names the offending command:

```
these commands are registered but not allowed in permissions/commands.toml,
so calling them fails at runtime: ["get_directory_accounts"]
```

It also guards against the handler format changing out from under it — if it parses fewer than 30 commands it fails rather than silently checking nothing.

## Also

The terminal step now comes **above** the add form. A second account has to exist before Ceiling can be pointed at it, and creating one happens in a terminal, so putting those instructions after the form had the order backwards.

## Not done

I briefly moved the whole panel into Providers → detail pane, on the theory that the tab was undiscoverable. That was wrong — the tab was found immediately, it just showed an error. Reverted; the only real problem was the ACL.

Blocks publishing 1.5.0.