### PR TITLE
Lay the usage-period boxes out consistently across providers

### DIFF
--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -7708,11 +7708,18 @@ body:has(.dashboard-shell) #root {
 }
 .usage-periods {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
-  gap: 8px;
-}
-.usage-periods[data-card-count="4"] {
+  /* Always two columns, so a provider with three boxes (one reset window)
+     and one with four (two windows) lay out consistently instead of
+     reflowing between 3-across and 2x2 with different box sizes. */
   grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  align-items: start;
+}
+/* A single current window (e.g. Codex when its 5-hour limit is lifted)
+   spans the top row, keeping the 7-day/30-day pair aligned beneath it
+   rather than leaving an empty cell. */
+.usage-periods[data-window-count="1"] .usage-period--current {
+  grid-column: 1 / -1;
 }
 .usage-period {
   min-width: 0;

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -647,6 +647,7 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
         <div
           className="usage-periods"
           data-card-count={usagePeriods.length}
+          data-window-count={usagePeriods.filter((period) => period.current).length}
           aria-label="Local usage summary"
         >
           {usagePeriods.map((period) => (


### PR DESCRIPTION
Reported: the Codex charts boxes look off-balance, and the Claude boxes are bigger with empty space.

## Cause

The boxes reflowed by count:
- **4 boxes** (Claude — two reset windows) forced a 2×2 with half-width boxes.
- **3 boxes** (Codex — its 5-hour window is currently lifted) fell through to `auto-fit`, cramming three narrower boxes into one row, each stretched to the tall window box's height.

So the providers looked different and their boxes were different sizes.

## Fix

Always two columns, and a lone current window spans the top row:
- **Codex:** `[Weekly window]` full width / `[7 days] [30 days]`
- **Claude:** `[5-hour] [Weekly]` / `[7 days] [30 days]`

The 7-day and 30-day boxes are now the same size on both providers. `align-items: start` so the shorter period boxes don't stretch to the taller window box and leave empty space.

## Not a placeholder box

Per your point: the 5-hour window is only *lifted*, not gone. No fake box is added — when OpenAI enforces it again, Codex simply has two windows and becomes a 2×2 on its own. Nothing is designed around its absence.

## Verified

Measured against the real stylesheet at 620px: Codex's weekly spans full width with the period pair aligned beneath (590 / 291 / 291), Claude is a clean 2×2 (291 all round), window boxes 121px tall vs period boxes 99px — natural heights, no stretched empty space.