### PR TITLE
Show the account closest to its limit on the taskbar strip

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -581,6 +581,43 @@ fn finish_provider_refresh(state: &tauri::State<'_, Mutex<AppState>>) -> Result<
 
 /// Persist the in-memory provider cache as `widget-snapshot.json` so
 /// `codexbar statusline` / `codexbar mcp` can read quota without networking.
+/// One reading per provider for the always-visible taskbar strip, choosing the
+/// account closest to its limit.
+///
+/// That strip has room for one entry per provider and exists to warn you, so
+/// the seat about to run out is the one worth surfacing. This is the same
+/// principle already applied to windows: show what is actually constraining
+/// you, not whichever reading arrived last. Hovering opens the flyout, which
+/// shows every account with its own label.
+///
+/// Without this a provider with two accounts emitted two entries under one
+/// `ProviderId`, which is ambiguous for every consumer downstream.
+pub(super) fn most_constrained_per_provider(
+    cached: &[ProviderUsageSnapshot],
+) -> Vec<&ProviderUsageSnapshot> {
+    let mut best: Vec<&ProviderUsageSnapshot> = Vec::new();
+    for snapshot in cached.iter().filter(|snap| snap.error.is_none()) {
+        match best
+            .iter_mut()
+            .find(|existing| existing.provider_id == snapshot.provider_id)
+        {
+            Some(existing) => {
+                let existing_used = existing.primary.used_percent;
+                let used = snapshot.primary.used_percent;
+                // Ties resolve on account id so the strip does not flicker
+                // between accounts as readings land in different orders.
+                let replace = used > existing_used
+                    || (used == existing_used && snapshot.account_id < existing.account_id);
+                if replace {
+                    *existing = snapshot;
+                }
+            }
+            None => best.push(snapshot),
+        }
+    }
+    best
+}
+
 fn persist_widget_snapshot_from_cache(
     state: &tauri::State<'_, Mutex<AppState>>,
     enabled_ids: &[ProviderId],
@@ -593,9 +630,8 @@ fn persist_widget_snapshot_from_cache(
         }
     };
 
-    let entries: Vec<_> = cached
-        .iter()
-        .filter(|snap| snap.error.is_none())
+    let entries: Vec<_> = most_constrained_per_provider(&cached)
+        .into_iter()
         .filter_map(widget_entry_from_usage_snapshot)
         .collect();
     if entries.is_empty() {

--- a/apps/desktop-tauri/src-tauri/src/commands/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/tests.rs
@@ -702,6 +702,66 @@ fn provider_cache_upsert_replaces_existing_provider() {
     assert_eq!(cache[0].error.as_deref(), Some("new"));
 }
 
+fn account_snapshot(account_id: &str, used: f64) -> ProviderUsageSnapshot {
+    let metadata = instantiate_provider(ProviderId::Codex).metadata().clone();
+    let result = ProviderFetchResult {
+        usage: codexbar::core::UsageSnapshot::new(codexbar::core::RateWindow::new(used)),
+        cost: None,
+        wayfinder_usage: None,
+        source_label: "oauth".to_string(),
+    };
+    let mut snapshot =
+        ProviderUsageSnapshot::from_fetch_result(ProviderId::Codex, &metadata, &result);
+    snapshot.account_id = Some(account_id.to_string());
+    snapshot
+}
+
+#[test]
+fn the_taskbar_strip_shows_the_account_closest_to_its_limit() {
+    let cached = vec![
+        account_snapshot("acct-personal", 12.0),
+        account_snapshot("acct-work", 91.0),
+    ];
+
+    let chosen = super::most_constrained_per_provider(&cached);
+
+    // One entry per provider, and it is the seat about to run out. Emitting
+    // both would put two entries under one ProviderId, which is ambiguous for
+    // everything downstream.
+    assert_eq!(chosen.len(), 1);
+    assert_eq!(chosen[0].account_id.as_deref(), Some("acct-work"));
+}
+
+#[test]
+fn the_taskbar_strip_does_not_flicker_between_tied_accounts() {
+    let one = vec![
+        account_snapshot("acct-b", 50.0),
+        account_snapshot("acct-a", 50.0),
+    ];
+    let other = vec![
+        account_snapshot("acct-a", 50.0),
+        account_snapshot("acct-b", 50.0),
+    ];
+
+    // Readings land in whatever order they finish, which must not change what
+    // the strip shows.
+    assert_eq!(
+        super::most_constrained_per_provider(&one)[0].account_id,
+        super::most_constrained_per_provider(&other)[0].account_id
+    );
+}
+
+#[test]
+fn the_taskbar_strip_skips_providers_that_failed_to_fetch() {
+    let mut errored = account_snapshot("acct-work", 91.0);
+    errored.error = Some("offline".to_string());
+
+    let cached = vec![errored];
+    let chosen = super::most_constrained_per_provider(&cached);
+
+    assert!(chosen.is_empty());
+}
+
 #[test]
 fn provider_cache_keeps_one_row_per_account() {
     let metadata = instantiate_provider(ProviderId::Codex).metadata().clone();


### PR DESCRIPTION
Answers "without the switcher, how does it know which bar to display on the taskbar when you aren't hovering?"

## The gap

`persist_widget_snapshot_from_cache` mapped **every** cache entry to a widget entry. With two Codex accounts that emits **two entries under one `ProviderId`** — ambiguous for every consumer: duplicate the provider in the strip, or pick whichever arrived last.

## The rule

One entry per provider, showing **the account closest to its limit**.

That strip exists to warn you, so the seat about to run out is the one worth surfacing. It is the same principle already applied to *windows* (surface what is actually constraining you), not a new rule invented for accounts. Hovering opens the flyout, which shows every account with its own label — so nothing is hidden, only summarised.

Ties resolve on account id, so the strip does not flicker between accounts as readings land in different orders.

## Tests

- The strip shows the account closest to its limit, and emits one entry rather than two.
- Reordering the readings does not change what is shown.
- A provider that failed to fetch is skipped, as before.