### PR TITLE
Name the account on each glance row, and drop the active-account controls

### DIFF
--- a/apps/desktop-tauri/src/components/PlanStatusCard.tsx
+++ b/apps/desktop-tauri/src/components/PlanStatusCard.tsx
@@ -169,6 +169,9 @@ export default function PlanStatusCard({
   const meters = glanceMeters(provider);
   const freshness = capacityFreshness(provider);
   const planName = displayPlanName(provider.planName, provider.displayName);
+  // Present only once accounts are configured. The label already reads
+  // "email (plan)", so it carries the plan too and nothing is lost.
+  const accountLabel = provider.accountLabel ?? null;
   const notEnforcedSummary = inactiveWindowSummary(provider, "notEnforced");
   const unavailableSummary = inactiveWindowSummary(provider, "unavailable");
   const resetCredits = codexResetCredits(provider);
@@ -196,8 +199,25 @@ export default function PlanStatusCard({
         <div className="plan-status-card__identity">
           <div className="plan-status-card__title-row">
             <span className="plan-status-card__name">{provider.displayName}</span>
-            {planName && (
-              <span className="plan-status-card__plan">{planName}</span>
+            {/* Two rows of the same provider are otherwise indistinguishable:
+                both read just "Codex". The account name is what tells them
+                apart, so it outranks the plan for the limited space here. */}
+            {accountLabel ? (
+              <span
+                className="plan-status-card__account"
+                style={
+                  provider.accountTint
+                    ? { color: provider.accountTint }
+                    : undefined
+                }
+                title={accountLabel}
+              >
+                {accountLabel}
+              </span>
+            ) : (
+              planName && (
+                <span className="plan-status-card__plan">{planName}</span>
+              )
             )}
           </div>
           {!provider.error && (freshness === "stale" || resetCredits != null) && (

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -9055,3 +9055,17 @@ body:has(.dashboard-shell) #root {
   background: var(--bg-elevated, rgba(255, 255, 255, 0.04));
   user-select: all;
 }
+
+/* Which account a glance row is reporting. Takes the account tint when set, so
+   two rows of one provider are distinguishable at a glance rather than by
+   reading their numbers. */
+.plan-status-card__account {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 0 1 auto;
+}

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
@@ -434,7 +434,7 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
     return (
       <div
         className={`menu-stack__item${isSelected ? " menu-stack__item--selected" : ""}`}
-        id={`card-${p.providerId}`}
+        id={`card-${providerRowKey(p)}`}
         key={providerRowKey(p)}
       >
         {isOverview ? (

--- a/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.tsx
@@ -9,7 +9,6 @@ import {
   getDirectoryAccounts,
   probeAccountDirectory,
   removeDirectoryAccount,
-  setActiveDirectoryAccount,
 } from "../../../lib/tauri";
 
 /** CLI to invoke when telling the user how to sign a second account in. */
@@ -176,11 +175,6 @@ function ProviderAccounts({ provider, busy, onRun }: ProviderProps) {
                 <div className="credential-card__info">
                   <strong>{account.label}</strong>
                   <span className="credential-card__meta">
-                    {account.isActive && (
-                      <span className="credential-card__badge credential-card__badge--set">
-                        {t("AccountsActive")}
-                      </span>
-                    )}
                     {!account.signedIn && (
                       <span className="credential-card__badge credential-card__badge--warn">
                         {t("AccountsSignedOut")}
@@ -202,22 +196,6 @@ function ProviderAccounts({ provider, busy, onRun }: ProviderProps) {
                   </span>
                 </div>
                 <div className="credential-card__actions">
-                  {!account.isActive && (
-                    <button
-                      className="credential-btn credential-btn--secondary"
-                      disabled={busy}
-                      onClick={() =>
-                        void onRun(() =>
-                          setActiveDirectoryAccount(
-                            provider.providerId,
-                            account.id,
-                          ),
-                        )
-                      }
-                    >
-                      {t("AccountsTrackThis")}
-                    </button>
-                  )}
                   <button
                     className="credential-btn credential-btn--danger"
                     disabled={busy}

--- a/rust/src/locale/en-US.ftl
+++ b/rust/src/locale/en-US.ftl
@@ -622,7 +622,7 @@ FirstRunDismiss = Dismiss
 
 # Config-directory accounts (SOU-285)
 SectionAccounts = Accounts
-AccountsIntro = Ceiling reads the account your CLI is signed in as. Add a config directory to track a specific account instead.
+AccountsIntro = Every account listed here is tracked, and each one gets its own bars. Add a config directory to track another.
 AccountsFollowingCli = Following the CLI
 AccountsFollowingCliHint = Tracking whichever account is signed in at
 AccountsActive = Active


### PR DESCRIPTION
Two Codex rows in the flyout both read just **"Codex"** — no way to tell which account each belonged to.

## Why the label was missing

I added it to `MenuCard`, which is the **detail** card. The flyout overview renders `PlanStatusCard`, which knew nothing about accounts.

The label now sits where the plan chip was, and takes the account tint. It **replaces** the plan rather than joining it: the label already reads `email (plan)`, so nothing is lost, space there is tight, and the account is the part that distinguishes two otherwise identical rows.

## Active-account controls removed

The "Active" badge and "Track this account" button described a state that no longer exists. Every configured account is tracked and drawn, so marking one "active" implied the others were being ignored — the opposite of what happens. The intro copy now says what actually happens: *"Every account listed here is tracked, and each one gets its own bars."*

## Also

Cards were keyed `card-<providerId>`, which stopped being unique the moment a provider had two rows. Now keyed by row.

## Known follow-ups

- The **CLI** still reports one account per provider via the stored active index, so that concept survives in the data model even though nothing sets it from the UI. Making `codexbar usage` fan out the way the app does would retire it completely.
- `get_provider_detail` merges "the latest cached snapshot" and with two accounts picks arbitrarily, so the Settings → Providers detail pane shows an unpredictable account. That needs the account selector, which is the next piece.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Account labels now appear prominently in provider status cards, with improved coloring, truncation, and accessibility details.
  * Provider cards now use more consistent identifiers for reliable display behavior.

* **Changes**
  * Removed the option to manually mark directory accounts as active.
  * Updated account guidance text to clarify how configured accounts are displayed and organized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->