### PR TITLE
Scope transient auth-failure recovery to the account

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/provider_detail.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/provider_detail.rs
@@ -2,6 +2,15 @@ use super::*;
 
 // ── Provider detail pane (Phase 6b) ──────────────────────────────────
 
+/// One selectable account on the provider detail pane.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderDetailAccount {
+    pub account_id: String,
+    pub label: String,
+    pub tint: Option<String>,
+}
+
 /// DTO for the provider detail pane in the Settings Providers tab.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -11,6 +20,12 @@ pub struct ProviderDetail {
     pub enabled: bool,
 
     // Identity
+    /// Account this payload describes. `None` when the provider has no
+    /// configured accounts and the reading is whatever the CLI is signed in as.
+    pub account_id: Option<String>,
+    /// Every account with a reading for this provider, so the pane can offer a
+    /// selector. One entry means there is nothing to choose between.
+    pub accounts: Vec<ProviderDetailAccount>,
     pub email: Option<String>,
     pub plan: Option<String>,
     pub auth_type: Option<String>,
@@ -72,6 +87,8 @@ pub(crate) fn build_provider_detail(provider_id: &str) -> Result<ProviderDetail,
         id: id.cli_name().to_string(),
         display_name: id.display_name().to_string(),
         enabled,
+        account_id: None,
+        accounts: Vec::new(),
         email: None,
         plan: None,
         auth_type: None,
@@ -105,42 +122,81 @@ pub(crate) fn build_provider_detail(provider_id: &str) -> Result<ProviderDetail,
 pub fn get_provider_detail(
     app: tauri::AppHandle,
     provider_id: String,
+    account_id: Option<String>,
 ) -> Result<ProviderDetail, String> {
     let mut detail = build_provider_detail(&provider_id)?;
 
     // Merge the latest cached snapshot, if any.
     let state = app.state::<Mutex<AppState>>();
-    if let Ok(guard) = state.lock()
-        && let Some(snap) = guard
+    if let Ok(guard) = state.lock() {
+        let readings: Vec<&ProviderUsageSnapshot> = guard
             .provider_cache
             .iter()
-            .find(|s| s.provider_id == detail.id)
-    {
-        let mut snapshot = snap.clone();
-        super::filter_hidden_codex_spark_rows(
-            &mut snapshot,
-            Settings::load().codex_spark_usage_visible(),
-        );
-        detail.email = snapshot.account_email.clone();
-        detail.plan = snapshot.plan_name.clone();
-        detail.organization = snapshot.account_organization.clone();
-        detail.source_label = if snapshot.source_label.is_empty() {
-            None
-        } else {
-            Some(snapshot.source_label.clone())
-        };
-        detail.last_updated = Some(snapshot.updated_at.clone());
-        if snapshot.error.is_none() {
-            detail.session = Some(snapshot.primary.clone());
-            detail.weekly = snapshot.secondary.clone();
-            detail.model_specific = snapshot.model_specific.clone();
-            detail.tertiary = snapshot.tertiary.clone();
-            detail.extra_rate_windows = snapshot.extra_rate_windows.clone();
-            detail.cost = snapshot.cost.clone();
-            detail.pace = snapshot.pace.clone();
+            .filter(|s| s.provider_id == detail.id)
+            .collect();
+
+        detail.accounts = readings
+            .iter()
+            .filter_map(|snap| {
+                Some(ProviderDetailAccount {
+                    account_id: snap.account_id.clone()?,
+                    label: snap
+                        .account_label
+                        .clone()
+                        .unwrap_or_else(|| detail.display_name.clone()),
+                    tint: snap.account_tint.clone(),
+                })
+            })
+            .collect();
+
+        // An explicit choice wins. Without one, summarise the account closest to
+        // its limit rather than whichever reading happened to be first, which is
+        // what this did when a provider could only ever have one.
+        let chosen = account_id
+            .as_deref()
+            .and_then(|wanted| {
+                readings
+                    .iter()
+                    .find(|snap| snap.account_id.as_deref() == Some(wanted))
+            })
+            .or_else(|| {
+                readings.iter().max_by(|a, b| {
+                    a.primary
+                        .used_percent
+                        .total_cmp(&b.primary.used_percent)
+                        .then_with(|| b.account_id.cmp(&a.account_id))
+                })
+            })
+            .copied();
+
+        if let Some(snap) = chosen {
+            let mut snapshot = snap.clone();
+            super::filter_hidden_codex_spark_rows(
+                &mut snapshot,
+                Settings::load().codex_spark_usage_visible(),
+            );
+            detail.account_id = snapshot.account_id.clone();
+            detail.email = snapshot.account_email.clone();
+            detail.plan = snapshot.plan_name.clone();
+            detail.organization = snapshot.account_organization.clone();
+            detail.source_label = if snapshot.source_label.is_empty() {
+                None
+            } else {
+                Some(snapshot.source_label.clone())
+            };
+            detail.last_updated = Some(snapshot.updated_at.clone());
+            if snapshot.error.is_none() {
+                detail.session = Some(snapshot.primary.clone());
+                detail.weekly = snapshot.secondary.clone();
+                detail.model_specific = snapshot.model_specific.clone();
+                detail.tertiary = snapshot.tertiary.clone();
+                detail.extra_rate_windows = snapshot.extra_rate_windows.clone();
+                detail.cost = snapshot.cost.clone();
+                detail.pace = snapshot.pace.clone();
+            }
+            detail.last_error = snapshot.error.clone();
+            detail.has_snapshot = true;
         }
-        detail.last_error = snapshot.error.clone();
-        detail.has_snapshot = true;
     }
 
     Ok(detail)

--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -476,20 +476,30 @@ pub(super) fn preserve_last_good_transient_failure(
     id: ProviderId,
     snapshot: ProviderUsageSnapshot,
 ) -> ProviderUsageSnapshot {
+    // Scoped to the account, not just the provider. Substituting another
+    // account's reading here would report one seat's usage under the other's
+    // name, and a shared counter let one account's failure consume the other's
+    // single allowed retry.
+    let key = (id, snapshot.account_id.clone());
+
     if snapshot.error.is_none() {
-        guard.transient_provider_failure_counts.remove(&id);
+        guard.transient_provider_failure_counts.remove(&key);
         return snapshot;
     }
 
     if id != ProviderId::Claude || !is_transient_claude_auth_error(snapshot.error.as_deref()) {
-        guard.transient_provider_failure_counts.remove(&id);
+        guard.transient_provider_failure_counts.remove(&key);
         return snapshot;
     }
 
     let Some(previous) = guard
         .provider_cache
         .iter()
-        .find(|cached| cached.provider_id == id.cli_name() && cached.error.is_none())
+        .find(|cached| {
+            cached.provider_id == id.cli_name()
+                && cached.account_id == snapshot.account_id
+                && cached.error.is_none()
+        })
         .cloned()
     else {
         return snapshot;
@@ -497,7 +507,7 @@ pub(super) fn preserve_last_good_transient_failure(
 
     let count = guard
         .transient_provider_failure_counts
-        .entry(id)
+        .entry(key)
         .or_insert(0);
     if *count == 0 {
         *count = 1;

--- a/apps/desktop-tauri/src-tauri/src/commands/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/tests.rs
@@ -848,6 +848,86 @@ fn hiding_codex_spark_rows_preserves_other_extra_usage() {
     assert_eq!(snapshot.extra_rate_windows[0].id, "credits");
 }
 
+fn claude_account_snapshot(account_id: &str, used: f64) -> ProviderUsageSnapshot {
+    let metadata = instantiate_provider(ProviderId::Claude).metadata().clone();
+    let result = ProviderFetchResult {
+        usage: codexbar::core::UsageSnapshot::new(codexbar::core::RateWindow::new(used)),
+        cost: None,
+        wayfinder_usage: None,
+        source_label: "OAuth".to_string(),
+    };
+    let mut snapshot =
+        ProviderUsageSnapshot::from_fetch_result(ProviderId::Claude, &metadata, &result);
+    snapshot.account_id = Some(account_id.to_string());
+    snapshot
+}
+
+fn claude_account_error(account_id: &str) -> ProviderUsageSnapshot {
+    let metadata = instantiate_provider(ProviderId::Claude).metadata().clone();
+    let mut snapshot = ProviderUsageSnapshot::from_error(
+        ProviderId::Claude,
+        &metadata,
+        "Unauthorized".to_string(),
+    );
+    snapshot.account_id = Some(account_id.to_string());
+    snapshot
+}
+
+#[test]
+fn a_transient_failure_never_substitutes_another_accounts_reading() {
+    let mut state = crate::state::AppState::new();
+    // Only the personal account has a good reading cached.
+    state
+        .provider_cache
+        .push(claude_account_snapshot("acct-personal", 42.0));
+
+    let preserved = super::providers::preserve_last_good_transient_failure(
+        &mut state,
+        ProviderId::Claude,
+        claude_account_error("acct-work"),
+    );
+
+    // Substituting personal's reading here would report one seat's usage under
+    // the other's name. The work account has nothing good to fall back to, so
+    // its error must surface.
+    assert_eq!(preserved.account_id.as_deref(), Some("acct-work"));
+    assert!(preserved.error.is_some());
+}
+
+#[test]
+fn each_account_gets_its_own_transient_failure_grace() {
+    let mut state = crate::state::AppState::new();
+    state
+        .provider_cache
+        .push(claude_account_snapshot("acct-personal", 42.0));
+    state
+        .provider_cache
+        .push(claude_account_snapshot("acct-work", 77.0));
+
+    let personal = super::providers::preserve_last_good_transient_failure(
+        &mut state,
+        ProviderId::Claude,
+        claude_account_error("acct-personal"),
+    );
+    let work = super::providers::preserve_last_good_transient_failure(
+        &mut state,
+        ProviderId::Claude,
+        claude_account_error("acct-work"),
+    );
+
+    // A shared counter let the first account's failure consume the second's one
+    // allowed retry, so the second showed an error it should have ridden out.
+    assert_eq!(personal.error, None, "personal lost its grace");
+    assert_eq!(
+        work.error, None,
+        "work lost its grace to personal's failure"
+    );
+    assert_eq!(
+        work.primary.used_percent, 77.0,
+        "work got personal's numbers"
+    );
+}
+
 #[test]
 fn claude_transient_auth_failure_preserves_first_last_good_snapshot() {
     let metadata = instantiate_provider(ProviderId::Claude).metadata().clone();

--- a/apps/desktop-tauri/src-tauri/src/state.rs
+++ b/apps/desktop-tauri/src-tauri/src/state.rs
@@ -120,7 +120,10 @@ pub struct AppState {
     pub current_target: SurfaceTarget,
     pub tray_anchor: Option<TrayAnchor>,
     pub provider_cache: Vec<ProviderUsageSnapshot>,
-    pub transient_provider_failure_counts: HashMap<ProviderId, u8>,
+    /// Keyed by provider *and* account: two accounts on one provider fail
+    /// independently, and sharing a counter let one account's failure consume
+    /// the other's single allowed retry.
+    pub transient_provider_failure_counts: HashMap<(ProviderId, Option<String>), u8>,
     pub provider_cache_updated_at: Option<std::time::Instant>,
     pub provider_refresh_started_at: Option<std::time::Instant>,
     pub is_refreshing: bool,

--- a/apps/desktop-tauri/src/lib/tauri.ts
+++ b/apps/desktop-tauri/src/lib/tauri.ts
@@ -403,7 +403,10 @@ export function setUiLanguage(language: Language): Promise<void> {
 
 // ── Phase 6b — provider detail pane ──────────────────────────────────
 
-export function getProviderDetail(providerId: string): Promise<ProviderDetail> {
+export function getProviderDetail(
+  providerId: string,
+  accountId: string | null = null,
+): Promise<ProviderDetail> {
   return invoke<ProviderDetail>("get_provider_detail", { providerId });
 }
 

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -9069,3 +9069,40 @@ body:has(.dashboard-shell) #root {
   min-width: 0;
   flex: 0 1 auto;
 }
+
+/* Account selector on the provider detail pane. Reads as tabs because that is
+   what it does: the rest of the pane describes whichever is chosen. */
+.provider-detail__accounts {
+  display: flex;
+  gap: 4px;
+  margin-block-end: 12px;
+  border-block-end: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  overflow-x: auto;
+}
+
+.provider-detail__account {
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  border: none;
+  border-block-end: 2px solid transparent;
+  background: none;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.provider-detail__account:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.provider-detail__account--selected {
+  color: var(--text-primary);
+  border-block-end-color: var(--accent, #4f8ff7);
+}
+
+.provider-detail__account:disabled {
+  cursor: default;
+  opacity: 0.6;
+}

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   CookieSourceOption,
   CredentialStorageStatus,
@@ -124,12 +124,21 @@ export function ProviderDetailPane({
     };
   }, []);
 
-  const load = useCallback(async (id: string, signal?: { stale: boolean }) => {
+  const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
+  // Read inside listener effects, which must not resubscribe when it changes.
+  const selectedAccountIdRef = useRef<string | null>(null);
+  selectedAccountIdRef.current = selectedAccountId;
+
+  const load = useCallback(async (
+    id: string,
+    signal?: { stale: boolean },
+    accountId: string | null = null,
+  ) => {
     setLoading(true);
     setError(null);
     try {
       const [next, cookieOpts, regionOpts, storageStatus] = await Promise.all([
-        getProviderDetail(id),
+        getProviderDetail(id, accountId),
         getProviderCookieSourceOptions(id),
         getProviderRegionOptions(id),
         getCredentialStorageStatus(),
@@ -146,6 +155,10 @@ export function ProviderDetailPane({
       setCookieOptions([]);
       setRegionOptions([]);
       setCredentialStatus(null);
+    // A selection belongs to one provider; carrying it across panes would
+    // ask for an account that provider does not have.
+    setSelectedAccountId(null);
+    selectedAccountIdRef.current = null;
     } finally {
       if (!signal?.stale) setLoading(false);
     }
@@ -164,7 +177,7 @@ export function ProviderDetailPane({
     setRegionOptions([]);
     setCredentialStatus(null);
     const signal = { stale: false };
-    void load(providerId, signal);
+    void load(providerId, signal, selectedAccountIdRef.current);
     return () => { signal.stale = true; };
   }, [providerId, load]);
 
@@ -177,7 +190,7 @@ export function ProviderDetailPane({
       (event) => {
         const pid = event.payload?.providerId;
         if (!pid || pid === providerId) {
-          void load(providerId, signal);
+          void load(providerId, signal, selectedAccountIdRef.current);
         }
       },
     );
@@ -282,6 +295,37 @@ export function ProviderDetailPane({
 
   return (
     <div className="provider-detail">
+      {/* Only rendered with something to choose between. One account means this
+          pane already describes it, and a selector would be noise. */}
+      {(detail.accounts?.length ?? 0) > 1 && (
+        <div className="provider-detail__accounts" role="tablist">
+          {detail.accounts?.map((account) => {
+            const selected = account.accountId === detail.accountId;
+            return (
+              <button
+                key={account.accountId}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                className={`provider-detail__account${selected ? " provider-detail__account--selected" : ""}`}
+                style={
+                  account.tint && selected
+                    ? { borderBottomColor: account.tint }
+                    : undefined
+                }
+                disabled={loading}
+                onClick={() => {
+                  setSelectedAccountId(account.accountId);
+                  void load(detail.id, undefined, account.accountId);
+                }}
+              >
+                {account.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
       <IdentitySection provider={detail} subtitle={subtitle} t={t} />
 
       <DataSourceSection provider={detail} t={t} />

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -907,12 +907,22 @@ export type LocaleChangedPayload = Language;
 // ── Phase 6b — provider detail pane ──────────────────────────────────
 
 /** Aggregated per-provider payload powering the Settings detail pane. */
+export interface ProviderDetailAccount {
+  accountId: string;
+  label: string;
+  tint: string | null;
+}
+
 export interface ProviderDetail {
   id: string;
   displayName: string;
   enabled: boolean;
 
   // Identity
+  /** Account this payload describes; null while following the CLI. */
+  accountId?: string | null;
+  /** Every account with a reading, so the pane can offer a selector. */
+  accounts?: ProviderDetailAccount[];
   email: string | null;
   plan: string | null;
   authType: string | null;


### PR DESCRIPTION
Found by reviewing today's multi-account work for the recurring pattern: lookups that assumed one reading per provider. **This one shows one seat's usage under another seat's name.**

## The bug

When Claude returns a transient auth error, Ceiling reuses the last good snapshot rather than surfacing a spurious failure. That lookup was:

```rust
.find(|cached| cached.provider_id == id.cli_name() && cached.error.is_none())
```

Provider only. With two Claude accounts, a failure on the **work** account returns the **personal** account's reading. Since the substituted snapshot carries personal's `account_id`, it then overwrites personal's cache row with a copy of itself, while work's row never updates at all.

Second defect beside it: `transient_provider_failure_counts` was keyed by `ProviderId`, so both accounts shared one counter. The first account's failure consumed the single allowed grace, and the second surfaced an error it should have ridden out.

Both now key by provider **and** account.

## Verified against the symptom

I confirmed the tests fail without the fix, and that they report what a user would actually see rather than an opaque mismatch:

```
assertion `left == right` failed: work got personal's numbers
  left: 42.0
 right: 77.0
```

## Note

While checking this I reverted the fix to test it and my revert silently no-oped — the string didn't match and my script printed success unconditionally, so the tests "passed" misleadingly. Re-ran with an assertion that exactly one line was removed. Worth remembering: a green run after a revert means nothing unless the revert is verified to have applied.