### PR TITLE
Count the dense-overview threshold in rows, not providers

### DIFF
--- a/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
@@ -190,10 +190,13 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
     initialProviderId,
   );
   const [gridExpanded, setGridExpanded] = useState(false);
+  // Counted in rows rather than providers: a provider with two accounts
+  // occupies two rows, and the check below already counts rows. Counting
+  // providers here made the two disagree once accounts could multiply them.
   const expectsDenseOverview =
     selectedProviderId === null &&
     !gridExpanded &&
-    settings.enabledProviders.length + 1 > DENSE_OVERVIEW_THRESHOLD;
+    sorted.length + 1 > DENSE_OVERVIEW_THRESHOLD;
   const denseTrayProviders = useMemo(() => {
     if (!expectsDenseOverview) return sorted;
     return hydrateProviderSlots(denseProviderSlots, providersById);


### PR DESCRIPTION
Two checks decide the compact overview and they disagreed: `expectsDenseOverview` counted **enabled providers**, while the check that actually slices the list counted **rendered rows**.

Those were the same number until a provider could have several accounts. Now a provider with two accounts occupies two rows, so the two could drift apart.

Both count rows now. The threshold is 32, so this changes nothing for any realistic setup — it just stops the inconsistency.