### PR TITLE
Describe 1.5.0 accounts as simultaneous, not a switcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 ## [Ceiling] 1.5.0 - 2026-07-22
 
 ### Added
-- Track more than one Codex or Claude account and switch between which one Ceiling watches, from a new Accounts tab. An account is a config directory (`CODEX_HOME` for Codex, `CLAUDE_CONFIG_DIR` for Claude) rather than a token you paste, because each CLI refreshes its own sign-in in place and a copy would stop working within hours. Sign a second account in with `mkdir "<path>"; $env:CODEX_HOME="<path>"; codex login`, point Ceiling at that folder, and it reads the name and plan off the folder itself so there is nothing to type. Adding an account checks the folder first and tells you whose account is in it before you commit.
+- Track more than one Codex or Claude account at the same time, from a new Accounts tab. Both accounts show side by side rather than one replacing the other, so you can watch a personal and a work seat at once. An account is a config directory (`CODEX_HOME` for Codex, `CLAUDE_CONFIG_DIR` for Claude) rather than a token you paste, because each CLI refreshes its own sign-in in place and a copy would stop working within hours. Sign a second account in with `mkdir "<path>"; $env:CODEX_HOME="<path>"; codex login`, point Ceiling at that folder, and it reads the name and plan off the folder itself so there is nothing to type. Adding an account checks the folder first and tells you whose account is in it before you commit.
 - Name the account each provider card is reporting, with an optional color so several accounts stay easy to tell apart at a glance.
 - Ceiling keeps following whichever account your CLI is signed in as until you add accounts yourself, so nothing changes if you only have one.
+
+### Removed
+- Remove the tray icon mode and merge tray icons settings. Neither had any effect: Ceiling has always drawn a single tray icon and nothing ever read those values.
 
 ### Fixed
 - Tell you about a reset that happened while Ceiling was closed. Resets found on the first check after starting up were being absorbed silently to avoid announcing stale news as if it had just happened, which meant an overnight reset was never mentioned at all. These now say when they actually happened, for example "This happened at 2:00 AM, while Ceiling was closed".


### PR DESCRIPTION
The 1.5.0 entry said accounts let you "switch between which one Ceiling watches". That was accurate for phase 1 and is wrong now that #112 makes them additive: both accounts show side by side.

Also adds a Removed section for `tray_icon_mode` and `merge_tray_icons`, which never had any effect.

Release notes are what users actually read, so this needs to land before the tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified multi-account support in the Accounts tab, including side-by-side Codex and Claude accounts.
  - Documented continued tracking of the CLI’s signed-in account until additional accounts are added.
  - Added details about optional account naming and colors per provider.
  - Noted the removal and consolidation of the ineffective tray icon mode setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->