### PR TITLE
Let the provider detail pane pick which account it describes

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/provider_detail.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/provider_detail.rs
@@ -2,6 +2,15 @@ use super::*;
 
 // ── Provider detail pane (Phase 6b) ──────────────────────────────────
 
+/// One selectable account on the provider detail pane.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderDetailAccount {
+    pub account_id: String,
+    pub label: String,
+    pub tint: Option<String>,
+}
+
 /// DTO for the provider detail pane in the Settings Providers tab.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -11,6 +20,12 @@ pub struct ProviderDetail {
     pub enabled: bool,
 
     // Identity
+    /// Account this payload describes. `None` when the provider has no
+    /// configured accounts and the reading is whatever the CLI is signed in as.
+    pub account_id: Option<String>,
+    /// Every account with a reading for this provider, so the pane can offer a
+    /// selector. One entry means there is nothing to choose between.
+    pub accounts: Vec<ProviderDetailAccount>,
     pub email: Option<String>,
     pub plan: Option<String>,
     pub auth_type: Option<String>,
@@ -72,6 +87,8 @@ pub(crate) fn build_provider_detail(provider_id: &str) -> Result<ProviderDetail,
         id: id.cli_name().to_string(),
         display_name: id.display_name().to_string(),
         enabled,
+        account_id: None,
+        accounts: Vec::new(),
         email: None,
         plan: None,
         auth_type: None,
@@ -105,42 +122,81 @@ pub(crate) fn build_provider_detail(provider_id: &str) -> Result<ProviderDetail,
 pub fn get_provider_detail(
     app: tauri::AppHandle,
     provider_id: String,
+    account_id: Option<String>,
 ) -> Result<ProviderDetail, String> {
     let mut detail = build_provider_detail(&provider_id)?;
 
     // Merge the latest cached snapshot, if any.
     let state = app.state::<Mutex<AppState>>();
-    if let Ok(guard) = state.lock()
-        && let Some(snap) = guard
+    if let Ok(guard) = state.lock() {
+        let readings: Vec<&ProviderUsageSnapshot> = guard
             .provider_cache
             .iter()
-            .find(|s| s.provider_id == detail.id)
-    {
-        let mut snapshot = snap.clone();
-        super::filter_hidden_codex_spark_rows(
-            &mut snapshot,
-            Settings::load().codex_spark_usage_visible(),
-        );
-        detail.email = snapshot.account_email.clone();
-        detail.plan = snapshot.plan_name.clone();
-        detail.organization = snapshot.account_organization.clone();
-        detail.source_label = if snapshot.source_label.is_empty() {
-            None
-        } else {
-            Some(snapshot.source_label.clone())
-        };
-        detail.last_updated = Some(snapshot.updated_at.clone());
-        if snapshot.error.is_none() {
-            detail.session = Some(snapshot.primary.clone());
-            detail.weekly = snapshot.secondary.clone();
-            detail.model_specific = snapshot.model_specific.clone();
-            detail.tertiary = snapshot.tertiary.clone();
-            detail.extra_rate_windows = snapshot.extra_rate_windows.clone();
-            detail.cost = snapshot.cost.clone();
-            detail.pace = snapshot.pace.clone();
+            .filter(|s| s.provider_id == detail.id)
+            .collect();
+
+        detail.accounts = readings
+            .iter()
+            .filter_map(|snap| {
+                Some(ProviderDetailAccount {
+                    account_id: snap.account_id.clone()?,
+                    label: snap
+                        .account_label
+                        .clone()
+                        .unwrap_or_else(|| detail.display_name.clone()),
+                    tint: snap.account_tint.clone(),
+                })
+            })
+            .collect();
+
+        // An explicit choice wins. Without one, summarise the account closest to
+        // its limit rather than whichever reading happened to be first, which is
+        // what this did when a provider could only ever have one.
+        let chosen = account_id
+            .as_deref()
+            .and_then(|wanted| {
+                readings
+                    .iter()
+                    .find(|snap| snap.account_id.as_deref() == Some(wanted))
+            })
+            .or_else(|| {
+                readings.iter().max_by(|a, b| {
+                    a.primary
+                        .used_percent
+                        .total_cmp(&b.primary.used_percent)
+                        .then_with(|| b.account_id.cmp(&a.account_id))
+                })
+            })
+            .copied();
+
+        if let Some(snap) = chosen {
+            let mut snapshot = snap.clone();
+            super::filter_hidden_codex_spark_rows(
+                &mut snapshot,
+                Settings::load().codex_spark_usage_visible(),
+            );
+            detail.account_id = snapshot.account_id.clone();
+            detail.email = snapshot.account_email.clone();
+            detail.plan = snapshot.plan_name.clone();
+            detail.organization = snapshot.account_organization.clone();
+            detail.source_label = if snapshot.source_label.is_empty() {
+                None
+            } else {
+                Some(snapshot.source_label.clone())
+            };
+            detail.last_updated = Some(snapshot.updated_at.clone());
+            if snapshot.error.is_none() {
+                detail.session = Some(snapshot.primary.clone());
+                detail.weekly = snapshot.secondary.clone();
+                detail.model_specific = snapshot.model_specific.clone();
+                detail.tertiary = snapshot.tertiary.clone();
+                detail.extra_rate_windows = snapshot.extra_rate_windows.clone();
+                detail.cost = snapshot.cost.clone();
+                detail.pace = snapshot.pace.clone();
+            }
+            detail.last_error = snapshot.error.clone();
+            detail.has_snapshot = true;
         }
-        detail.last_error = snapshot.error.clone();
-        detail.has_snapshot = true;
     }
 
     Ok(detail)

--- a/apps/desktop-tauri/src/lib/tauri.ts
+++ b/apps/desktop-tauri/src/lib/tauri.ts
@@ -403,7 +403,10 @@ export function setUiLanguage(language: Language): Promise<void> {
 
 // ── Phase 6b — provider detail pane ──────────────────────────────────
 
-export function getProviderDetail(providerId: string): Promise<ProviderDetail> {
+export function getProviderDetail(
+  providerId: string,
+  accountId: string | null = null,
+): Promise<ProviderDetail> {
   return invoke<ProviderDetail>("get_provider_detail", { providerId });
 }
 

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -9069,3 +9069,40 @@ body:has(.dashboard-shell) #root {
   min-width: 0;
   flex: 0 1 auto;
 }
+
+/* Account selector on the provider detail pane. Reads as tabs because that is
+   what it does: the rest of the pane describes whichever is chosen. */
+.provider-detail__accounts {
+  display: flex;
+  gap: 4px;
+  margin-block-end: 12px;
+  border-block-end: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  overflow-x: auto;
+}
+
+.provider-detail__account {
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  border: none;
+  border-block-end: 2px solid transparent;
+  background: none;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.provider-detail__account:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.provider-detail__account--selected {
+  color: var(--text-primary);
+  border-block-end-color: var(--accent, #4f8ff7);
+}
+
+.provider-detail__account:disabled {
+  cursor: default;
+  opacity: 0.6;
+}

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   CookieSourceOption,
   CredentialStorageStatus,
@@ -124,12 +124,21 @@ export function ProviderDetailPane({
     };
   }, []);
 
-  const load = useCallback(async (id: string, signal?: { stale: boolean }) => {
+  const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
+  // Read inside listener effects, which must not resubscribe when it changes.
+  const selectedAccountIdRef = useRef<string | null>(null);
+  selectedAccountIdRef.current = selectedAccountId;
+
+  const load = useCallback(async (
+    id: string,
+    signal?: { stale: boolean },
+    accountId: string | null = null,
+  ) => {
     setLoading(true);
     setError(null);
     try {
       const [next, cookieOpts, regionOpts, storageStatus] = await Promise.all([
-        getProviderDetail(id),
+        getProviderDetail(id, accountId),
         getProviderCookieSourceOptions(id),
         getProviderRegionOptions(id),
         getCredentialStorageStatus(),
@@ -146,6 +155,10 @@ export function ProviderDetailPane({
       setCookieOptions([]);
       setRegionOptions([]);
       setCredentialStatus(null);
+    // A selection belongs to one provider; carrying it across panes would
+    // ask for an account that provider does not have.
+    setSelectedAccountId(null);
+    selectedAccountIdRef.current = null;
     } finally {
       if (!signal?.stale) setLoading(false);
     }
@@ -164,7 +177,7 @@ export function ProviderDetailPane({
     setRegionOptions([]);
     setCredentialStatus(null);
     const signal = { stale: false };
-    void load(providerId, signal);
+    void load(providerId, signal, selectedAccountIdRef.current);
     return () => { signal.stale = true; };
   }, [providerId, load]);
 
@@ -177,7 +190,7 @@ export function ProviderDetailPane({
       (event) => {
         const pid = event.payload?.providerId;
         if (!pid || pid === providerId) {
-          void load(providerId, signal);
+          void load(providerId, signal, selectedAccountIdRef.current);
         }
       },
     );
@@ -282,6 +295,37 @@ export function ProviderDetailPane({
 
   return (
     <div className="provider-detail">
+      {/* Only rendered with something to choose between. One account means this
+          pane already describes it, and a selector would be noise. */}
+      {(detail.accounts?.length ?? 0) > 1 && (
+        <div className="provider-detail__accounts" role="tablist">
+          {detail.accounts?.map((account) => {
+            const selected = account.accountId === detail.accountId;
+            return (
+              <button
+                key={account.accountId}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                className={`provider-detail__account${selected ? " provider-detail__account--selected" : ""}`}
+                style={
+                  account.tint && selected
+                    ? { borderBottomColor: account.tint }
+                    : undefined
+                }
+                disabled={loading}
+                onClick={() => {
+                  setSelectedAccountId(account.accountId);
+                  void load(detail.id, undefined, account.accountId);
+                }}
+              >
+                {account.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
       <IdentitySection provider={detail} subtitle={subtitle} t={t} />
 
       <DataSourceSection provider={detail} t={t} />

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -907,12 +907,22 @@ export type LocaleChangedPayload = Language;
 // ── Phase 6b — provider detail pane ──────────────────────────────────
 
 /** Aggregated per-provider payload powering the Settings detail pane. */
+export interface ProviderDetailAccount {
+  accountId: string;
+  label: string;
+  tint: string | null;
+}
+
 export interface ProviderDetail {
   id: string;
   displayName: string;
   enabled: boolean;
 
   // Identity
+  /** Account this payload describes; null while following the CLI. */
+  accountId?: string | null;
+  /** Every account with a reading, so the pane can offer a selector. */
+  accounts?: ProviderDetailAccount[];
   email: string | null;
   plan: string | null;
   authType: string | null;


### PR DESCRIPTION
Third of the three issues raised: *"the providers page probably needs to be updated with a dropdown or selector of some type to see stats on that account."*

## It was worse than a missing selector

`get_provider_detail` merged "the latest cached snapshot" using `.find(|s| s.provider_id == detail.id)`. That was exact while a provider could only have one reading. With two accounts it returns **whichever the iterator reaches first** — so Settings → Providers showed an unpredictable account's identity, usage, cost *and* charts, and could change between refreshes.

Same class of bug as the taskbar strip: a lookup that was correct when provider implied account.

## Fix

- The command takes an optional account, and reports every account that has a reading so the pane can offer a selector.
- Without an explicit choice it falls back to the **account closest to its limit**, matching what the taskbar strip and the providers list already do, instead of an arbitrary one.
- The selector renders **only when there is more than one account**, so nothing changes for a single account.
- It sits above everything else, because it decides what the rest of the pane describes, and is marked up as tabs because that is how it behaves.
- The choice survives live refreshes (which arrive whenever a snapshot lands) and resets when switching providers, so it cannot ask one provider for another's account. Held in a ref as well as state so the listener effects do not resubscribe on every selection.

Charts were already account-scoped by email, so they follow the selection for free.

## Verified

Rendered against the real stylesheet: two tabs at 189px and 134px in a 526px row, no clipping, no horizontal scroll, tint underline on the selected tab only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account selection to provider detail views, including available account tabs and account-specific usage data.
  * Provider cards now display account names, with optional color accents.
  * Provider details automatically select the most relevant account when none is chosen.

* **Improvements**
  * Simplified account settings by removing active-account indicators and tracking controls.
  * Updated account guidance to clarify that all listed accounts are tracked independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->