### PR TITLE
Scan each account's own directory for its charts (SOU-308)

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -8,7 +8,7 @@
 use chrono::{DateTime, Datelike, Local, LocalResult, NaiveDate, TimeZone, Timelike, Utc};
 use codexbar::core::OpenAIDashboardCacheStore;
 use codexbar::cost_scanner::{
-    CostScanner, CostSummary, CostUsageReport, CurrentUsageWindow,
+    CostScanner, CostSummary, CostUsageReport, CurrentUsageWindow, get_cost_usage_report_scoped,
     get_cost_usage_report_with_windows,
 };
 use codexbar::locale::{self, LocaleKey};
@@ -331,10 +331,19 @@ struct PersistedChartCache {
 pub async fn get_provider_chart_data(
     provider_id: String,
     account_email: Option<String>,
+    account_id: Option<String>,
     source_label: Option<String>,
     usage_windows: Option<Vec<LocalUsageWindowRequest>>,
 ) -> ProviderChartData {
     let usage_windows = usage_windows.unwrap_or_default();
+    // An account's local logs live under its own config directory. Scanning
+    // that directory is what makes its charts distinct from another account's;
+    // without it every account shows the same machine-wide totals.
+    let scoped_home = account_id.as_deref().and_then(|id| {
+        codexbar::core::ProviderId::from_cli_name(&provider_id).and_then(|provider| {
+            codexbar::core::ConfiguredAccounts::load().config_dir_for_account(provider, id)
+        })
+    });
     let cache_key = chart_cache_key(
         &provider_id,
         account_email.as_deref(),
@@ -347,7 +356,13 @@ pub async fn get_provider_chart_data(
         if current_unix_ms().saturating_sub(cached.refreshed_at_ms)
             > CHART_CACHE_TTL.as_millis() as i64
         {
-            schedule_chart_cache_refresh(cache_key, provider_id, account_email, usage_windows);
+            schedule_chart_cache_refresh(
+                cache_key,
+                provider_id,
+                account_email,
+                scoped_home.clone(),
+                usage_windows,
+            );
         }
         return cached.data;
     }
@@ -357,7 +372,13 @@ pub async fn get_provider_chart_data(
     if !quota_history.is_empty() {
         let mut immediate = ProviderChartData::empty(provider_id.clone());
         immediate.quota_history = quota_history;
-        schedule_chart_cache_refresh(cache_key, provider_id, account_email, usage_windows);
+        schedule_chart_cache_refresh(
+            cache_key,
+            provider_id,
+            account_email,
+            scoped_home.clone(),
+            usage_windows,
+        );
         return immediate;
     }
 
@@ -367,6 +388,7 @@ pub async fn get_provider_chart_data(
         build_provider_chart_data_with_cancel(
             provider_id,
             account_email,
+            scoped_home,
             usage_windows,
             Some(cancel),
         )
@@ -413,6 +435,7 @@ fn schedule_chart_cache_refresh(
     key: String,
     provider_id: String,
     account_email: Option<String>,
+    scoped_home: Option<std::path::PathBuf>,
     usage_windows: Vec<LocalUsageWindowRequest>,
 ) {
     let Ok(mut active) = active_cache_refreshes().lock() else {
@@ -426,7 +449,13 @@ fn schedule_chart_cache_refresh(
     tauri::async_runtime::spawn(async move {
         let refresh_key = key.clone();
         let refreshed = tauri::async_runtime::spawn_blocking(move || {
-            build_provider_chart_data_with_cancel(provider_id, account_email, usage_windows, None)
+            build_provider_chart_data_with_cancel(
+                provider_id,
+                account_email,
+                scoped_home,
+                usage_windows,
+                None,
+            )
         })
         .await;
         match refreshed {
@@ -867,12 +896,13 @@ pub(crate) fn build_provider_chart_data(
     provider_id: String,
     account_email: Option<String>,
 ) -> ProviderChartData {
-    build_provider_chart_data_with_cancel(provider_id, account_email, Vec::new(), None)
+    build_provider_chart_data_with_cancel(provider_id, account_email, None, Vec::new(), None)
 }
 
 fn build_provider_chart_data_with_cancel(
     provider_id: String,
     account_email: Option<String>,
+    scoped_home: Option<std::path::PathBuf>,
     usage_window_requests: Vec<LocalUsageWindowRequest>,
     cancel: Option<Arc<AtomicBool>>,
 ) -> ProviderChartData {
@@ -897,7 +927,7 @@ fn build_provider_chart_data_with_cancel(
     // reset-aligned windows so one pass over the logs serves both.
     let (comparison_specs, comparison_windows) = comparison_period_specs(Utc::now());
     usage_windows.extend(comparison_windows);
-    let report = get_cost_usage_report_with_windows(&provider_id, 30, &usage_windows);
+    let report = get_cost_usage_report_scoped(&provider_id, 30, &usage_windows, scoped_home);
     let cost_history: Vec<DailyCostPoint> = report
         .as_ref()
         .map(|report| {

--- a/apps/desktop-tauri/src/lib/tauri.ts
+++ b/apps/desktop-tauri/src/lib/tauri.ts
@@ -253,12 +253,14 @@ export function getAppInfo(): Promise<AppInfoBridge> {
 export function getProviderChartData(
   providerId: string,
   accountEmail?: string,
+  accountId?: string,
   usageWindows?: import("../types/bridge").LocalUsageWindowRequest[],
   sourceLabel?: string,
 ): Promise<ProviderChartData> {
   return invoke<ProviderChartData>("get_provider_chart_data", {
     providerId,
     accountEmail,
+    accountId,
     usageWindows,
     sourceLabel,
   });

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -9133,3 +9133,9 @@ body:has(.dashboard-shell) #root {
   color: var(--text-muted, rgba(255, 255, 255, 0.5));
   font-weight: 500;
 }
+
+.charts-compare-note {
+  margin: 0 0 10px;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}

--- a/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
@@ -134,7 +134,13 @@ export default function ChartsPanel({
         </div>
       )}
       {comparing ? (
-        <ProviderComparison providers={[comparisonProviders[0], comparisonProviders[1]]} />
+        <>
+          <p className="charts-compare-note">
+            Compares all Codex usage against all Claude usage on this machine,
+            across every account.
+          </p>
+          <ProviderComparison providers={[comparisonProviders[0], comparisonProviders[1]]} />
+        </>
       ) : (
         <ChartsSection
           key={providerRowKey(selected)}

--- a/apps/desktop-tauri/src/surfaces/ProviderComparison.tsx
+++ b/apps/desktop-tauri/src/surfaces/ProviderComparison.tsx
@@ -123,7 +123,12 @@ export default function ProviderComparison({ providers }: {
     const load = async () => {
       try {
         const results = await Promise.all(providers.map(async (provider) => {
-          const result = await getProviderChartData(provider.providerId, provider.accountEmail ?? undefined, providerLocalUsageWindows(provider));
+          const result = await getProviderChartData(
+            provider.providerId,
+            provider.accountEmail ?? undefined,
+            undefined,
+            providerLocalUsageWindows(provider),
+          );
           return [provider.providerId, result] as const;
         }));
         if (cancelled) return;

--- a/apps/desktop-tauri/src/surfaces/ProviderDetailView.tsx
+++ b/apps/desktop-tauri/src/surfaces/ProviderDetailView.tsx
@@ -219,7 +219,11 @@ export default function ProviderDetailView({
     }
     let cancelled = false;
     setChartData(null);
-    getProviderChartData(provider.providerId, provider.accountEmail ?? undefined)
+    getProviderChartData(
+      provider.providerId,
+      provider.accountEmail ?? undefined,
+      provider.accountId ?? undefined,
+    )
       .then((data) => {
         if (!cancelled) setChartData(data);
       })

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
@@ -239,6 +239,7 @@ describe("ChartsSection local usage summary", () => {
     expect(tauriMocks.getProviderChartData).toHaveBeenCalledWith(
       "claude",
       undefined,
+      undefined,
       [],
       "Claude CLI",
     );

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -413,7 +413,13 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
         cancelled = true;
       };
     }
-    getProviderChartData(providerId, accountEmail ?? undefined, usageWindows, sourceLabel)
+    getProviderChartData(
+      providerId,
+      accountEmail ?? undefined,
+      providerSnapshot?.accountId ?? undefined,
+      usageWindows,
+      sourceLabel,
+    )
       .then((d) => {
         if (!cancelled) {
           chartDataCache.set(cacheKey, d);
@@ -497,6 +503,7 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
         const next = await getProviderChartData(
           providerId,
           accountEmail ?? undefined,
+          providerSnapshot?.accountId ?? undefined,
           usageWindows,
           sourceLabel,
         );

--- a/rust/src/core/configured_accounts.rs
+++ b/rust/src/core/configured_accounts.rs
@@ -104,6 +104,32 @@ impl ConfiguredAccounts {
         }
     }
 
+    /// The config directory of the account with `account_id`, if configured.
+    ///
+    /// Charts scan a provider's local logs, which live under this directory. An
+    /// account's charts are only distinct from another's when scanned from its
+    /// own directory rather than the shared ambient one.
+    pub fn config_dir_for_account(
+        &self,
+        provider: ProviderId,
+        account_id: &str,
+    ) -> Option<PathBuf> {
+        fn find<I: crate::core::AccountIdentity>(
+            data: &crate::core::DirectoryAccountData<I>,
+            account_id: &str,
+        ) -> Option<PathBuf> {
+            data.accounts
+                .iter()
+                .find(|account| account.id.to_string() == account_id)
+                .map(|account| account.config_dir.clone())
+        }
+        match provider {
+            ProviderId::Codex => find(&self.codex, account_id),
+            ProviderId::Claude => find(&self.claude, account_id),
+            _ => None,
+        }
+    }
+
     /// Whether `provider` stores its accounts as config directories.
     pub fn supports(provider: ProviderId) -> bool {
         matches!(provider, ProviderId::Codex | ProviderId::Claude)

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -526,12 +526,27 @@ struct ClaudeUsageRecord {
 /// Cost usage scanner
 pub struct CostScanner {
     days: u32,
+    /// When set, scan only this provider config directory's logs instead of
+    /// every candidate home. This is what makes one account's charts distinct
+    /// from another's: each account is its own directory.
+    scoped_home: Option<PathBuf>,
 }
 
 impl CostScanner {
     /// Create a new scanner for the last N days
     pub fn new(days: u32) -> Self {
-        Self { days }
+        Self {
+            days,
+            scoped_home: None,
+        }
+    }
+
+    /// A scanner that reads only `home`'s logs (an account's config directory).
+    pub fn scoped_to(days: u32, home: PathBuf) -> Self {
+        Self {
+            days,
+            scoped_home: Some(home),
+        }
     }
 
     /// Scan Codex local logs
@@ -628,6 +643,16 @@ impl CostScanner {
     }
 
     fn get_codex_sessions_dirs(&self) -> Vec<PathBuf> {
+        if let Some(home) = &self.scoped_home {
+            // Only this account's directory. No ambient home, no custom dirs, no
+            // WSL roots, or the scan would pull in other accounts' logs.
+            return codex_sessions_dir_candidates(
+                None,
+                Some(home.to_string_lossy().into_owned()),
+                &[],
+                &[],
+            );
+        }
         let settings = Settings::load();
         let codex_home = std::env::var("CODEX_HOME").ok();
         codex_sessions_dir_candidates(
@@ -722,6 +747,9 @@ impl CostScanner {
     }
 
     fn get_claude_projects_dir(&self) -> PathBuf {
+        if let Some(home) = &self.scoped_home {
+            return home.join("projects");
+        }
         if let Ok(claude_config) = std::env::var("CLAUDE_CONFIG_DIR") {
             let trimmed = claude_config.trim();
             if !trimmed.is_empty() {
@@ -1098,8 +1126,23 @@ pub fn get_cost_usage_report_with_windows(
     days: u32,
     current_windows: &[CurrentUsageWindow],
 ) -> Option<CostUsageReport> {
+    get_cost_usage_report_scoped(provider, days, current_windows, None)
+}
+
+/// As [`get_cost_usage_report_with_windows`], but scoped to one account's config
+/// directory when `scoped_home` is given, so its charts reflect only its own
+/// logs rather than every account's on the machine.
+pub fn get_cost_usage_report_scoped(
+    provider: &str,
+    days: u32,
+    current_windows: &[CurrentUsageWindow],
+    scoped_home: Option<PathBuf>,
+) -> Option<CostUsageReport> {
     let days = days.max(1);
-    let scanner = CostScanner::new(days);
+    let scanner = match scoped_home {
+        Some(home) => CostScanner::scoped_to(days, home),
+        None => CostScanner::new(days),
+    };
     match provider {
         "codex" => Some(scan_codex_report(&scanner, days, current_windows)),
         "claude" => Some(scan_claude_report(&scanner, days, current_windows)),
@@ -1675,6 +1718,69 @@ mod tests {
     /// therefore shrank every total, while the summary scanner still counted
     /// it. The archived rollout must be included, and a rollout present in both
     /// places must still count once.
+    /// Two accounts live in two config directories. A scoped scan must read only
+    /// its own directory, or both accounts' charts show the same machine-wide
+    /// totals (the reported bug: identical stats on both Codex tabs).
+    #[test]
+    fn a_scoped_scan_reads_only_its_own_account_directory() {
+        let today = Local::now().date_naive();
+        let day = today.format("%Y-%m-%d").to_string();
+        let ts = format!("{day}T10:00:00.000Z");
+        let line = |input: u32| {
+            format!(
+                r#"{{"timestamp":"{ts}","type":"event_msg","payload":{{"type":"token_count","info":{{"last_token_usage":{{"input_tokens":{input},"cached_input_tokens":0,"output_tokens":0}}}}}}}}"#
+            )
+        };
+
+        fn day_dir(home: &Path, today: chrono::NaiveDate) -> PathBuf {
+            home.join("sessions")
+                .join(today.format("%Y").to_string())
+                .join(today.format("%m").to_string())
+                .join(today.format("%d").to_string())
+        }
+
+        // Personal home: one rollout of 1000 input tokens.
+        let personal = tempfile::tempdir().unwrap();
+        let pd = day_dir(personal.path(), today);
+        std::fs::create_dir_all(&pd).unwrap();
+        std::fs::write(
+            pd.join(format!(
+                "rollout-{day}-11111111-1111-1111-1111-111111111111.jsonl"
+            )),
+            line(1000),
+        )
+        .unwrap();
+
+        // Work home: one rollout of 7000 input tokens.
+        let work = tempfile::tempdir().unwrap();
+        let wd = day_dir(work.path(), today);
+        std::fs::create_dir_all(&wd).unwrap();
+        std::fs::write(
+            wd.join(format!(
+                "rollout-{day}-22222222-2222-2222-2222-222222222222.jsonl"
+            )),
+            line(7000),
+        )
+        .unwrap();
+
+        let personal_report = scan_codex_report(
+            &CostScanner::scoped_to(2, personal.path().to_path_buf()),
+            2,
+            &[],
+        );
+        let work_report = scan_codex_report(
+            &CostScanner::scoped_to(2, work.path().to_path_buf()),
+            2,
+            &[],
+        );
+
+        // Each account sees only its own logs, not the other's, and not the sum.
+        assert_eq!(personal_report.thirty_days.input_tokens, 1000);
+        assert_eq!(work_report.thirty_days.input_tokens, 7000);
+        assert_eq!(personal_report.thirty_days.sessions_count, 1);
+        assert_eq!(work_report.thirty_days.sessions_count, 1);
+    }
+
     #[test]
     fn codex_report_counts_archived_rollouts_exactly_once() {
         let _guard = codex_home_lock().lock().expect("codex home lock");


### PR DESCRIPTION
Two Codex accounts showed **identical charts** — same 148.8M weekly, same cost-by-model, everything. Both tabs cached separately by email, but the local-log scan read `CODEX_HOME` (the ambient directory) regardless of which account was selected, so every account showed the same machine-wide totals. The on-screen "not account-scoped" notice was the symptom.

## Fix

An account *is* a config directory, and its logs live under it. The cost scanner now takes an optional scoped home; when set it reads only that directory's `sessions`/`archived_sessions` (Codex) or `projects` (Claude), with no ambient home, custom dirs, or WSL roots mixed in. `get_provider_chart_data` resolves the scoped home from the account id via `ConfiguredAccounts` and threads it through the scan and the cache-refresh path.

So with two accounts in separate directories — the recommended setup, and yours — each account's charts finally reflect only its own usage.

## Compare clarification

Added a line to the Compare tab: *"Compares all Codex usage against all Claude usage on this machine, across every account."* Compare and the machine-wide API-value card are deliberately left unscoped.

## Verified end to end

A test scans two temp directories and asserts each scoped scan sees only its own logs (1000 vs 7000 tokens). Confirmed it **fails without the fix** — where it instead read the real `~/.codex` and returned **148,471,987 tokens**, exactly the 148.8M from the bug report. That's about as direct a confirmation of the root cause as it gets.

## Honest caveat (unchanged)

A directory that *historically* held several accounts still mixes their old logs, because the logs carry no account id — that's the SOU-297 limitation. New logs are separated by directory going forward. For you: `~/.codex-work` is clean (only work logs since you created it); `~/.codex` still contains the pre-split mixed history, which the notice explains.

1132 Rust + 299 frontend tests, clippy clean.