### PR TITLE
Show one Charts section per provider, not per account

### DIFF
--- a/apps/desktop-tauri/src/surfaces/ChartsPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/ChartsPanel.test.tsx
@@ -106,11 +106,10 @@ describe("ChartsPanel", () => {
     expect(getByTestId("charts-section").textContent).toBe("claude");
   });
 
-  it("keeps two accounts of one provider as distinct, selectable tabs", () => {
-    // The reported setup and my own #124 regression: selecting the second
-    // account's chart reverted on the next render because the validity check
-    // compared a row key against a bare providerId.
-    const { getAllByRole, getByTestId, rerender } = render(
+  it("collapses a provider's accounts into a single tab, since local logs are machine-wide", () => {
+    // Local activity is scanned from logs that carry no account identity, so
+    // two Codex accounts must not present as two tabs of separable data.
+    const { getAllByRole, getByTestId } = render(
       <ChartsPanel
         providers={[
           provider({
@@ -118,51 +117,25 @@ describe("ChartsPanel", () => {
             displayName: "Codex",
             accountId: "acct-personal",
             accountEmail: "tsouth2@gmail.com",
-            planName: "Pro Lite",
           }),
           provider({
             providerId: "codex",
             displayName: "Codex",
             accountId: "acct-work",
             accountEmail: "bts@cssi.us",
-            planName: "ChatGPT Team",
           }),
+          provider({ providerId: "claude", displayName: "Claude" }),
         ]}
       />,
     );
 
-    // Two Codex tabs, each named by its own email — not two bare "Codex".
-    const personalTab = getAllByRole("tab", { name: /tsouth2@gmail.com/ });
-    const workTab = getAllByRole("tab", { name: /bts@cssi.us/ });
-    expect(personalTab).toHaveLength(1);
-    expect(workTab).toHaveLength(1);
+    // One Codex tab, one Claude tab, plus Compare — not one tab per account.
+    expect(getAllByRole("tab", { name: /Codex/ })).toHaveLength(1);
+    expect(getAllByRole("tab", { name: /Claude/ })).toHaveLength(1);
 
-    fireEvent.click(workTab[0]);
-    expect(getByTestId("charts-section").textContent).toBe("codex:bts@cssi.us");
-
-    // A background refresh re-renders with a fresh providers array. The
-    // selection must survive rather than snapping back.
-    rerender(
-      <ChartsPanel
-        providers={[
-          provider({
-            providerId: "codex",
-            displayName: "Codex",
-            accountId: "acct-personal",
-            accountEmail: "tsouth2@gmail.com",
-            planName: "Pro Lite",
-          }),
-          provider({
-            providerId: "codex",
-            displayName: "Codex",
-            accountId: "acct-work",
-            accountEmail: "bts@cssi.us",
-            planName: "ChatGPT Team",
-          }),
-        ]}
-      />,
-    );
-    expect(getByTestId("charts-section").textContent).toBe("codex:bts@cssi.us");
+    fireEvent.click(getAllByRole("tab", { name: /Codex/ })[0]);
+    // One Codex section, not one per account.
+    expect(getByTestId("charts-section").textContent).toMatch(/^codex/);
   });
 
   it("omits the selector when only one provider is supported", () => {

--- a/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
@@ -7,9 +7,7 @@ import { ChartsSection } from "./settings/providers/sections/charts/ChartsSectio
 import ProviderComparison from "./ProviderComparison";
 import { TotalApiValueCard } from "../components/TotalApiValueCard";
 import {
-  accountIdentityLabel,
-  hasMultipleAccounts,
-  providerRowKey,
+  onePerProvider,
   representativeForProvider,
 } from "../lib/providerRow";
 
@@ -33,8 +31,10 @@ export default function ChartsPanel({
 
   const supported = useMemo(
     () =>
-      providers.filter(
-        (p) => providerSupportsChartData(p.providerId) && !p.error,
+      onePerProvider(
+        providers.filter(
+          (p) => providerSupportsChartData(p.providerId) && !p.error,
+        ),
       ),
     [providers],
   );
@@ -57,12 +57,12 @@ export default function ChartsPanel({
     }
     setSelectedId((prev) =>
       prev &&
-      (supported.some((p) => providerRowKey(p) === prev) ||
+      (supported.some((p) => p.providerId === prev) ||
         (prev === COMPARE_ID && comparisonProviders))
         ? prev
         : comparisonProviders
           ? COMPARE_ID
-          : providerRowKey(supported[0]),
+          : supported[0].providerId,
     );
   }, [supported, comparisonProviders]);
 
@@ -83,7 +83,7 @@ export default function ChartsPanel({
 
   const comparing = selectedId === COMPARE_ID && comparisonProviders !== null;
   const selected =
-    supported.find((p) => providerRowKey(p) === selectedId) ?? supported[0];
+    supported.find((p) => p.providerId === selectedId) ?? supported[0];
   const tabCount = supported.length + (comparisonProviders ? 1 : 0);
 
   return (
@@ -105,17 +105,16 @@ export default function ChartsPanel({
             </button>
           )}
           {supported.map((p) => {
-            const isActive =
-              !comparing && providerRowKey(p) === providerRowKey(selected);
+            const isActive = !comparing && p.providerId === selected.providerId;
             return (
               <button
-                key={providerRowKey(p)}
+                key={p.providerId}
                 type="button"
                 role="tab"
                 aria-selected={isActive}
                 className="charts-provider-tab"
                 data-active={isActive ? "true" : "false"}
-                onClick={() => setSelectedId(providerRowKey(p))}
+                onClick={() => setSelectedId(p.providerId)}
               >
                 <ProviderIcon
                   providerId={p.providerId}
@@ -123,11 +122,7 @@ export default function ChartsPanel({
                   className="charts-provider-tab__icon"
                   title={p.displayName}
                 />
-                <span>
-                  {hasMultipleAccounts(supported, p.providerId)
-                    ? (accountIdentityLabel(p) ?? p.displayName)
-                    : p.displayName}
-                </span>
+                <span>{p.displayName}</span>
               </button>
             );
           })}
@@ -143,7 +138,7 @@ export default function ChartsPanel({
         </>
       ) : (
         <ChartsSection
-          key={providerRowKey(selected)}
+          key={selected.providerId}
           providerId={selected.providerId}
           accountEmail={selected.accountEmail}
           providerSnapshot={selected}

--- a/apps/desktop-tauri/src/surfaces/ProviderDetailView.tsx
+++ b/apps/desktop-tauri/src/surfaces/ProviderDetailView.tsx
@@ -219,11 +219,7 @@ export default function ProviderDetailView({
     }
     let cancelled = false;
     setChartData(null);
-    getProviderChartData(
-      provider.providerId,
-      provider.accountEmail ?? undefined,
-      provider.accountId ?? undefined,
-    )
+    getProviderChartData(provider.providerId, provider.accountEmail ?? undefined)
       .then((data) => {
         if (!cancelled) setChartData(data);
       })

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -416,7 +416,7 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
     getProviderChartData(
       providerId,
       accountEmail ?? undefined,
-      providerSnapshot?.accountId ?? undefined,
+      undefined,
       usageWindows,
       sourceLabel,
     )
@@ -503,7 +503,7 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
         const next = await getProviderChartData(
           providerId,
           accountEmail ?? undefined,
-          providerSnapshot?.accountId ?? undefined,
+          undefined,
           usageWindows,
           sourceLabel,
         );


### PR DESCRIPTION
Two Codex accounts showed the same charts, or the second showed nothing. This is not a bug in the split — it's that local activity **cannot** be split by account, confirmed with your real data:

- `~/.codex` (personal): **99** log files
- `~/.codex-work` (work): **0** log files — a credential and nothing else

Codex writes every session log to the default `~/.codex` regardless of which account is signed in; setting `CODEX_HOME` per login only moved the credential. Combined with the deeper fact that the logs carry no account identity, a per-account chart view can only ever show identical machine-wide totals or an empty directory. Neither is real.

## Change

The Charts page has one tab per provider again — Compare, Codex, Claude, Cursor. The account distinction stays where it is genuine: the overview, flyout and tray quota bars come from each account's **API**, not the logs, and remain per-account.

The directory-scoping added in #126 is left in as a latent capability for anyone who truly keeps separate log directories, but the UI no longer scopes local activity by account, so the charts reflect the whole machine — which is exactly what the on-screen "not account-scoped" notice already says.

## Test

The test that asserted two distinct account tabs now asserts the opposite: two Codex accounts collapse to one Codex tab.

## Why this is the right call, not a retreat

The per-account chart tabs were showing a lie — identical numbers or an empty directory dressed up as separable data. Removing them removes the lie. There is no real per-account chart data to lose, because the logs don't contain it.