### PR TITLE
Fix the remaining lookups that assumed one reading per provider

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/powertoys.rs
+++ b/apps/desktop-tauri/src-tauri/src/powertoys.rs
@@ -26,6 +26,13 @@ pub struct PowerToysSnapshot {
 pub struct PowerToysProviderSnapshot {
     id: String,
     name: String,
+    /// Which account this entry reports. A provider can appear more than once,
+    /// so `id` alone no longer identifies an entry; consumers keying on it
+    /// would collapse two accounts into one.
+    account_id: Option<String>,
+    /// Human name for that account, so two entries for one provider are not
+    /// two indistinguishable rows.
+    account_label: Option<String>,
     status_text: String,
     subtitle: Option<String>,
     primary_label: Option<String>,
@@ -80,6 +87,8 @@ fn provider_snapshot(provider: ProviderUsageSnapshot) -> PowerToysProviderSnapsh
     PowerToysProviderSnapshot {
         id: provider.provider_id,
         name: provider.display_name,
+        account_id: provider.account_id,
+        account_label: provider.account_label,
         status_text,
         subtitle,
         primary_label: provider.primary_label,

--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -538,10 +538,20 @@ mod windows_host {
             .into_iter()
             .filter(|provider_id| settings.enabled_providers.contains(provider_id))
             .map(|provider_id| {
+                // One tile per provider, showing the account closest to its
+                // limit. `.find` returned whichever account sat first in the
+                // cache, which changes as fetches finish in different orders,
+                // so the tile flipped between accounts between refreshes.
                 let snapshot = guard
                     .provider_cache
                     .iter()
-                    .find(|snapshot| snapshot.provider_id == provider_id);
+                    .filter(|snapshot| snapshot.provider_id == provider_id)
+                    .max_by(|a, b| {
+                        a.primary
+                            .used_percent
+                            .total_cmp(&b.primary.used_percent)
+                            .then_with(|| b.account_id.cmp(&a.account_id))
+                    });
                 let percent =
                     snapshot
                         .filter(|snapshot| snapshot.error.is_none())

--- a/apps/desktop-tauri/src/hooks/useProviders.test.tsx
+++ b/apps/desktop-tauri/src/hooks/useProviders.test.tsx
@@ -118,6 +118,31 @@ describe("useProviders", () => {
     vi.useRealTimers();
   });
 
+  it("drops a removed account instead of leaving a ghost card", async () => {
+    vi.useFakeTimers();
+    const personal = { ...provider("codex", 12), accountId: "acct-personal" };
+    const work = { ...provider("codex", 88), accountId: "acct-work" };
+    tauriMocks.getCachedProviders.mockResolvedValue([personal, work]);
+
+    const { result } = renderHook(() => useProviders());
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+    expect(result.current.providers).toHaveLength(2);
+
+    // Deleting an account evicts its rows in the backend and emits
+    // settings-changed, which re-reads the whole cache.
+    tauriMocks.getCachedProviders.mockResolvedValue([personal]);
+    await act(async () => {
+      emitProviderEvent("settings-changed", undefined);
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    const ids = result.current.providers.map((p) => p.accountId);
+    expect(ids).toEqual(["acct-personal"]);
+    vi.useRealTimers();
+  });
+
   it("uses stale-aware refresh on mount", async () => {
     renderHook(() => useProviders());
 

--- a/apps/desktop-tauri/src/hooks/useProviders.ts
+++ b/apps/desktop-tauri/src/hooks/useProviders.ts
@@ -74,8 +74,16 @@ export function useProviders(options: UseProvidersOptions = {}): UseProvidersRes
   const settingsReloadEpochRef = useRef(0);
   const settingsReloadingRef = useRef(false);
 
-  const mergeSnapshots = useCallback((snapshots: ProviderUsageSnapshot[]) => {
-    if (snapshots.length === 0) return;
+  /**
+   * @param authoritative the payload is the complete cache, so rows missing
+   * from it have been removed and must be dropped. Event-driven merges are
+   * partial and only ever upsert.
+   */
+  const mergeSnapshots = useCallback((
+    snapshots: ProviderUsageSnapshot[],
+    authoritative = false,
+  ) => {
+    if (snapshots.length === 0 && !authoritative) return;
     setProviders((prev) => {
       const next = [...prev];
       // Keyed by provider *and* account. Keying on provider alone meant a
@@ -94,7 +102,12 @@ export function useProviders(options: UseProvidersOptions = {}): UseProvidersRes
           next.push(snapshot);
         }
       }
-      return next;
+      if (!authoritative) return next;
+      // Deleting an account evicts its rows in the backend, but an upsert-only
+      // merge left the card on screen indefinitely, still showing its last
+      // percentages as though live.
+      const live = new Set(snapshots.map(providerRowKey));
+      return next.filter((provider) => live.has(providerRowKey(provider)));
     });
   }, []);
 
@@ -174,7 +187,7 @@ export function useProviders(options: UseProvidersOptions = {}): UseProvidersRes
       getCachedProviders()
         .then((cached) => {
           if (!cancelled && epoch === settingsReloadEpochRef.current) {
-            mergeSnapshots(cached);
+            mergeSnapshots(cached, true);
           }
         })
         .finally(() => {

--- a/apps/desktop-tauri/src/lib/providerOrder.test.ts
+++ b/apps/desktop-tauri/src/lib/providerOrder.test.ts
@@ -69,3 +69,55 @@ describe("orderProviderSnapshots", () => {
     expect(ordered.map((provider) => provider.providerId)).toEqual(["codex"]);
   });
 });
+
+describe("orderProviderSnapshots with several accounts", () => {
+  const snap = (providerId: string, accountId: string) =>
+    ({
+      providerId,
+      accountId,
+      displayName: providerId,
+    }) as unknown as Parameters<typeof orderProviderSnapshots>[0][number];
+
+  const catalog = [
+    { id: "codex", displayName: "Codex" },
+    { id: "claude", displayName: "Claude" },
+  ] as unknown as Parameters<typeof orderProviderSnapshots>[1];
+
+  it("keeps both accounts of a provider", () => {
+    const out = orderProviderSnapshots(
+      [snap("codex", "b"), snap("codex", "a")],
+      catalog,
+      ["codex"],
+    );
+
+    expect(out).toHaveLength(2);
+  });
+
+  it("orders two accounts the same way regardless of arrival order", () => {
+    // Fetches finish in whatever order they finish. Without a tiebreak the
+    // comparator was non-transitive and the rows swapped between refreshes.
+    const one = orderProviderSnapshots(
+      [snap("codex", "b"), snap("codex", "a")],
+      catalog,
+      ["codex"],
+    ).map((p) => p.accountId);
+    const other = orderProviderSnapshots(
+      [snap("codex", "a"), snap("codex", "b")],
+      catalog,
+      ["codex"],
+    ).map((p) => p.accountId);
+
+    expect(one).toEqual(other);
+  });
+
+  it("keeps a provider's accounts adjacent", () => {
+    const out = orderProviderSnapshots(
+      [snap("codex", "b"), snap("claude", "c"), snap("codex", "a")],
+      catalog,
+      ["codex", "claude"],
+    ).map((p) => p.providerId);
+
+    // An unrelated provider must not be sorted in between two accounts.
+    expect(out).toEqual(["codex", "codex", "claude"]);
+  });
+});

--- a/apps/desktop-tauri/src/lib/providerOrder.ts
+++ b/apps/desktop-tauri/src/lib/providerOrder.ts
@@ -24,8 +24,19 @@ export function orderProviderSnapshots(
     const aOrder = order.get(a.providerId);
     const bOrder = order.get(b.providerId);
     if (aOrder != null && bOrder != null && aOrder !== bOrder) return aOrder - bOrder;
+    // Both ordered and equal means two accounts of one provider. Falling through
+    // to the `aOrder != null` branch returned -1 for compare(a,b) *and*
+    // compare(b,a), which is not a valid comparator: sort output became
+    // implementation-defined and the two rows swapped between refreshes as
+    // fetches finished in different orders.
+    if (aOrder != null && bOrder != null) {
+      return (a.accountId ?? "").localeCompare(b.accountId ?? "");
+    }
     if (aOrder != null) return -1;
     if (bOrder != null) return 1;
-    return a.displayName.localeCompare(b.displayName);
+    const byName = a.displayName.localeCompare(b.displayName);
+    return byName !== 0
+      ? byName
+      : (a.accountId ?? "").localeCompare(b.accountId ?? "");
   });
 }

--- a/apps/desktop-tauri/src/surfaces/AccountsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/AccountsPanel.tsx
@@ -4,6 +4,7 @@ import { ProviderIcon } from "../components/providers/ProviderIcon";
 import { capacityFreshness } from "../lib/capacityPresentation";
 import { formatRelativeUpdated } from "../lib/relativeTime";
 import { useLocale } from "../hooks/useLocale";
+import { providerRowKey } from "../lib/providerRow";
 
 /**
  * Accounts = "what is Ceiling watching, and is it healthy?" One card per
@@ -135,7 +136,7 @@ export default function AccountsPanel({
       <div className="accounts-list">
         {providers.map((provider) => (
           <AccountRow
-            key={provider.providerId}
+            key={providerRowKey(provider)}
             provider={provider}
             hideEmail={hideEmail}
             nowMs={nowMs}

--- a/apps/desktop-tauri/src/surfaces/ActivityTimeline.tsx
+++ b/apps/desktop-tauri/src/surfaces/ActivityTimeline.tsx
@@ -2,6 +2,7 @@ import { Fragment, useEffect, useMemo, useState } from "react";
 import type { ProviderUsageSnapshot, RateWindowSnapshot } from "../types/bridge";
 import { ProviderIcon } from "../components/providers/ProviderIcon";
 import { allMeasuredWindows } from "../lib/capacityPresentation";
+import { providerRowKey } from "../lib/providerRow";
 
 /**
  * Activity is a calm schedule of the rate-window resets providers report.
@@ -76,7 +77,9 @@ function collectEntries(providers: ProviderUsageSnapshot[]): TimelineEntry[] {
         ? Date.parse(measured.window.resetsAt)
         : NaN;
       entries.push({
-        key: `${provider.providerId}:${measured.id}`,
+        // Includes the account: two accounts both have a "session" window, so
+      // keying on provider alone collided them into one timeline row.
+      key: `${providerRowKey(provider)}:${measured.id}`,
         providerId: provider.providerId,
         displayName: provider.displayName,
         label: measured.label,

--- a/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
@@ -6,6 +6,7 @@ import { providerSupportsChartData } from "../lib/providerCharts";
 import { ChartsSection } from "./settings/providers/sections/charts/ChartsSection";
 import ProviderComparison from "./ProviderComparison";
 import { TotalApiValueCard } from "../components/TotalApiValueCard";
+import { providerRowKey, representativeForProvider } from "../lib/providerRow";
 
 const COMPARE_ID = "compare";
 
@@ -35,8 +36,10 @@ export default function ChartsPanel({
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const comparisonProviders = useMemo(() => {
-    const codex = supported.find((provider) => provider.providerId === "codex");
-    const claude = supported.find((provider) => provider.providerId === "claude");
+    // Compare is provider-versus-provider, so it needs one reading each. Taking
+    // the first was arbitrary once a provider could have two accounts.
+    const codex = representativeForProvider(supported, "codex");
+    const claude = representativeForProvider(supported, "claude");
     return codex && claude ? [codex, claude] as const : null;
   }, [supported]);
 
@@ -70,7 +73,8 @@ export default function ChartsPanel({
   }
 
   const comparing = selectedId === COMPARE_ID && comparisonProviders !== null;
-  const selected = supported.find((p) => p.providerId === selectedId) ?? supported[0];
+  const selected =
+    supported.find((p) => providerRowKey(p) === selectedId) ?? supported[0];
   const tabCount = supported.length + (comparisonProviders ? 1 : 0);
 
   return (
@@ -92,16 +96,17 @@ export default function ChartsPanel({
             </button>
           )}
           {supported.map((p) => {
-            const isActive = !comparing && p.providerId === selected.providerId;
+            const isActive =
+              !comparing && providerRowKey(p) === providerRowKey(selected);
             return (
               <button
-                key={p.providerId}
+                key={providerRowKey(p)}
                 type="button"
                 role="tab"
                 aria-selected={isActive}
                 className="charts-provider-tab"
                 data-active={isActive ? "true" : "false"}
-                onClick={() => setSelectedId(p.providerId)}
+                onClick={() => setSelectedId(providerRowKey(p))}
               >
                 <ProviderIcon
                   providerId={p.providerId}
@@ -109,7 +114,7 @@ export default function ChartsPanel({
                   className="charts-provider-tab__icon"
                   title={p.displayName}
                 />
-                <span>{p.displayName}</span>
+                <span>{p.accountLabel ?? p.displayName}</span>
               </button>
             );
           })}
@@ -119,7 +124,7 @@ export default function ChartsPanel({
         <ProviderComparison providers={[comparisonProviders[0], comparisonProviders[1]]} />
       ) : (
         <ChartsSection
-          key={selected.providerId}
+          key={providerRowKey(selected)}
           providerId={selected.providerId}
           accountEmail={selected.accountEmail}
           providerSnapshot={selected}

--- a/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
@@ -2,7 +2,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type React
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import type { BootstrapState, ProviderUsageSnapshot } from "../types/bridge";
 import { openSettingsWindow, quitApp as quitApplication } from "../lib/tauri";
-import { providerRowKey } from "../lib/providerRow";
+import { providerRowKey, representativeForProvider } from "../lib/providerRow";
 import { useProviders } from "../hooks/useProviders";
 import { useSettings } from "../hooks/useSettings";
 import { useUpdateState } from "../hooks/useUpdateState";
@@ -185,12 +185,29 @@ export default function PopOutPanel({
     }
   }, [providers.length, selectedProviderId, sorted]);
 
-  const selectedProvider = useMemo(
-    () => sorted.find((provider) => provider.providerId === selectedProviderId) ?? null,
-    [selectedProviderId, sorted],
-  );
+  // Which row is open, when the user clicked a specific card. Selection is
+  // still tracked by provider because deep links name a provider, not an
+  // account, so both are kept.
+  const [selectedRowKey, setSelectedRowKey] = useState<string | null>(null);
+
+  const selectedProvider = useMemo(() => {
+    if (selectedProviderId === null) return null;
+    // An exact row wins; `.find` by provider alone opened the first account no
+    // matter which card was clicked, so clicking the second account showed the
+    // first account's numbers under its name.
+    const exact = sorted.find(
+      (provider) =>
+        providerRowKey(provider) === selectedRowKey &&
+        provider.providerId === selectedProviderId,
+    );
+    if (exact) return exact;
+    // Arrived by deep link, or the chosen row is gone: summarise the account
+    // closest to its limit, as every other surface does.
+    return representativeForProvider(sorted, selectedProviderId);
+  }, [selectedProviderId, selectedRowKey, sorted]);
 
   const handleGridClick = useCallback((nextProviderId: string | null) => {
+    if (nextProviderId === null) setSelectedRowKey(null);
     setSelectedProviderId(nextProviderId);
   }, []);
 
@@ -401,7 +418,10 @@ export default function PopOutPanel({
                             resetTimeRelative={settings.resetTimeRelative}
                             showResetWhenExhausted={settings.showResetWhenExhausted}
                             showAsUsed={settings.showAsUsed}
-                            onSelect={() => handleGridClick(p.providerId)}
+                            onSelect={() => {
+                              setSelectedRowKey(providerRowKey(p));
+                              handleGridClick(p.providerId);
+                            }}
                           />
                         </div>
                       </Fragment>

--- a/apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx
+++ b/apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx
@@ -15,6 +15,7 @@ import {
   setSurfaceMode,
 } from "../lib/tauri";
 import type { BootstrapState, ProviderUsageSnapshot, RateWindowSnapshot } from "../types/bridge";
+import { providerRowKey } from "../lib/providerRow";
 
 const FLYOUT_WIDTH = 344;
 const MAX_VISIBLE_PROVIDERS = 6;
@@ -281,7 +282,7 @@ export default function TaskbarFlyout({ state }: { state: BootstrapState }) {
 
         <div className="taskbar-flyout__providers">
           {visibleProviders.map((provider) => (
-            <ProviderRow key={provider.providerId} provider={provider} showAsUsed={settings.showAsUsed} now={now} />
+            <ProviderRow key={providerRowKey(provider)} provider={provider} showAsUsed={settings.showAsUsed} now={now} />
           ))}
           {visibleProviders.length === 0 && (
             <div className="taskbar-flyout__empty">Syncing provider usage…</div>

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
@@ -20,7 +20,11 @@ import { useLocale } from "../hooks/useLocale";
 import { useSurfaceTarget } from "../hooks/useSurfaceMode";
 import { useTrayPanelLayout } from "../hooks/useTrayPanelLayout";
 import MenuCard from "../components/MenuCard";
-import { onePerProvider, providerRowKey } from "../lib/providerRow";
+import {
+  onePerProvider,
+  providerRowKey,
+  representativeForProvider,
+} from "../lib/providerRow";
 import PlanStatusCard from "../components/PlanStatusCard";
 import MenuSurface, {
   MenuEmpty,
@@ -178,10 +182,19 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
       ),
     [settings.enabledProviders, settings.providerOrder, sorted, state.providers],
   );
-  const providersById = useMemo(
-    () => new Map(sorted.map((provider) => [provider.providerId, provider])),
-    [sorted],
-  );
+  const providersById = useMemo(() => {
+    // The dense overview has one tile per provider. `new Map` keyed by provider
+    // keeps the *last* duplicate, so two accounts collapsed to an arbitrary one
+    // that disagreed with the normal view. Choose the same way every other
+    // provider-level summary does.
+    const byProvider = new Map<string, ProviderUsageSnapshot>();
+    for (const provider of sorted) {
+      if (byProvider.has(provider.providerId)) continue;
+      const best = representativeForProvider(sorted, provider.providerId);
+      if (best) byProvider.set(provider.providerId, best);
+    }
+    return byProvider;
+  }, [sorted]);
   const initialProviderId =
     surfaceTarget?.kind === "provider" ? surfaceTarget.providerId : null;
 


### PR DESCRIPTION
Everything left on the review list. All the same mistake: code written when a provider implied exactly one reading, which silently collapses or arbitrarily picks once a provider has an account each.

## Wrong data shown

| Surface | What happened |
|---|---|
| **Native taskbar widget** (`taskbar_widget.rs:541`) | Took the first cache row, so the tile flipped between accounts as fetches finished in different orders — and could disagree with the widget snapshot MCP/statusline read. Now most-constrained, matching #119. |
| **Pop-out detail view** | Clicking the second account opened the **first** account's usage, plan and email under the second account's name. The second account's detail was unreachable. Now resolves the clicked row, falling back to most-constrained for deep links, which name a provider not an account. |
| **Charts panel** | Rendered a tab per reading but resolved and keyed them by provider: two identically-labelled "Codex" tabs sharing a React key, both `aria-selected`, both charting the first account. Tabs now carry the account name; Compare picks a representative rather than the first row. |
| **Dense overview** | Built a provider-keyed `Map`, which keeps the *last* duplicate — an arbitrary account, disagreeing with the normal view. |
| **Deleted accounts** | The backend evicted the rows; the frontend merge only ever upserted, so the card stayed on screen showing its last percentages as though live. A full cache read is now authoritative and drops what it omits. |

## Presentation

- **Row keys** in the accounts panel, taskbar flyout and activity timeline collided across accounts, so React could keep a row's DOM state attached to the other account's data.
- **The sort comparator** returned `-1` for both `compare(a,b)` and `compare(b,a)` when two rows shared a provider. That is not a valid comparator: sort output was implementation-defined and rows swapped between refreshes. Now tiebreaks on account id, and a provider's accounts stay adjacent.
- **PowerToys pipe** emitted two entries under one `id` with nothing to distinguish them; now carries account id and label.

## Verification

The ghost-row test was verified to fail without its fix (`expected [ 'acct-personal', 'acct-work' ] to deeply equal [ 'acct-personal' ]`). New comparator tests cover both accounts surviving, stable order regardless of arrival order, and accounts staying adjacent.

1126 Rust + 295 frontend passing, clippy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying multiple accounts from the same provider, including account-specific identity labels.
  * Provider charts, selections, timelines, taskbar widgets, and flyouts now distinguish between account entries.

* **Bug Fixes**
  * Removed stale provider rows after accounts are removed or settings change.
  * Improved provider ordering and selection consistency when multiple accounts are present.
  * Prevented duplicate or conflicting entries across account-based views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->