### PR TITLE
Merge provider readings by account, so both accounts reach the UI

### DIFF
--- a/apps/desktop-tauri/src/hooks/useProviders.test.tsx
+++ b/apps/desktop-tauri/src/hooks/useProviders.test.tsx
@@ -74,6 +74,50 @@ describe("useProviders", () => {
     );
   });
 
+  it("keeps both accounts of one provider instead of the last one winning", async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useProviders());
+
+    const personal = { ...provider("codex", 12), accountId: "acct-personal" };
+    const work = { ...provider("codex", 88), accountId: "acct-work" };
+
+    // Both land inside the same 80ms flush window, which is what happens on a
+    // real refresh: the fan-out fetches every account concurrently.
+    act(() => {
+      emitProviderEvent("provider-updated", personal);
+      emitProviderEvent("provider-updated", work);
+      vi.advanceTimersByTime(100);
+    });
+
+    const ids = result.current.providers.map((p) => p.accountId).sort();
+    expect(ids).toEqual(["acct-personal", "acct-work"]);
+    vi.useRealTimers();
+  });
+
+  it("still replaces a reading of the same account rather than duplicating it", async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useProviders());
+
+    act(() => {
+      emitProviderEvent("provider-updated", {
+        ...provider("codex", 12),
+        accountId: "acct-work",
+      });
+      vi.advanceTimersByTime(100);
+    });
+    act(() => {
+      emitProviderEvent("provider-updated", {
+        ...provider("codex", 44),
+        accountId: "acct-work",
+      });
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current.providers).toHaveLength(1);
+    expect(result.current.providers[0].primary?.usedPercent).toBe(44);
+    vi.useRealTimers();
+  });
+
   it("uses stale-aware refresh on mount", async () => {
     renderHook(() => useProviders());
 

--- a/apps/desktop-tauri/src/hooks/useProviders.ts
+++ b/apps/desktop-tauri/src/hooks/useProviders.ts
@@ -5,6 +5,7 @@ import type {
   RefreshCompletePayload,
   RefreshStartedPayload,
 } from "../types/bridge";
+import { providerRowKey } from "../lib/providerRow";
 import {
   getCachedProviders,
   refreshProviders,
@@ -77,13 +78,19 @@ export function useProviders(options: UseProvidersOptions = {}): UseProvidersRes
     if (snapshots.length === 0) return;
     setProviders((prev) => {
       const next = [...prev];
-      const byId = new Map(next.map((provider, index) => [provider.providerId, index]));
+      // Keyed by provider *and* account. Keying on provider alone meant a
+      // provider's second account replaced its first here, so only one of two
+      // configured accounts ever reached the UI.
+      const byRow = new Map(
+        next.map((provider, index) => [providerRowKey(provider), index]),
+      );
       for (const snapshot of snapshots) {
-        const idx = byId.get(snapshot.providerId);
+        const rowKey = providerRowKey(snapshot);
+        const idx = byRow.get(rowKey);
         if (idx !== undefined) {
           next[idx] = snapshot;
         } else {
-          byId.set(snapshot.providerId, next.length);
+          byRow.set(rowKey, next.length);
           next.push(snapshot);
         }
       }
@@ -102,7 +109,10 @@ export function useProviders(options: UseProvidersOptions = {}): UseProvidersRes
   }, [mergeSnapshots]);
 
   const queueSnapshot = useCallback((snapshot: ProviderUsageSnapshot) => {
-    pendingSnapshotsRef.current.set(snapshot.providerId, snapshot);
+    // Both accounts of a provider land inside the same 80ms flush window, so
+    // this queue must key by account too or the second silently discards the
+    // first before it is ever merged.
+    pendingSnapshotsRef.current.set(providerRowKey(snapshot), snapshot);
     if (settingsReloadingRef.current || flushTimerRef.current !== undefined) return;
     flushTimerRef.current = window.setTimeout(flushPendingSnapshots, 80);
   }, [flushPendingSnapshots]);


### PR DESCRIPTION
**This is why two accounts still showed as either/or.**

The backend was fine: it fetched both accounts, cached them under separate keys, and `get_cached_providers` returned both. `useProviders` then threw one away before anything rendered.

Two places, both keyed by provider id alone:

- **The pending-snapshot queue** is a `Map` keyed by provider (`useProviders.ts:105`). A refresh fans out over every account concurrently, so both readings land inside the same 80ms flush window — the second overwrote the first before it was ever merged.
- **The merge index** was keyed the same way (`useProviders.ts:80`), so even if both got through, the second would replace the first in the array instead of being appended.

Both now key by provider **and** account, via the existing `providerRowKey`.

## Verified against the actual symptom

The regression test emits two accounts inside one flush window, which is what a real refresh does. I confirmed it fails without the fix, reporting the reported behavior rather than an opaque count:

```
expected [ 'acct-work' ] to deeply equal [ 'acct-personal', 'acct-work' ]
```

Only the work account survives — exactly what was seen in the app. A second test covers the other direction: a fresh reading of the same account still replaces rather than duplicating.

## What this should produce

With both accounts registered (#116) and both surviving the merge, the overview and the taskbar flyout render one card per account, each labeled with its account and optionally tinted.

## Not in this PR

The dedicated switcher chip for the flyout. Both accounts now display there rather than one, so the switcher's purpose changes — it was requested when only one was visible. Worth judging once two actually render.