### PR TITLE
Show the account email on every usage card, and add it to the flyout

### DIFF
--- a/apps/desktop-tauri/src/components/MenuCard.test.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.test.tsx
@@ -82,6 +82,7 @@ function renderCard(
     showAsUsed?: boolean;
     showResetWhenExhausted?: boolean;
     onLayoutChange?: () => void;
+    showAccount?: boolean;
   } = {},
 ) {
   return render(
@@ -92,6 +93,7 @@ function renderCard(
         resetTimeRelative={true}
         showAsUsed={opts.showAsUsed}
         showResetWhenExhausted={opts.showResetWhenExhausted}
+        showAccount={opts.showAccount}
         onLayoutChange={opts.onLayoutChange}
       />
     </LocaleProvider>,
@@ -262,36 +264,36 @@ describe("MenuCard", () => {
     expect(document.querySelector(".menu-metric--inactive")).not.toBeNull();
   });
 
-  it("names the tracked account and tints it, and stays silent without one", async () => {
+  it("names the account by email with plan, tinted, when several share a provider", async () => {
     const tracked = provider(null);
-    tracked.accountLabel = "work@example.com (team)";
+    tracked.accountEmail = "work@example.com";
+    tracked.planName = "ChatGPT Team";
+    // A custom label must not be what shows; the email is the identity.
+    tracked.accountLabel = "Work";
     tracked.accountTint = "#4f8ff7";
-    const { unmount } = renderCard(tracked);
+    const { unmount } = renderCard(tracked, { showAccount: true });
 
-    const label = await screen.findByText("work@example.com (team)");
+    const label = await screen.findByText("work@example.com (ChatGPT Team)");
     expect(label).toBeInTheDocument();
     expect(label).toHaveStyle({ color: "rgb(79, 143, 247)" });
     unmount();
 
-    // Following the CLI: no account was chosen, so naming one would be a lie.
-    const following = provider(null);
-    following.accountLabel = null;
-    renderCard(following);
-    // Let the locale settle before asserting an absence, so the assertion is
-    // about the account label and not about the card still mounting.
-    await screen.findByText(following.displayName);
+    // A single account for this provider: naming it is noise, so it stays hidden.
+    const single = provider(null);
+    single.accountEmail = "solo@example.com";
+    renderCard(single, { showAccount: false });
+    await screen.findByText(single.displayName);
 
     expect(document.querySelector(".menu-card__account")).toBeNull();
   });
 
-  it("does not print the email twice when the account label already contains it", async () => {
+  it("does not also print the standalone email row once the account line shows it", async () => {
     const snapshot = provider(null);
     snapshot.accountEmail = "tsouth2@example.com";
-    // Labels are seeded from the directory, so they usually embed the email.
-    snapshot.accountLabel = "tsouth2@example.com (prolite)";
-    renderCard(snapshot);
+    snapshot.planName = "Pro Lite";
+    renderCard(snapshot, { showAccount: true });
 
-    await screen.findByText("tsouth2@example.com (prolite)");
+    await screen.findByText("tsouth2@example.com (Pro Lite)");
 
     expect(document.querySelector(".menu-card__email")).toBeNull();
   });

--- a/apps/desktop-tauri/src/components/MenuCard.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.tsx
@@ -604,7 +604,9 @@ export default function MenuCard({
                   {promo.title}
                 </span>
               ))}
-              {planName && (
+              {/* The account line already shows the plan, so drop the badge
+                  when an account is named to avoid printing it twice. */}
+              {planName && !accountName && (
                 <span className="menu-card__plan-badge">{planName}</span>
               )}
             </div>

--- a/apps/desktop-tauri/src/components/MenuCard.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.tsx
@@ -22,6 +22,7 @@ import {
 import PaceDetailsChart from "./PaceDetailsChart";
 import { ProviderIcon } from "./providers/ProviderIcon";
 import { getProviderIcon } from "./providers/providerIcons";
+import { accountIdentityLabel } from "../lib/providerRow";
 
 /** Small copy-to-clipboard button matching macOS CopyIconButton (doc.on.doc → checkmark). */
 function CopyIconButton({ text }: { text: string }) {
@@ -59,6 +60,8 @@ interface MenuCardProps {
   compactMetrics?: boolean;
   /** When false, hide local token activity (overview glance). Default true. */
   showActivitySection?: boolean;
+  /** True when this provider has more than one account. */
+  showAccount?: boolean;
   isRefreshing?: boolean;
   onLayoutChange?: () => void;
 }
@@ -406,6 +409,7 @@ export default function MenuCard({
   showAsUsed = false,
   compactMetrics: _compactMetrics = false,
   showActivitySection = true,
+  showAccount = false,
   isRefreshing = false,
   onLayoutChange,
 }: MenuCardProps) {
@@ -450,14 +454,12 @@ export default function MenuCard({
       : provider.accountEmail
     : null;
   const planName = !isWayfinder ? displayPlanName(provider.planName) : null;
-  // Present only once the user has configured accounts for this provider. While
-  // Ceiling is following the CLI there is no chosen account to name, so the
-  // backend sends null and nothing renders.
-  const accountLabel = !isWayfinder ? (provider.accountLabel ?? null) : null;
-  // Account labels are seeded from the directory and usually already contain the
-  // email, so showing both would print it twice in one row.
-  const email =
-    accountLabel && rawEmail && accountLabel.includes(rawEmail) ? null : rawEmail;
+  // The account's email, shown only when several accounts share this provider.
+  const accountName =
+    !isWayfinder && showAccount ? accountIdentityLabel(provider) : null;
+  // The account line already carries the email, so do not also print the raw
+  // email row below it.
+  const email = accountName ? null : rawEmail;
 
   const metrics: Array<MetricEntry | InactiveMetricEntry> = [
     ...(isWayfinder
@@ -555,7 +557,7 @@ export default function MenuCard({
           />
           <div className="menu-card__name-group">
             <span className="menu-card__name">{provider.displayName}</span>
-            {accountLabel && (
+            {accountName && (
               <span
                 className="menu-card__account"
                 style={
@@ -563,9 +565,9 @@ export default function MenuCard({
                     ? { color: provider.accountTint }
                     : undefined
                 }
-                title={accountLabel}
+                title={accountName}
               >
-                {accountLabel}
+                {accountName}
               </span>
             )}
             {!provider.error && email && <span className="menu-card__email">{email}</span>}

--- a/apps/desktop-tauri/src/components/PlanStatusCard.test.tsx
+++ b/apps/desktop-tauri/src/components/PlanStatusCard.test.tsx
@@ -61,6 +61,65 @@ function provider(
 }
 
 describe("PlanStatusCard", () => {
+  it("names each account by email when a provider has two (the reported bug)", () => {
+    // Exactly the user's setup: two Codex accounts.
+    const { unmount } = render(
+      <PlanStatusCard
+        provider={provider({
+          providerId: "codex",
+          displayName: "Codex",
+          accountId: "acct-personal",
+          accountEmail: "tsouth2@gmail.com",
+          planName: "Pro Lite",
+          // A custom label must NOT be what shows.
+          accountLabel: "Personal",
+        })}
+        showAccount
+        resetTimeRelative
+      />,
+    );
+    expect(screen.getByText("tsouth2@gmail.com (Pro Lite)")).toBeInTheDocument();
+    // The custom label is not shown on the card.
+    expect(screen.queryByText("Personal")).toBeNull();
+    unmount();
+
+    render(
+      <PlanStatusCard
+        provider={provider({
+          providerId: "codex",
+          displayName: "Codex",
+          accountId: "acct-work",
+          accountEmail: "bts@cssi.us",
+          planName: "ChatGPT Team",
+          accountLabel: "Work",
+        })}
+        showAccount
+        resetTimeRelative
+      />,
+    );
+    // The second account shows its OWN email, not "Work".
+    expect(screen.getByText("bts@cssi.us (ChatGPT Team)")).toBeInTheDocument();
+    expect(screen.queryByText("Work")).toBeNull();
+  });
+
+  it("stays on the plan chip for a single account, no email clutter", () => {
+    render(
+      <PlanStatusCard
+        provider={provider({
+          providerId: "codex",
+          displayName: "Codex",
+          accountEmail: "solo@example.com",
+          planName: "ChatGPT Pro",
+        })}
+        showAccount={false}
+        resetTimeRelative
+      />,
+    );
+    // One account: the email is not shown, the plan chip is.
+    expect(screen.queryByText(/solo@example.com/)).toBeNull();
+    expect(screen.getByText("ChatGPT Pro")).toBeInTheDocument();
+  });
+
   it("shows an available Codex reset as a quiet chip", () => {
     render(
       <PlanStatusCard

--- a/apps/desktop-tauri/src/components/PlanStatusCard.tsx
+++ b/apps/desktop-tauri/src/components/PlanStatusCard.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import type { ProviderUsageSnapshot, RateWindowSnapshot } from "../types/bridge";
 import { ProviderIcon } from "./providers/ProviderIcon";
+import { accountIdentityLabel } from "../lib/providerRow";
 import { getProviderIcon } from "./providers/providerIcons";
 import { useFormattedResetTime } from "../hooks/useFormattedResetTime";
 import { useLocale } from "../hooks/useLocale";
@@ -156,6 +157,7 @@ export default function PlanStatusCard({
   showResetWhenExhausted = false,
   showAsUsed = false,
   isRefreshing = false,
+  showAccount = false,
   onSelect,
 }: {
   provider: ProviderUsageSnapshot;
@@ -163,15 +165,18 @@ export default function PlanStatusCard({
   showResetWhenExhausted?: boolean;
   showAsUsed?: boolean;
   isRefreshing?: boolean;
+  // True when this provider has more than one account. With one, the account
+  // name is noise, so it stays hidden and the plan chip shows as before.
+  showAccount?: boolean;
   onSelect?: () => void;
 }) {
   const brand = getProviderIcon(provider.providerId).brandColor;
   const meters = glanceMeters(provider);
   const freshness = capacityFreshness(provider);
   const planName = displayPlanName(provider.planName, provider.displayName);
-  // Present only once accounts are configured. The label already reads
-  // "email (plan)", so it carries the plan too and nothing is lost.
-  const accountLabel = provider.accountLabel ?? null;
+  // The account's email, shown only when several accounts share this provider.
+  // It replaces the plan chip because it already carries the plan.
+  const accountName = showAccount ? accountIdentityLabel(provider) : null;
   const notEnforcedSummary = inactiveWindowSummary(provider, "notEnforced");
   const unavailableSummary = inactiveWindowSummary(provider, "unavailable");
   const resetCredits = codexResetCredits(provider);
@@ -202,7 +207,7 @@ export default function PlanStatusCard({
             {/* Two rows of the same provider are otherwise indistinguishable:
                 both read just "Codex". The account name is what tells them
                 apart, so it outranks the plan for the limited space here. */}
-            {accountLabel ? (
+            {accountName ? (
               <span
                 className="plan-status-card__account"
                 style={
@@ -210,9 +215,9 @@ export default function PlanStatusCard({
                     ? { color: provider.accountTint }
                     : undefined
                 }
-                title={accountLabel}
+                title={accountName}
               >
-                {accountLabel}
+                {accountName}
               </span>
             ) : (
               planName && (

--- a/apps/desktop-tauri/src/lib/providerRow.ts
+++ b/apps/desktop-tauri/src/lib/providerRow.ts
@@ -95,3 +95,23 @@ export function representativeForProvider<
     return (candidate.accountId ?? "") < (best.accountId ?? "") ? candidate : best;
   });
 }
+
+/**
+ * How an account is named on a usage card: its email, plus plan when known.
+ *
+ * Deliberately the email, not `accountLabel`. The label is what the user typed
+ * when adding the account ("Work"), or an auto-derived "email (plan)" when they
+ * did not — so two accounts could show two different *kinds* of thing, one an
+ * email and one a nickname. The email is the real identity and is consistent.
+ * The custom label still names the account on the Accounts page.
+ */
+export function accountIdentityLabel(
+  provider: Pick<
+    ProviderUsageSnapshot,
+    "accountEmail" | "accountLabel" | "planName"
+  >,
+): string | null {
+  const identity = provider.accountEmail ?? provider.accountLabel ?? null;
+  if (!identity) return null;
+  return provider.planName ? `${identity} (${provider.planName})` : identity;
+}

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -9106,3 +9106,16 @@ body:has(.dashboard-shell) #root {
   cursor: default;
   opacity: 0.6;
 }
+
+/* Which account a flyout row reports. Its own line under the provider name,
+   because the topline is space-between and would crush it. */
+.taskbar-flyout__provider-account {
+  margin-top: 1px;
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 15px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -9119,3 +9119,17 @@ body:has(.dashboard-shell) #root {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* Account identity in the pop-out drill-in header and the activity timeline. */
+.provider-focus__account {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  overflow-wrap: anywhere;
+}
+
+.activity-timeline__account {
+  color: var(--text-muted, rgba(255, 255, 255, 0.5));
+  font-weight: 500;
+}

--- a/apps/desktop-tauri/src/surfaces/ActivityTimeline.tsx
+++ b/apps/desktop-tauri/src/surfaces/ActivityTimeline.tsx
@@ -2,7 +2,11 @@ import { Fragment, useEffect, useMemo, useState } from "react";
 import type { ProviderUsageSnapshot, RateWindowSnapshot } from "../types/bridge";
 import { ProviderIcon } from "../components/providers/ProviderIcon";
 import { allMeasuredWindows } from "../lib/capacityPresentation";
-import { providerRowKey } from "../lib/providerRow";
+import {
+  accountIdentityLabel,
+  hasMultipleAccounts,
+  providerRowKey,
+} from "../lib/providerRow";
 
 /**
  * Activity is a calm schedule of the rate-window resets providers report.
@@ -14,6 +18,8 @@ type TimelineEntry = {
   key: string;
   providerId: string;
   displayName: string;
+  /** Account name, when this provider has more than one; else null. */
+  accountName: string | null;
   label: string;
   window: RateWindowSnapshot;
   resetMs: number | null;
@@ -78,10 +84,15 @@ function collectEntries(providers: ProviderUsageSnapshot[]): TimelineEntry[] {
         : NaN;
       entries.push({
         // Includes the account: two accounts both have a "session" window, so
-      // keying on provider alone collided them into one timeline row.
-      key: `${providerRowKey(provider)}:${measured.id}`,
+        // keying on provider alone collided them into one timeline row.
+        key: `${providerRowKey(provider)}:${measured.id}`,
         providerId: provider.providerId,
         displayName: provider.displayName,
+        // Two Codex rows are otherwise identical text; name the account so they
+        // are not indistinguishable.
+        accountName: hasMultipleAccounts(providers, provider.providerId)
+          ? accountIdentityLabel(provider)
+          : null,
         label: measured.label,
         window: measured.window,
         resetMs: Number.isNaN(parsed) ? null : parsed,
@@ -167,7 +178,12 @@ function FeaturedReset({ entry, nowMs }: { entry: TimelineEntry; nowMs: number }
           className="activity-next__icon"
           title={entry.displayName}
         />
-        <span>{entry.displayName}</span>
+        <span>
+          {entry.displayName}
+          {entry.accountName && (
+            <span className="activity-timeline__account"> · {entry.accountName}</span>
+          )}
+        </span>
         <span className="activity-next__window">{entry.label}</span>
       </div>
       <div className="activity-next__glance">
@@ -196,7 +212,12 @@ function TimelineRow({ entry, nowMs }: { entry: TimelineEntry; nowMs: number }) 
             className="activity-row__icon"
             title={entry.displayName}
           />
-          <span className="activity-row__name">{entry.displayName}</span>
+          <span className="activity-row__name">
+            {entry.displayName}
+            {entry.accountName && (
+              <span className="activity-timeline__account"> · {entry.accountName}</span>
+            )}
+          </span>
           <span className="activity-row__label">{entry.label}</span>
           <span className="activity-row__pct">{Math.round(usedPct)}% used</span>
         </div>

--- a/apps/desktop-tauri/src/surfaces/ChartsPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/ChartsPanel.test.tsx
@@ -6,8 +6,17 @@ import type { ProviderUsageSnapshot } from "../types/bridge";
 // Stub the async, backend-fetching ChartsSection so this test exercises only
 // ChartsPanel's own selection logic.
 vi.mock("./settings/providers/sections/charts/ChartsSection", () => ({
-  ChartsSection: ({ providerId }: { providerId: string }) => (
-    <div data-testid="charts-section">{providerId}</div>
+  ChartsSection: ({
+    providerId,
+    accountEmail,
+  }: {
+    providerId: string;
+    accountEmail?: string | null;
+  }) => (
+    <div data-testid="charts-section">
+      {providerId}
+      {accountEmail ? `:${accountEmail}` : ""}
+    </div>
   ),
 }));
 vi.mock("./ProviderComparison", () => ({
@@ -95,6 +104,65 @@ describe("ChartsPanel", () => {
     expect(getByRole("tab", { name: /Compare/ }).getAttribute("aria-selected")).toBe("true");
     fireEvent.click(getByRole("tab", { name: /Claude/ }));
     expect(getByTestId("charts-section").textContent).toBe("claude");
+  });
+
+  it("keeps two accounts of one provider as distinct, selectable tabs", () => {
+    // The reported setup and my own #124 regression: selecting the second
+    // account's chart reverted on the next render because the validity check
+    // compared a row key against a bare providerId.
+    const { getAllByRole, getByTestId, rerender } = render(
+      <ChartsPanel
+        providers={[
+          provider({
+            providerId: "codex",
+            displayName: "Codex",
+            accountId: "acct-personal",
+            accountEmail: "tsouth2@gmail.com",
+            planName: "Pro Lite",
+          }),
+          provider({
+            providerId: "codex",
+            displayName: "Codex",
+            accountId: "acct-work",
+            accountEmail: "bts@cssi.us",
+            planName: "ChatGPT Team",
+          }),
+        ]}
+      />,
+    );
+
+    // Two Codex tabs, each named by its own email — not two bare "Codex".
+    const personalTab = getAllByRole("tab", { name: /tsouth2@gmail.com/ });
+    const workTab = getAllByRole("tab", { name: /bts@cssi.us/ });
+    expect(personalTab).toHaveLength(1);
+    expect(workTab).toHaveLength(1);
+
+    fireEvent.click(workTab[0]);
+    expect(getByTestId("charts-section").textContent).toBe("codex:bts@cssi.us");
+
+    // A background refresh re-renders with a fresh providers array. The
+    // selection must survive rather than snapping back.
+    rerender(
+      <ChartsPanel
+        providers={[
+          provider({
+            providerId: "codex",
+            displayName: "Codex",
+            accountId: "acct-personal",
+            accountEmail: "tsouth2@gmail.com",
+            planName: "Pro Lite",
+          }),
+          provider({
+            providerId: "codex",
+            displayName: "Codex",
+            accountId: "acct-work",
+            accountEmail: "bts@cssi.us",
+            planName: "ChatGPT Team",
+          }),
+        ]}
+      />,
+    );
+    expect(getByTestId("charts-section").textContent).toBe("codex:bts@cssi.us");
   });
 
   it("omits the selector when only one provider is supported", () => {

--- a/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
@@ -6,7 +6,12 @@ import { providerSupportsChartData } from "../lib/providerCharts";
 import { ChartsSection } from "./settings/providers/sections/charts/ChartsSection";
 import ProviderComparison from "./ProviderComparison";
 import { TotalApiValueCard } from "../components/TotalApiValueCard";
-import { providerRowKey, representativeForProvider } from "../lib/providerRow";
+import {
+  accountIdentityLabel,
+  hasMultipleAccounts,
+  providerRowKey,
+  representativeForProvider,
+} from "../lib/providerRow";
 
 const COMPARE_ID = "compare";
 
@@ -51,9 +56,13 @@ export default function ChartsPanel({
       return;
     }
     setSelectedId((prev) =>
-      prev && (supported.some((p) => p.providerId === prev) || (prev === COMPARE_ID && comparisonProviders))
+      prev &&
+      (supported.some((p) => providerRowKey(p) === prev) ||
+        (prev === COMPARE_ID && comparisonProviders))
         ? prev
-        : comparisonProviders ? COMPARE_ID : supported[0].providerId,
+        : comparisonProviders
+          ? COMPARE_ID
+          : providerRowKey(supported[0]),
     );
   }, [supported, comparisonProviders]);
 
@@ -114,7 +123,11 @@ export default function ChartsPanel({
                   className="charts-provider-tab__icon"
                   title={p.displayName}
                 />
-                <span>{p.accountLabel ?? p.displayName}</span>
+                <span>
+                  {hasMultipleAccounts(supported, p.providerId)
+                    ? (accountIdentityLabel(p) ?? p.displayName)
+                    : p.displayName}
+                </span>
               </button>
             );
           })}

--- a/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
@@ -2,7 +2,11 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type React
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import type { BootstrapState, ProviderUsageSnapshot } from "../types/bridge";
 import { openSettingsWindow, quitApp as quitApplication } from "../lib/tauri";
-import { providerRowKey, representativeForProvider } from "../lib/providerRow";
+import {
+  hasMultipleAccounts,
+  providerRowKey,
+  representativeForProvider,
+} from "../lib/providerRow";
 import { useProviders } from "../hooks/useProviders";
 import { useSettings } from "../hooks/useSettings";
 import { useUpdateState } from "../hooks/useUpdateState";
@@ -414,6 +418,7 @@ export default function PopOutPanel({
                         <div className="menu-stack__item">
                           <PlanStatusCard
                             provider={p}
+                            showAccount={hasMultipleAccounts(sorted, p.providerId)}
                             isRefreshing={refreshingProviderIds.has(p.providerId)}
                             resetTimeRelative={settings.resetTimeRelative}
                             showResetWhenExhausted={settings.showResetWhenExhausted}

--- a/apps/desktop-tauri/src/surfaces/ProviderDetailView.tsx
+++ b/apps/desktop-tauri/src/surfaces/ProviderDetailView.tsx
@@ -12,6 +12,7 @@ import { useLocale } from "../hooks/useLocale";
 import { formatRelativeUpdated } from "../lib/relativeTime";
 import { getProviderChartData } from "../lib/tauri";
 import { providerSupportsChartData } from "../lib/providerCharts";
+import { accountIdentityLabel } from "../lib/providerRow";
 import {
   allMeasuredWindows,
   codexResetCredits,
@@ -245,6 +246,9 @@ export default function ProviderDetailView({
   const primaryPercent = Math.round(percentFor(provider.primary, showAsUsed));
   const primaryLabel = provider.primaryLabel?.trim() || "Primary";
   const planName = displayPlanName(provider.planName);
+  // A drill-in opens a specific account, so name it whenever there is an email.
+  // Without this, two accounts on one provider open two identical detail views.
+  const accountName = accountIdentityLabel(provider);
   const resetCredits = codexResetCredits(provider);
   const updated = Number.isNaN(Date.parse(provider.updatedAt))
     ? provider.updatedAt
@@ -262,6 +266,17 @@ export default function ProviderDetailView({
         />
         <div>
           <h2>{provider.displayName}</h2>
+          {accountName && (
+            <span
+              className="provider-focus__account"
+              style={
+                provider.accountTint ? { color: provider.accountTint } : undefined
+              }
+              title={accountName}
+            >
+              {accountName}
+            </span>
+          )}
           <span>{updatedLabel}</span>
         </div>
         <div className="provider-focus__badges">

--- a/apps/desktop-tauri/src/surfaces/TaskbarFlyout.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/TaskbarFlyout.test.tsx
@@ -98,6 +98,32 @@ describe("TaskbarFlyout", () => {
     ];
   });
 
+  it("shows both accounts' emails when a provider has two (screenshot-1 bug)", async () => {
+    // Exactly the reported setup: two Codex accounts in the taskbar flyout.
+    const personal = provider("codex", "Codex", 46, 6 * 24 * 60, "Weekly");
+    personal.accountId = "acct-personal";
+    personal.accountEmail = "tsouth2@gmail.com";
+    personal.planName = "Pro Lite";
+    const work = provider("codex", "Codex", 16, 6 * 24 * 60, "Weekly");
+    work.accountId = "acct-work";
+    work.accountEmail = "bts@cssi.us";
+    work.planName = "ChatGPT Team";
+    providerState.providers = [personal, work];
+
+    render(<TaskbarFlyout state={state} />);
+
+    // Both accounts appear, each named by its own email — not two bare "Codex"
+    // rows, which is what the user saw.
+    expect(
+      await screen.findByText("tsouth2@gmail.com (Pro Lite)"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("bts@cssi.us (ChatGPT Team)")).toBeInTheDocument();
+    // Both rows still render.
+    expect(screen.getAllByText("Codex")).toHaveLength(2);
+    expect(screen.getByText("46%")).toBeInTheDocument();
+    expect(screen.getByText("16%")).toBeInTheDocument();
+  });
+
   it("shows at-a-glance usage and the soonest provider reset", async () => {
     providerState.providers[0].resetCreditsAvailable = 1;
     render(<TaskbarFlyout state={state} />);

--- a/apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx
+++ b/apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx
@@ -15,7 +15,11 @@ import {
   setSurfaceMode,
 } from "../lib/tauri";
 import type { BootstrapState, ProviderUsageSnapshot, RateWindowSnapshot } from "../types/bridge";
-import { providerRowKey } from "../lib/providerRow";
+import {
+  accountIdentityLabel,
+  hasMultipleAccounts,
+  providerRowKey,
+} from "../lib/providerRow";
 
 const FLYOUT_WIDTH = 344;
 const MAX_VISIBLE_PROVIDERS = 6;
@@ -92,11 +96,15 @@ function flyoutWindows(provider: ProviderUsageSnapshot): ConstrainingWindow[] {
   return [...preferred, ...remaining].slice(0, MAX_VISIBLE_WINDOWS_PER_PROVIDER);
 }
 
-function ProviderRow({ provider, showAsUsed, now }: {
+function ProviderRow({ provider, showAccount, showAsUsed, now }: {
   provider: ProviderUsageSnapshot;
+  // True when this provider has more than one account, so the account name is
+  // needed to tell its rows apart. With one account it would be noise.
+  showAccount: boolean;
   showAsUsed: boolean;
   now: number;
 }) {
+  const accountName = showAccount ? accountIdentityLabel(provider) : null;
   const icon = getProviderIcon(provider.providerId);
   if (provider.error) {
     return (
@@ -107,6 +115,11 @@ function ProviderRow({ provider, showAsUsed, now }: {
             <span className="taskbar-flyout__provider-name">{provider.displayName}</span>
             <span className="taskbar-flyout__provider-unavailable">Unavailable</span>
           </div>
+          {accountName && (
+            <div className="taskbar-flyout__provider-account" title={accountName}>
+              {accountName}
+            </div>
+          )}
           <div className="taskbar-flyout__provider-status">Last sync failed · open Ceiling for details</div>
         </div>
       </div>
@@ -132,6 +145,11 @@ function ProviderRow({ provider, showAsUsed, now }: {
             </span>
           )}
         </div>
+        {accountName && (
+          <div className="taskbar-flyout__provider-account" title={accountName}>
+            {accountName}
+          </div>
+        )}
         <div className="taskbar-flyout__meters">
           {windows.map(({ id, label, window }) => {
             const percent = valueFor(window, showAsUsed);
@@ -282,7 +300,13 @@ export default function TaskbarFlyout({ state }: { state: BootstrapState }) {
 
         <div className="taskbar-flyout__providers">
           {visibleProviders.map((provider) => (
-            <ProviderRow key={providerRowKey(provider)} provider={provider} showAsUsed={settings.showAsUsed} now={now} />
+            <ProviderRow
+              key={providerRowKey(provider)}
+              provider={provider}
+              showAccount={hasMultipleAccounts(taskbarProviders, provider.providerId)}
+              showAsUsed={settings.showAsUsed}
+              now={now}
+            />
           ))}
           {visibleProviders.length === 0 && (
             <div className="taskbar-flyout__empty">Syncing provider usage…</div>

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
@@ -21,6 +21,7 @@ import { useSurfaceTarget } from "../hooks/useSurfaceMode";
 import { useTrayPanelLayout } from "../hooks/useTrayPanelLayout";
 import MenuCard from "../components/MenuCard";
 import {
+  hasMultipleAccounts,
   onePerProvider,
   providerRowKey,
   representativeForProvider,
@@ -453,6 +454,7 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
         {isOverview ? (
           <PlanStatusCard
             provider={p}
+            showAccount={hasMultipleAccounts(sorted, p.providerId)}
             isRefreshing={refreshingProviderIds.has(p.providerId)}
             resetTimeRelative={settings.resetTimeRelative}
             showResetWhenExhausted={settings.showResetWhenExhausted}
@@ -462,6 +464,7 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
         ) : (
           <MenuCard
             provider={p}
+            showAccount={hasMultipleAccounts(sorted, p.providerId)}
             isRefreshing={refreshingProviderIds.has(p.providerId)}
             hideEmail={settings.hidePersonalInfo}
             resetTimeRelative={settings.resetTimeRelative}


### PR DESCRIPTION
Both problems reported from the installed build:
1. Taskbar flyout showed **two identical "Codex" rows** with no account label.
2. Overview showed the email for the primary account but the custom label ("Work") for the second.

## One cause behind both

The flyout's `ProviderRow` rendered only `provider.displayName` — the label work in #120 only touched the overview and detail cards, never this component. It now shows the account on its own line under the provider name.

The overview showed `accountLabel`, which is:
- the user's custom text ("Work") when they set one, or
- an auto-derived "email (plan)" when they did not.

So one account read as an email and the other as a nickname. All cards now show the account **email with its plan** — the real, consistent identity. The custom label still names the account on the Accounts page and drives its tint.

## Gated on multiple accounts

`accountIdentityLabel` is shown only when a provider actually has more than one account (`hasMultipleAccounts`, which existed unused). A single-account setup is unchanged — it still shows the plan chip, not a redundant email.

`accountIdentityLabel` centralises the "email (plan)" formatting so the flyout, overview and detail cards can't drift apart.

## Verified

Measured against the real stylesheet at the flyout's actual 361px width — both account lines render in full (291px content column) without clipping. The two MenuCard tests from #120 were rewritten for the email model. 295 frontend tests, locale in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account-specific labels when multiple accounts use the same provider.
  * Display account email and plan details across taskbar, tray, timeline, charts, and provider views.
  * Added distinct, selectable tabs for multiple provider accounts.
  * Preserved account selection when provider data refreshes.

* **Bug Fixes**
  * Prevented duplicate or generic provider labels when accounts share a provider.
  * Avoided repeating plan information when account details are displayed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->