### PR TITLE
Show the sign-in command in PowerShell syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Ceiling] 1.5.0 - 2026-07-22
 
 ### Added
-- Track more than one Codex or Claude account and switch between which one Ceiling watches, from a new Accounts tab. An account is a config directory (`CODEX_HOME` for Codex, `CLAUDE_CONFIG_DIR` for Claude) rather than a token you paste, because each CLI refreshes its own sign-in in place and a copy would stop working within hours. Sign a second account in with `CODEX_HOME=<path> codex login`, point Ceiling at that folder, and it reads the name and plan off the folder itself so there is nothing to type. Adding an account checks the folder first and tells you whose account is in it before you commit.
+- Track more than one Codex or Claude account and switch between which one Ceiling watches, from a new Accounts tab. An account is a config directory (`CODEX_HOME` for Codex, `CLAUDE_CONFIG_DIR` for Claude) rather than a token you paste, because each CLI refreshes its own sign-in in place and a copy would stop working within hours. Sign a second account in with `$env:CODEX_HOME="<path>"; codex login`, point Ceiling at that folder, and it reads the name and plan off the folder itself so there is nothing to type. Adding an account checks the folder first and tells you whose account is in it before you commit.
 - Name the account each provider card is reporting, with an optional color so several accounts stay easy to tell apart at a glance.
 - Ceiling keeps following whichever account your CLI is signed in as until you add accounts yourself, so nothing changes if you only have one.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Ceiling] 1.5.0 - 2026-07-22
 
 ### Added
-- Track more than one Codex or Claude account and switch between which one Ceiling watches, from a new Accounts tab. An account is a config directory (`CODEX_HOME` for Codex, `CLAUDE_CONFIG_DIR` for Claude) rather than a token you paste, because each CLI refreshes its own sign-in in place and a copy would stop working within hours. Sign a second account in with `$env:CODEX_HOME="<path>"; codex login`, point Ceiling at that folder, and it reads the name and plan off the folder itself so there is nothing to type. Adding an account checks the folder first and tells you whose account is in it before you commit.
+- Track more than one Codex or Claude account and switch between which one Ceiling watches, from a new Accounts tab. An account is a config directory (`CODEX_HOME` for Codex, `CLAUDE_CONFIG_DIR` for Claude) rather than a token you paste, because each CLI refreshes its own sign-in in place and a copy would stop working within hours. Sign a second account in with `mkdir "<path>"; $env:CODEX_HOME="<path>"; codex login`, point Ceiling at that folder, and it reads the name and plan off the folder itself so there is nothing to type. Adding an account checks the folder first and tells you whose account is in it before you commit.
 - Name the account each provider card is reporting, with an optional color so several accounts stay easy to tell apart at a glance.
 - Ceiling keeps following whichever account your CLI is signed in as until you add accounts yourself, so nothing changes if you only have one.
 

--- a/apps/desktop-tauri/src/i18n/keys.ts
+++ b/apps/desktop-tauri/src/i18n/keys.ts
@@ -611,6 +611,7 @@ export const ALL_LOCALE_KEYS = [
   "AccountsCheckButton",
   "AccountsAddButton",
   "AccountsProbeSignedOut",
+  "AccountsProbeMissing",
   "AccountsProbeAlreadyAdded",
   "AccountsSetupHint",
   "AccountsTint",

--- a/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.tsx
@@ -239,7 +239,8 @@ function ProviderAccounts({ provider, busy, onRun }: ProviderProps) {
       <p className="settings-section__hint accounts-setup-hint">
         {t("AccountsSetupHint")}{" "}
         <code className="accounts-path">
-          $env:{provider.envVar}=&quot;&lt;path&gt;&quot;; {cli} login
+          mkdir &quot;&lt;path&gt;&quot;; $env:{provider.envVar}=&quot;&lt;path&gt;&quot;;{" "}
+          {cli} login
         </code>
       </p>
       <div className="credential-add-form accounts-add">
@@ -286,9 +287,11 @@ function ProviderAccounts({ provider, busy, onRun }: ProviderProps) {
           <p className="credential-card__meta accounts-probe">
             {probe.alreadyAddedAs
               ? `${t("AccountsProbeAlreadyAdded")} ${probe.alreadyAddedAs}`
-              : probe.signedIn
-                ? (probe.suggestedLabel ?? probe.configDir)
-                : t("AccountsProbeSignedOut")}
+              : !probe.exists
+                ? t("AccountsProbeMissing")
+                : probe.signedIn
+                  ? (probe.suggestedLabel ?? probe.configDir)
+                  : t("AccountsProbeSignedOut")}
           </p>
         )}
       </div>

--- a/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.tsx
@@ -239,7 +239,7 @@ function ProviderAccounts({ provider, busy, onRun }: ProviderProps) {
       <p className="settings-section__hint accounts-setup-hint">
         {t("AccountsSetupHint")}{" "}
         <code className="accounts-path">
-          {provider.envVar}=&lt;path&gt; {cli} login
+          $env:{provider.envVar}=&quot;&lt;path&gt;&quot;; {cli} login
         </code>
       </p>
       <div className="credential-add-form accounts-add">

--- a/rust/src/locale.rs
+++ b/rust/src/locale.rs
@@ -852,6 +852,7 @@ locale_keys! {
     AccountsCheckButton,
     AccountsAddButton,
     AccountsProbeSignedOut,
+    AccountsProbeMissing,
     AccountsProbeAlreadyAdded,
     AccountsSetupHint,
     AccountsTint,

--- a/rust/src/locale/en-US.ftl
+++ b/rust/src/locale/en-US.ftl
@@ -645,5 +645,5 @@ AccountsCheckButton = Check
 AccountsAddButton = Add
 AccountsProbeSignedOut = No account is signed in there yet.
 AccountsProbeAlreadyAdded = Already added as
-AccountsSetupHint = To sign a second account into its own directory, run this in a terminal:
+AccountsSetupHint = To sign a second account into its own directory, run this in PowerShell, then paste that path below:
 AccountsTint = Accent color

--- a/rust/src/locale/en-US.ftl
+++ b/rust/src/locale/en-US.ftl
@@ -644,6 +644,7 @@ AccountsLabelPlaceholder = Label (optional, read from the directory)
 AccountsCheckButton = Check
 AccountsAddButton = Add
 AccountsProbeSignedOut = No account is signed in there yet.
+AccountsProbeMissing = That folder does not exist yet. Create it and sign in first.
 AccountsProbeAlreadyAdded = Already added as
 AccountsSetupHint = To sign a second account into its own directory, run this in PowerShell, then paste that path below:
 AccountsTint = Accent color


### PR DESCRIPTION
The Accounts tab told people to run:

```
CODEX_HOME=<path> codex login
```

Ceiling is a Windows application, so that is the one shell where the instruction cannot work. PowerShell has no inline environment-variable prefix and treats the line as a parse error.

Now:

```powershell
$env:CODEX_HOME="<path>"; codex login
```

It also names PowerShell explicitly, so there is no ambiguity about where to run it. Same correction in the 1.5.0 changelog entry.

Found by walking through the setup as a user would. No test would have caught it: the string was rendered correctly, it was just wrong for the platform Ceiling ships on.