### PR TITLE
Grok weekly label + local session token analytics

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -202,6 +202,10 @@ pub struct LocalTokenBreakdown {
     pub output_tokens: u64,
     pub cache_read_tokens: u64,
     pub cache_write_tokens: u64,
+    /// Reasoning tokens when the provider reports them (Grok). Not added into
+    /// `processed_tokens` because they are often already counted in output.
+    #[serde(default)]
+    pub reasoning_tokens: u64,
 }
 
 /// Per-model local spend for a period. `cost` is `None` for models with no
@@ -1331,6 +1335,7 @@ fn current_unix_ms() -> i64 {
 fn localized_estimate_note(provider_id: &str, lang: codexbar::settings::Language) -> String {
     match provider_id {
         "claude" => locale::get_text(lang, LocaleKey::PanelEstimatedFromLocalLogsClaude),
+        "grok" => locale::get_text(lang, LocaleKey::PanelEstimatedFromLocalLogsGrok),
         _ => locale::get_text(lang, LocaleKey::PanelEstimatedFromLocalLogs),
     }
 }
@@ -1344,6 +1349,11 @@ fn scan_local_cost(
     match provider_id {
         "codex" => Some(scanner.scan_codex_with_cancel(cancel)),
         "claude" => Some(scanner.scan_claude_with_cancel(cancel)),
+        // Grok has no cancel-aware summary path yet; use the full report scan.
+        "grok" => {
+            let _ = (scanner, cancel);
+            codexbar::cost_scanner::get_cost_usage_report("grok", days).map(|r| r.thirty_days)
+        }
         _ => None,
     }
 }
@@ -1356,6 +1366,7 @@ fn token_breakdown(provider_id: &str, summary: &CostSummary) -> LocalTokenBreakd
         output_tokens: normalized.output_tokens,
         cache_read_tokens: normalized.cache_read_tokens,
         cache_write_tokens: normalized.cache_write_tokens,
+        reasoning_tokens: summary.reasoning_tokens,
     }
 }
 
@@ -2206,6 +2217,7 @@ mod tests {
                 output_tokens: 14_000_000,
                 cache_read_tokens: 4_810_000_000,
                 cache_write_tokens: 120_000_000,
+                reasoning_tokens: 0,
             }
         );
     }
@@ -2228,6 +2240,30 @@ mod tests {
                 output_tokens: 2_000_000,
                 cache_read_tokens: 808_000_000,
                 cache_write_tokens: 0,
+                reasoning_tokens: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn grok_token_breakdown_folds_cache_and_surfaces_reasoning() {
+        let summary = CostSummary {
+            input_tokens: 1000,
+            output_tokens: 100,
+            cached_tokens: 800,
+            cache_read_tokens: 800,
+            reasoning_tokens: 40,
+            ..CostSummary::default()
+        };
+        assert_eq!(
+            token_breakdown("grok", &summary),
+            LocalTokenBreakdown {
+                processed_tokens: 1100, // fresh 200 + output 100 + cache 800
+                fresh_input_tokens: 200,
+                output_tokens: 100,
+                cache_read_tokens: 800,
+                cache_write_tokens: 0,
+                reasoning_tokens: 40,
             }
         );
     }

--- a/apps/desktop-tauri/src/i18n/keys.ts
+++ b/apps/desktop-tauri/src/i18n/keys.ts
@@ -486,6 +486,7 @@ export const ALL_LOCALE_KEYS = [
   "PanelTopModelPrefix",
   "PanelEstimatedFromLocalLogs",
   "PanelEstimatedFromLocalLogsClaude",
+  "PanelEstimatedFromLocalLogsGrok",
   "PanelExpected",
   "PanelActual",
   "PanelUsedSuffix",

--- a/apps/desktop-tauri/src/lib/providerCharts.ts
+++ b/apps/desktop-tauri/src/lib/providerCharts.ts
@@ -5,8 +5,8 @@ import type {
 } from "../types/bridge";
 
 // Providers whose live snapshots are sampled into local quota history, and/or
-// that have transcript/cost scanners. Grok has no local CLI transcripts, but
-// Ceiling records its weekly-pool snapshots so the Limits chart still grows.
+// that have transcript/cost scanners. Grok also has local session logs under
+// ~/.grok/sessions (tokens, cache, effort, projects).
 const PROVIDER_CHART_DATA_IDS = new Set([
   "claude",
   "codex",
@@ -67,7 +67,7 @@ function usageWindowRequest(
 export function providerLocalUsageWindows(
   provider: ProviderUsageSnapshot | null | undefined,
 ): LocalUsageWindowRequest[] {
-  if (!provider || !["codex", "claude"].includes(provider.providerId.toLowerCase())) {
+  if (!provider || !["codex", "claude", "grok"].includes(provider.providerId.toLowerCase())) {
     return [];
   }
   return [
@@ -84,11 +84,11 @@ export function providerLocalUsageWindows(
   ].filter((window): window is LocalUsageWindowRequest => window !== null);
 }
 
-/** Whether an active Codex/Claude limit cannot be tied to a provider reset boundary. */
+/** Whether an active Codex/Claude/Grok limit cannot be tied to a provider reset boundary. */
 export function providerHasUnavailableResetBoundary(
   provider: ProviderUsageSnapshot | null | undefined,
 ): boolean {
-  if (!provider || !["codex", "claude"].includes(provider.providerId.toLowerCase())) {
+  if (!provider || !["codex", "claude", "grok"].includes(provider.providerId.toLowerCase())) {
     return false;
   }
   return hasUnavailableResetBoundary(provider.primary)

--- a/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
@@ -73,7 +73,7 @@ export default function ChartsPanel({
         <div className="charts-empty">
           <strong>No charts yet</strong>
           Limits and local usage history show up here for providers Ceiling can
-          chart — Codex, Claude, Cursor, OpenAI, and Grok (weekly pool samples).
+          chart — Codex, Claude, Cursor, OpenAI, and Grok (weekly pool + local sessions).
         </div>
       </div>
     );

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -87,12 +87,17 @@ function TokenMix({ breakdown }: { breakdown: LocalTokenBreakdown }) {
   const cacheShare = breakdown.processedTokens > 0
     ? (cachedTokens / breakdown.processedTokens) * 100
     : 0;
-  const items = [
+  const items: Array<[string, number]> = [
     ["Fresh input", breakdown.freshInputTokens],
     ["Output", breakdown.outputTokens],
     ["Cache read", breakdown.cacheReadTokens],
     ["Cache write", breakdown.cacheWriteTokens],
-  ] as const;
+  ];
+  // Reasoning is often already inside output; show it as a separate metric,
+  // not as an extra bucket that would inflate processed totals.
+  if ((breakdown.reasoningTokens ?? 0) > 0) {
+    items.push(["Reasoning", breakdown.reasoningTokens ?? 0]);
+  }
   return (
     <div className="usage-token-mix" aria-label="Last 7 days token breakdown">
       <div className="usage-token-mix__header">
@@ -404,7 +409,7 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
     setEnriching(
       cached !== null &&
       !cached.localUsage &&
-      ["codex", "claude"].includes(providerId.toLowerCase()),
+      ["codex", "claude", "grok"].includes(providerId.toLowerCase()),
     );
     setFailed(false);
     if (!providerSupportsChartData(providerId)) {
@@ -425,7 +430,7 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
           chartDataCache.set(cacheKey, d);
           setData(d);
           setEnriching(
-            !d.localUsage && ["codex", "claude"].includes(providerId.toLowerCase()),
+            !d.localUsage && ["codex", "claude", "grok"].includes(providerId.toLowerCase()),
           );
           setLoading(false);
         }
@@ -485,9 +490,9 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
     if (
       !data ||
       data.localUsage ||
-      !["codex", "claude"].includes(providerId.toLowerCase())
+      !["codex", "claude", "grok"].includes(providerId.toLowerCase())
     ) {
-      if (data?.localUsage || !["codex", "claude"].includes(providerId.toLowerCase())) {
+      if (data?.localUsage || !["codex", "claude", "grok"].includes(providerId.toLowerCase())) {
         setEnriching(false);
       }
       return;

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -762,6 +762,8 @@ export interface LocalTokenBreakdown {
   outputTokens: number;
   cacheReadTokens: number;
   cacheWriteTokens: number;
+  /** Present when the provider reports reasoning tokens (e.g. Grok). */
+  reasoningTokens?: number;
 }
 
 export interface ProviderChartData {

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -35,7 +35,7 @@ App-Bound Encryption details.
 | **Cursor** | Your signed-in Cursor IDE session (`state.vscdb`), or cursor.com cookies you provide | cursor.com |
 | **GitHub Copilot** | Your GitHub CLI / Git Credential Manager token (or a device-flow sign-in) | api.github.com, or your GitHub Enterprise host |
 | **Gemini** | The OAuth token from the Gemini CLI (`~/.gemini/oauth_creds.json`) | Google Code Assist and OAuth endpoints |
-| **Grok** | The OIDC session from Grok Build (`~/.grok/auth.json` via `grok login`), or grok.com cookies you provide; tokens refresh via auth.x.ai | grok.com, auth.x.ai |
+| **Grok** | The OIDC session from Grok Build (`~/.grok/auth.json` via `grok login`), or grok.com cookies you provide; tokens refresh via auth.x.ai; plus local `~/.grok/sessions` logs for tokens / cache / effort / projects | grok.com, auth.x.ai |
 | Other providers | A local session or token on this PC, or the provider's own usage endpoint | The provider's own domain only |
 
 ## Network policy

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -19,8 +19,8 @@ use crate::codex_costs::{
 use crate::codex_sessions::{codex_sessions_dir_candidates, default_wsl_roots};
 use crate::core::{CostUsageDayRange, CostUsagePricing, JsonlScanner};
 use crate::grok_costs::{
-    discover_grok_session_dirs, grok_sessions_dir, load_session_meta, parse_grok_updates_file,
-    should_count_grok_record, GrokUsageRecord,
+    GrokUsageRecord, discover_grok_session_dirs, grok_sessions_dir, load_session_meta,
+    parse_grok_updates_file, should_count_grok_record,
 };
 use crate::settings::Settings;
 
@@ -118,10 +118,7 @@ pub struct ModelTokenCounts {
 /// twice.
 pub fn provider_folds_cache_into_input(provider_id: &str) -> bool {
     // Codex and Grok report cache-read tokens inside the input total.
-    matches!(
-        provider_id.to_ascii_lowercase().as_str(),
-        "codex" | "grok"
-    )
+    matches!(provider_id.to_ascii_lowercase().as_str(), "codex" | "grok")
 }
 
 /// Token buckets with each token counted exactly once, whatever the provider's

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -1,4 +1,4 @@
-//! Local cost-usage scanner for Codex and Claude
+//! Local cost-usage scanner for Codex, Claude, and Grok Build
 //!
 //! Scans local JSONL log files to aggregate token usage and calculate costs
 
@@ -14,10 +14,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use crate::codex_costs::scan_codex_file_cost;
 use crate::codex_costs::{
     add_codex_record_to_summary, add_codex_records_to_summary, codex_period_start,
-    codex_scan_dates, scan_codex_file_cost_for_range,
+    codex_scan_dates, project_bucket, scan_codex_file_cost_for_range,
 };
 use crate::codex_sessions::{codex_sessions_dir_candidates, default_wsl_roots};
 use crate::core::{CostUsageDayRange, CostUsagePricing, JsonlScanner};
+use crate::grok_costs::{
+    discover_grok_session_dirs, grok_sessions_dir, load_session_meta, parse_grok_updates_file,
+    should_count_grok_record, GrokUsageRecord,
+};
 use crate::settings::Settings;
 
 /// Cost summary from scanning local logs
@@ -35,6 +39,9 @@ pub struct CostSummary {
     pub cache_read_tokens: u64,
     /// Input tokens written into a provider cache.
     pub cache_write_tokens: u64,
+    /// Reasoning / thinking tokens reported by the provider (display-only;
+    /// often a subset of output, so not added into processed totals).
+    pub reasoning_tokens: u64,
     /// Number of sessions/conversations scanned
     pub sessions_count: u32,
     /// Cost breakdown by model
@@ -110,7 +117,11 @@ pub struct ModelTokenCounts {
 /// adds the cache bucket to a Codex input count therefore counts those tokens
 /// twice.
 pub fn provider_folds_cache_into_input(provider_id: &str) -> bool {
-    provider_id.eq_ignore_ascii_case("codex")
+    // Codex and Grok report cache-read tokens inside the input total.
+    matches!(
+        provider_id.to_ascii_lowercase().as_str(),
+        "codex" | "grok"
+    )
 }
 
 /// Token buckets with each token counted exactly once, whatever the provider's
@@ -1109,6 +1120,7 @@ pub fn has_cost_usage_sources() -> bool {
         .iter()
         .any(|dir| dir.exists())
         || scanner.get_claude_projects_dir().exists()
+        || grok_sessions_dir(None).is_some_and(|dir| dir.exists())
 }
 
 /// Build chart history and period summaries with one transcript pass.
@@ -1146,6 +1158,7 @@ pub fn get_cost_usage_report_scoped(
     match provider {
         "codex" => Some(scan_codex_report(&scanner, days, current_windows)),
         "claude" => Some(scan_claude_report(&scanner, days, current_windows)),
+        "grok" => Some(scan_grok_report(&scanner, days, current_windows)),
         _ => None,
     }
 }
@@ -1195,6 +1208,7 @@ fn merge_summary(target: &mut CostSummary, source: &CostSummary) {
     target.cached_tokens += source.cached_tokens;
     target.cache_read_tokens += source.cache_read_tokens;
     target.cache_write_tokens += source.cache_write_tokens;
+    target.reasoning_tokens += source.reasoning_tokens;
     target.sessions_count += source.sessions_count;
     for (model, cost) in &source.by_model {
         *target.by_model.entry(model.clone()).or_insert(0.0) += cost;
@@ -1482,6 +1496,146 @@ fn scan_codex_report(
     }
 
     rollups.finish(days)
+}
+
+fn add_grok_record_to_summary(summary: &mut CostSummary, record: &GrokUsageRecord) {
+    // No public SuperGrok API rate card — keep dollars unset, still track tokens.
+    summary.unknown_models.insert(record.model.clone());
+    summary.input_tokens += record.input;
+    summary.output_tokens += record.output;
+    summary.cached_tokens += record.cache_read;
+    summary.cache_read_tokens += record.cache_read;
+    summary.reasoning_tokens += record.reasoning;
+
+    let model_tokens = summary
+        .by_model_tokens
+        .entry(record.model.clone())
+        .or_default();
+    model_tokens.input_tokens += record.input;
+    model_tokens.output_tokens += record.output;
+    model_tokens.cached_tokens += record.cache_read;
+    model_tokens.cache_read_tokens += record.cache_read;
+    model_tokens.calls += 1;
+
+    let effort = match record
+        .effort
+        .as_deref()
+        .map(str::trim)
+        .filter(|e| !e.is_empty())
+    {
+        Some(effort) => effort.to_ascii_lowercase(),
+        None => "unknown".to_string(),
+    };
+    let effort_tokens = summary.by_effort_tokens.entry(effort).or_default();
+    effort_tokens.input_tokens += record.input;
+    effort_tokens.output_tokens += record.output;
+    effort_tokens.cached_tokens += record.cache_read;
+    effort_tokens.cache_read_tokens += record.cache_read;
+    effort_tokens.calls += 1;
+
+    let project = project_bucket(record.project.as_deref());
+    let project_tokens = summary.by_project_tokens.entry(project).or_default();
+    project_tokens.input_tokens += record.input;
+    project_tokens.output_tokens += record.output;
+    project_tokens.cached_tokens += record.cache_read;
+    project_tokens.cache_read_tokens += record.cache_read;
+    project_tokens.calls += 1;
+}
+
+fn scan_grok_report(
+    scanner: &CostScanner,
+    days: u32,
+    windows: &[CurrentUsageWindow],
+) -> CostUsageReport {
+    let _ = scanner;
+    let mut daily = empty_daily_summaries(days);
+    let mut current_windows = empty_current_window_summaries(windows);
+    let Some(sessions_root) = grok_sessions_dir(None) else {
+        return finish_report(daily, days, None, (0, 0, 0), None, current_windows);
+    };
+    if !sessions_root.exists() {
+        return finish_report(daily, days, None, (0, 0, 0), None, current_windows);
+    }
+
+    let today = Local::now().date_naive();
+    let seven_day_start = today - Duration::days(6);
+    let cutoff = Utc::now() - Duration::days(days as i64);
+    let mut seen = HashSet::new();
+    let mut undated = CostSummary::default();
+    let mut latest: Option<(DateTime<Utc>, CostSummary)> = None;
+    let mut today_sessions = 0;
+    let mut seven_day_sessions = 0;
+    let mut period_sessions = 0;
+
+    for session_dir in discover_grok_session_dirs(&sessions_root) {
+        let meta = load_session_meta(&session_dir);
+        let updates = session_dir.join("updates.jsonl");
+        let records = parse_grok_updates_file(&updates, &meta, cutoff);
+        if records.is_empty() {
+            continue;
+        }
+
+        let mut file_summary = CostSummary::default();
+        let mut latest_recorded_at: Option<DateTime<Utc>> = None;
+        let mut contributed_today = false;
+        let mut contributed_seven_days = false;
+        let mut counted = 0u32;
+
+        for record in &records {
+            if !should_count_grok_record(record, cutoff, &mut seen) {
+                continue;
+            }
+            counted += 1;
+            add_grok_record_to_summary(&mut file_summary, record);
+            add_to_current_windows(&mut current_windows, windows, record.timestamp, |summary| {
+                add_grok_record_to_summary(summary, record)
+            });
+            if let Some(timestamp) = record.timestamp {
+                let date = timestamp.with_timezone(&Local).date_naive();
+                let day = date.format("%Y-%m-%d").to_string();
+                if let Some(day_summary) = daily.get_mut(&day) {
+                    add_grok_record_to_summary(day_summary, record);
+                }
+                contributed_today |= date == today;
+                contributed_seven_days |= date >= seven_day_start;
+                if latest_recorded_at.is_none_or(|seen_at| timestamp > seen_at) {
+                    latest_recorded_at = Some(timestamp);
+                }
+            } else {
+                add_grok_record_to_summary(&mut undated, record);
+            }
+        }
+
+        if counted == 0 {
+            continue;
+        }
+        file_summary.sessions_count = 1;
+        period_sessions += 1;
+        today_sessions += u32::from(contributed_today);
+        seven_day_sessions += u32::from(contributed_seven_days);
+
+        let fallback_modified = fs::metadata(&updates)
+            .and_then(|metadata| metadata.modified())
+            .ok()
+            .map(DateTime::<Utc>::from)
+            .unwrap_or(DateTime::<Utc>::UNIX_EPOCH);
+        let recorded_at = latest_recorded_at.unwrap_or(fallback_modified);
+        if latest
+            .as_ref()
+            .is_none_or(|(seen_at, _)| recorded_at > *seen_at)
+        {
+            latest = Some((recorded_at, file_summary));
+        }
+    }
+
+    finish_report(
+        daily,
+        days,
+        latest.map(|(_, summary)| summary),
+        (today_sessions, seven_day_sessions, period_sessions),
+        Some(&undated),
+        current_windows,
+    )
 }
 
 fn scan_claude_report(
@@ -2227,5 +2381,58 @@ mod tests {
 
         let _ = std::fs::remove_file(&file_a);
         let _ = std::fs::remove_file(&file_b);
+    }
+
+    #[test]
+    fn grok_report_rolls_up_tokens_cache_effort_and_project() {
+        let home = tempfile::tempdir().unwrap();
+        let session = home
+            .path()
+            .join("sessions")
+            .join("proj")
+            .join("019f-session");
+        std::fs::create_dir_all(&session).unwrap();
+        let now = Utc::now();
+        let ts = now.timestamp() as f64;
+        let ms = now.timestamp_millis();
+        let updates = format!(
+            r#"{{"timestamp":{ts},"method":"_x.ai/session/update","params":{{"sessionId":"s1","_meta":{{"eventId":"e1","agentTimestampMs":{ms}}},"update":{{"sessionUpdate":"turn_completed","prompt_id":"p1","usage":{{"inputTokens":1000,"outputTokens":100,"cachedReadTokens":800,"reasoningTokens":40,"modelUsage":{{"grok-4.5-build":{{"inputTokens":1000,"outputTokens":100,"cachedReadTokens":800,"reasoningTokens":40}}}}}}}}}}}}"#
+        );
+        std::fs::write(session.join("updates.jsonl"), updates).unwrap();
+        std::fs::write(
+            session.join("summary.json"),
+            r#"{"info":{"cwd":"C:\\projects\\personal\\ceiling"},"reasoning_effort":"high","current_model_id":"grok-4.5"}"#,
+        )
+        .unwrap();
+
+        // SAFETY: test-only env override; restored after the scan.
+        let prev = std::env::var_os("GROK_HOME");
+        // SAFETY: single-threaded test isolation for GROK_HOME.
+        unsafe {
+            std::env::set_var("GROK_HOME", home.path());
+        }
+        let report = scan_grok_report(&CostScanner::new(7), 7, &[]);
+        match prev {
+            Some(value) => unsafe { std::env::set_var("GROK_HOME", value) },
+            None => unsafe { std::env::remove_var("GROK_HOME") },
+        }
+
+        assert_eq!(report.thirty_days.sessions_count, 1);
+        assert_eq!(report.thirty_days.input_tokens, 1000);
+        assert_eq!(report.thirty_days.output_tokens, 100);
+        assert_eq!(report.thirty_days.cache_read_tokens, 800);
+        assert_eq!(report.thirty_days.reasoning_tokens, 40);
+        assert!(report.thirty_days.by_effort_tokens.contains_key("high"));
+        assert!(report.thirty_days.by_project_tokens.contains_key("ceiling"));
+        assert!(
+            report
+                .thirty_days
+                .by_model_tokens
+                .contains_key("grok-4.5-build")
+        );
+        assert_eq!(report.thirty_days.total_cost_usd, 0.0);
+        let normalized = report.thirty_days.normalized_tokens("grok");
+        assert_eq!(normalized.fresh_input_tokens, 200);
+        assert_eq!(normalized.cache_read_tokens, 800);
     }
 }

--- a/rust/src/grok_costs.rs
+++ b/rust/src/grok_costs.rs
@@ -1,0 +1,422 @@
+//! Local Grok Build session usage scanner.
+//!
+//! Reads `~/.grok/sessions/<project>/<session-id>/updates.jsonl` turn_completed
+//! records (plus sibling `summary.json` for project + reasoning effort). Grok
+//! does not publish per-token API rates for SuperGrok pool usage, so costs stay
+//! unpriced; token / cache / effort / project rollups still feed charts.
+
+use chrono::{DateTime, TimeZone, Utc};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+/// One turn-level usage row from a Grok session log.
+#[derive(Debug, Clone)]
+pub struct GrokUsageRecord {
+    pub timestamp: Option<DateTime<Utc>>,
+    pub model: String,
+    pub effort: Option<String>,
+    pub project: Option<String>,
+    pub input: u64,
+    pub output: u64,
+    pub cache_read: u64,
+    pub reasoning: u64,
+    pub dedup_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SessionMeta {
+    pub project: Option<String>,
+    pub effort: Option<String>,
+    pub model: Option<String>,
+}
+
+/// Resolve Grok home (`GROK_HOME` or `~/.grok`).
+pub fn grok_home() -> Option<PathBuf> {
+    if let Ok(home) = std::env::var("GROK_HOME") {
+        let trimmed = home.trim();
+        if !trimmed.is_empty() {
+            return Some(PathBuf::from(trimmed));
+        }
+    }
+    dirs::home_dir().map(|home| home.join(".grok"))
+}
+
+/// Root of encoded project session trees.
+pub fn grok_sessions_dir(home: Option<&Path>) -> Option<PathBuf> {
+    home.map(|h| h.join("sessions"))
+        .or_else(|| grok_home().map(|h| h.join("sessions")))
+}
+
+/// Session directories that contain an `updates.jsonl` (or may after filtering).
+pub fn discover_grok_session_dirs(sessions_root: &Path) -> Vec<PathBuf> {
+    let mut sessions = Vec::new();
+    let Ok(project_entries) = fs::read_dir(sessions_root) else {
+        return sessions;
+    };
+    for project in project_entries.flatten() {
+        let project_path = project.path();
+        if !project_path.is_dir() {
+            continue;
+        }
+        // Skip the search index and any non-project files at the root.
+        let name = project.file_name();
+        if name == "session_search.sqlite" || name.to_string_lossy().ends_with(".sqlite") {
+            continue;
+        }
+        let Ok(session_entries) = fs::read_dir(&project_path) else {
+            continue;
+        };
+        for session in session_entries.flatten() {
+            let session_path = session.path();
+            if !session_path.is_dir() {
+                continue;
+            }
+            if session_path.join("updates.jsonl").is_file() {
+                sessions.push(session_path);
+            }
+        }
+    }
+    sessions.sort();
+    sessions
+}
+
+pub fn load_session_meta(session_dir: &Path) -> SessionMeta {
+    let summary_path = session_dir.join("summary.json");
+    let Ok(raw) = fs::read_to_string(&summary_path) else {
+        return SessionMeta::default();
+    };
+    let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+        return SessionMeta::default();
+    };
+    let cwd = value
+        .pointer("/info/cwd")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let project = cwd.map(|path| {
+        Path::new(path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(path)
+            .to_string()
+    });
+    let effort = value
+        .get("reasoning_effort")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_ascii_lowercase());
+    let model = value
+        .get("current_model_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    SessionMeta {
+        project,
+        effort,
+        model,
+    }
+}
+
+/// Parse turn_completed usage rows from one session's updates.jsonl.
+pub fn parse_grok_updates_file(
+    path: &Path,
+    meta: &SessionMeta,
+    cutoff: DateTime<Utc>,
+) -> Vec<GrokUsageRecord> {
+    let Ok(file) = File::open(path) else {
+        return Vec::new();
+    };
+    let reader = BufReader::new(file);
+    let mut records = Vec::new();
+    for line in reader.lines().map_while(Result::ok) {
+        if !line.contains("turn_completed") {
+            continue;
+        }
+        let Ok(event) = serde_json::from_str::<GrokUpdateEvent>(&line) else {
+            continue;
+        };
+        for record in records_from_event(&event, meta) {
+            if record
+                .timestamp
+                .is_some_and(|ts| ts < cutoff)
+            {
+                continue;
+            }
+            records.push(record);
+        }
+    }
+    records
+}
+
+fn records_from_event(event: &GrokUpdateEvent, meta: &SessionMeta) -> Vec<GrokUsageRecord> {
+    let update = match &event.params.update {
+        Some(u) if u.session_update.as_deref() == Some("turn_completed") => u,
+        _ => return Vec::new(),
+    };
+    let usage = match &update.usage {
+        Some(u) => u,
+        None => return Vec::new(),
+    };
+
+    let timestamp = parse_timestamp(event.timestamp, event.params.meta.as_ref());
+    let dedup_key = event
+        .params
+        .meta
+        .as_ref()
+        .and_then(|m| m.event_id.clone())
+        .or_else(|| {
+            update.prompt_id.as_ref().map(|pid| {
+                format!(
+                    "{}:{}",
+                    event.params.session_id.as_deref().unwrap_or(""),
+                    pid
+                )
+            })
+        });
+    let project = meta.project.clone();
+    let effort = meta.effort.clone();
+    let fallback_model = update
+        .meta
+        .as_ref()
+        .and_then(|m| m.model_id.clone())
+        .or_else(|| meta.model.clone())
+        .unwrap_or_else(|| "grok".to_string());
+
+    if let Some(model_usage) = usage.model_usage.as_ref()
+        && !model_usage.is_empty()
+    {
+        return model_usage
+            .iter()
+            .map(|(model, counts)| GrokUsageRecord {
+                timestamp,
+                model: model.clone(),
+                effort: effort.clone(),
+                project: project.clone(),
+                input: counts.input_tokens.unwrap_or(0),
+                output: counts.output_tokens.unwrap_or(0),
+                cache_read: counts.cached_read_tokens.unwrap_or(0),
+                reasoning: counts.reasoning_tokens.unwrap_or(0),
+                dedup_key: dedup_key
+                    .as_ref()
+                    .map(|key| format!("{key}:{model}")),
+            })
+            .filter(|r| r.input > 0 || r.output > 0 || r.cache_read > 0 || r.reasoning > 0)
+            .collect();
+    }
+
+    let record = GrokUsageRecord {
+        timestamp,
+        model: fallback_model,
+        effort,
+        project,
+        input: usage.input_tokens.unwrap_or(0),
+        output: usage.output_tokens.unwrap_or(0),
+        cache_read: usage.cached_read_tokens.unwrap_or(0),
+        reasoning: usage.reasoning_tokens.unwrap_or(0),
+        dedup_key,
+    };
+    if record.input > 0 || record.output > 0 || record.cache_read > 0 || record.reasoning > 0 {
+        vec![record]
+    } else {
+        Vec::new()
+    }
+}
+
+fn parse_timestamp(
+    root_timestamp: Option<f64>,
+    meta: Option<&GrokParamsMeta>,
+) -> Option<DateTime<Utc>> {
+    if let Some(ms) = meta.and_then(|m| m.agent_timestamp_ms) {
+        let secs = (ms / 1000) as i64;
+        let nsecs = ((ms % 1000) * 1_000_000) as u32;
+        return Utc.timestamp_opt(secs, nsecs).single();
+    }
+    let ts = root_timestamp?;
+    if !ts.is_finite() || ts <= 0.0 {
+        return None;
+    }
+    // Seconds if small; milliseconds if clearly past year ~2001 in ms scale.
+    if ts > 1_000_000_000_000.0 {
+        let ms = ts as i64;
+        Utc.timestamp_opt(ms / 1000, ((ms % 1000) * 1_000_000) as u32)
+            .single()
+    } else {
+        Utc.timestamp_opt(ts as i64, 0).single()
+    }
+}
+
+pub fn should_count_grok_record(
+    record: &GrokUsageRecord,
+    cutoff: DateTime<Utc>,
+    seen: &mut HashSet<String>,
+) -> bool {
+    if record.timestamp.is_some_and(|ts| ts < cutoff) {
+        return false;
+    }
+    if let Some(key) = record.dedup_key.as_ref() {
+        if !seen.insert(key.clone()) {
+            return false;
+        }
+    }
+    true
+}
+
+#[derive(Debug, Deserialize)]
+struct GrokUpdateEvent {
+    #[serde(default)]
+    timestamp: Option<f64>,
+    #[serde(default)]
+    params: GrokUpdateParams,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokUpdateParams {
+    #[serde(default, rename = "sessionId")]
+    session_id: Option<String>,
+    #[serde(default, rename = "_meta")]
+    meta: Option<GrokParamsMeta>,
+    #[serde(default)]
+    update: Option<GrokSessionUpdate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GrokParamsMeta {
+    #[serde(default, rename = "eventId")]
+    event_id: Option<String>,
+    #[serde(default, rename = "agentTimestampMs")]
+    agent_timestamp_ms: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GrokSessionUpdate {
+    #[serde(default, rename = "sessionUpdate")]
+    session_update: Option<String>,
+    #[serde(default, rename = "prompt_id")]
+    prompt_id: Option<String>,
+    #[serde(default, rename = "_meta")]
+    meta: Option<GrokUpdateMeta>,
+    #[serde(default)]
+    usage: Option<GrokUsageBlock>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GrokUpdateMeta {
+    #[serde(default, rename = "modelId")]
+    model_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GrokUsageBlock {
+    #[serde(default, rename = "inputTokens")]
+    input_tokens: Option<u64>,
+    #[serde(default, rename = "outputTokens")]
+    output_tokens: Option<u64>,
+    #[serde(default, rename = "cachedReadTokens")]
+    cached_read_tokens: Option<u64>,
+    #[serde(default, rename = "reasoningTokens")]
+    reasoning_tokens: Option<u64>,
+    #[serde(default, rename = "modelUsage")]
+    model_usage: Option<std::collections::HashMap<String, GrokModelUsageCounts>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GrokModelUsageCounts {
+    #[serde(default, rename = "inputTokens")]
+    input_tokens: Option<u64>,
+    #[serde(default, rename = "outputTokens")]
+    output_tokens: Option<u64>,
+    #[serde(default, rename = "cachedReadTokens")]
+    cached_read_tokens: Option<u64>,
+    #[serde(default, rename = "reasoningTokens")]
+    reasoning_tokens: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    fn write_session(dir: &Path, updates: &str, summary: &str) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join("summary.json"), summary).unwrap();
+        let mut f = File::create(dir.join("updates.jsonl")).unwrap();
+        f.write_all(updates.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn parses_turn_completed_with_cache_and_reasoning() {
+        let dir = tempdir().unwrap();
+        let session = dir.path().join("sess");
+        let ts = Utc.with_ymd_and_hms(2026, 7, 20, 12, 0, 0).unwrap().timestamp() as f64;
+        let ms = (ts * 1000.0) as i64;
+        let updates = format!(
+            r#"{{"timestamp":{ts},"method":"_x.ai/session/update","params":{{"sessionId":"s1","_meta":{{"eventId":"e1","agentTimestampMs":{ms}}},"update":{{"sessionUpdate":"turn_completed","prompt_id":"p1","usage":{{"inputTokens":1000,"outputTokens":100,"totalTokens":1100,"cachedReadTokens":800,"reasoningTokens":40,"modelUsage":{{"grok-4.5-build":{{"inputTokens":1000,"outputTokens":100,"cachedReadTokens":800,"reasoningTokens":40}}}}}}}}}}}}"#
+        );
+        let summary = r#"{
+          "info": {"id": "s1", "cwd": "C:\\projects\\personal\\ceiling"},
+          "current_model_id": "grok-4.5",
+          "reasoning_effort": "high"
+        }"#;
+        write_session(&session, &updates, summary);
+
+        let meta = load_session_meta(&session);
+        assert_eq!(meta.project.as_deref(), Some("ceiling"));
+        assert_eq!(meta.effort.as_deref(), Some("high"));
+
+        let cutoff = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let records = parse_grok_updates_file(&session.join("updates.jsonl"), &meta, cutoff);
+        assert_eq!(records.len(), 1);
+        let r = &records[0];
+        assert_eq!(r.model, "grok-4.5-build");
+        assert_eq!(r.input, 1000);
+        assert_eq!(r.output, 100);
+        assert_eq!(r.cache_read, 800);
+        assert_eq!(r.reasoning, 40);
+        assert_eq!(r.effort.as_deref(), Some("high"));
+        assert_eq!(r.project.as_deref(), Some("ceiling"));
+
+    }
+
+    #[test]
+    fn dedups_on_event_id() {
+        let mut seen = HashSet::new();
+        let record = GrokUsageRecord {
+            timestamp: Some(Utc::now()),
+            model: "grok-4.5-build".into(),
+            effort: Some("high".into()),
+            project: Some("ceiling".into()),
+            input: 10,
+            output: 1,
+            cache_read: 0,
+            reasoning: 0,
+            dedup_key: Some("e1:grok-4.5-build".into()),
+        };
+        let cutoff = Utc::now() - chrono::Duration::days(30);
+        assert!(should_count_grok_record(&record, cutoff, &mut seen));
+        assert!(!should_count_grok_record(&record, cutoff, &mut seen));
+    }
+
+    #[test]
+    fn discovers_nested_session_dirs() {
+        let dir = tempdir().unwrap();
+        let sessions = dir.path().join("sessions");
+        let nested = sessions
+            .join("C%3A%5Cprojects%5Cpersonal%5Cceiling")
+            .join("019f-session");
+        write_session(
+            &nested,
+            "{\"timestamp\":1}\n",
+            r#"{"info":{"cwd":"C:\\projects\\personal\\ceiling"}}"#,
+        );
+        fs::write(sessions.join("session_search.sqlite"), b"").unwrap();
+        let found = discover_grok_session_dirs(&sessions);
+        assert_eq!(found, vec![nested]);
+    }
+}

--- a/rust/src/grok_costs.rs
+++ b/rust/src/grok_costs.rs
@@ -142,10 +142,7 @@ pub fn parse_grok_updates_file(
             continue;
         };
         for record in records_from_event(&event, meta) {
-            if record
-                .timestamp
-                .is_some_and(|ts| ts < cutoff)
-            {
+            if record.timestamp.is_some_and(|ts| ts < cutoff) {
                 continue;
             }
             records.push(record);
@@ -202,9 +199,7 @@ fn records_from_event(event: &GrokUpdateEvent, meta: &SessionMeta) -> Vec<GrokUs
                 output: counts.output_tokens.unwrap_or(0),
                 cache_read: counts.cached_read_tokens.unwrap_or(0),
                 reasoning: counts.reasoning_tokens.unwrap_or(0),
-                dedup_key: dedup_key
-                    .as_ref()
-                    .map(|key| format!("{key}:{model}")),
+                dedup_key: dedup_key.as_ref().map(|key| format!("{key}:{model}")),
             })
             .filter(|r| r.input > 0 || r.output > 0 || r.cache_read > 0 || r.reasoning > 0)
             .collect();
@@ -233,7 +228,7 @@ fn parse_timestamp(
     meta: Option<&GrokParamsMeta>,
 ) -> Option<DateTime<Utc>> {
     if let Some(ms) = meta.and_then(|m| m.agent_timestamp_ms) {
-        let secs = (ms / 1000) as i64;
+        let secs = ms / 1000;
         let nsecs = ((ms % 1000) * 1_000_000) as u32;
         return Utc.timestamp_opt(secs, nsecs).single();
     }
@@ -259,10 +254,10 @@ pub fn should_count_grok_record(
     if record.timestamp.is_some_and(|ts| ts < cutoff) {
         return false;
     }
-    if let Some(key) = record.dedup_key.as_ref() {
-        if !seen.insert(key.clone()) {
-            return false;
-        }
+    if let Some(key) = record.dedup_key.as_ref()
+        && !seen.insert(key.clone())
+    {
+        return false;
     }
     true
 }
@@ -354,7 +349,10 @@ mod tests {
     fn parses_turn_completed_with_cache_and_reasoning() {
         let dir = tempdir().unwrap();
         let session = dir.path().join("sess");
-        let ts = Utc.with_ymd_and_hms(2026, 7, 20, 12, 0, 0).unwrap().timestamp() as f64;
+        let ts = Utc
+            .with_ymd_and_hms(2026, 7, 20, 12, 0, 0)
+            .unwrap()
+            .timestamp() as f64;
         let ms = (ts * 1000.0) as i64;
         let updates = format!(
             r#"{{"timestamp":{ts},"method":"_x.ai/session/update","params":{{"sessionId":"s1","_meta":{{"eventId":"e1","agentTimestampMs":{ms}}},"update":{{"sessionUpdate":"turn_completed","prompt_id":"p1","usage":{{"inputTokens":1000,"outputTokens":100,"totalTokens":1100,"cachedReadTokens":800,"reasoningTokens":40,"modelUsage":{{"grok-4.5-build":{{"inputTokens":1000,"outputTokens":100,"cachedReadTokens":800,"reasoningTokens":40}}}}}}}}}}}}"#
@@ -381,7 +379,6 @@ mod tests {
         assert_eq!(r.reasoning, 40);
         assert_eq!(r.effort.as_deref(), Some("high"));
         assert_eq!(r.project.as_deref(), Some("ceiling"));
-
     }
 
     #[test]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cli;
 pub mod core;
 pub mod cost_scanner;
 pub mod cursor_activity;
+mod grok_costs;
 pub mod host;
 pub mod locale;
 pub mod logging;

--- a/rust/src/locale.rs
+++ b/rust/src/locale.rs
@@ -721,6 +721,7 @@ locale_keys! {
     PanelTopModelPrefix,
     PanelEstimatedFromLocalLogs,
     PanelEstimatedFromLocalLogsClaude,
+    PanelEstimatedFromLocalLogsGrok,
     PanelExpected,
     PanelActual,
     PanelUsedSuffix,

--- a/rust/src/locale/en-US.ftl
+++ b/rust/src/locale/en-US.ftl
@@ -481,6 +481,7 @@ PanelThirtyDayCostHistogram = 30 day cost histogram
 PanelTopModelPrefix = Top model
 PanelEstimatedFromLocalLogs = API-equivalent estimate from local logs; not subscription spend
 PanelEstimatedFromLocalLogsClaude = API-equivalent estimate from local Claude logs; not subscription spend
+PanelEstimatedFromLocalLogsGrok = Tokens from local Grok Build sessions (~/.grok/sessions); SuperGrok pool usage, not a dollar bill
 PanelExpected = Expected
 PanelActual = Actual
 PanelUsedSuffix = used
@@ -609,7 +610,7 @@ DataSourceCodex = Uses the OAuth token from your Codex CLI (~/.codex) plus local
 DataSourceCursor = Uses your signed-in Cursor IDE session, or cursor.com cookies you provide. Talks only to cursor.com.
 DataSourceCopilot = Uses your GitHub CLI or Git Credential Manager token, or a device-flow sign-in. Talks only to api.github.com, or your configured GitHub Enterprise host.
 DataSourceGemini = Reads the OAuth token from the Gemini CLI (~/.gemini). Talks only to Google's Code Assist and OAuth endpoints.
-DataSourceGrok = Uses ~/.grok/auth.json from `grok login` (Grok Build / SuperGrok), or grok.com browser cookies you provide. Talks only to grok.com and auth.x.ai. Weekly pool percent is sampled into local charts; Grok does not expose local transcript cost logs like Codex or Claude.
+DataSourceGrok = Uses ~/.grok/auth.json from `grok login` (Grok Build / SuperGrok), or grok.com browser cookies you provide. Talks only to grok.com and auth.x.ai. Weekly pool percent is sampled into local charts. Local Grok Build sessions under ~/.grok/sessions supply token, cache, reasoning, and project breakdowns (no public API-dollar rate for SuperGrok pool usage).
 DataSourceGeneric = Reads this provider's usage from a local session or token on this PC, or by calling the provider's own usage endpoint. Your credentials are stored only on this PC and are never sent to Ceiling-operated servers; usage requests go only to that provider (or, for Wayfinder, your configured gateway).
 
 # First-run checklist (SOU-157)

--- a/rust/src/providers/grok/mod.rs
+++ b/rust/src/providers/grok/mod.rs
@@ -64,11 +64,15 @@ impl GrokProvider {
             metadata: ProviderMetadata {
                 id: ProviderId::Grok,
                 display_name: "Grok",
-                session_label: "Weekly pool",
-                weekly_label: "Extra credits",
+                // Primary meter is the shared SuperGrok / Grok Build weekly
+                // pool. Bridge uses weekly_label when window_minutes is weekly
+                // cadence (~7d), so both labels must read "Weekly" — not
+                // "Extra credits" (that was only meant for optional prepaid).
+                session_label: "Weekly",
+                weekly_label: "Weekly",
                 supports_opus: false,
-                // Extra-credit balance is parsed when the billing RPC includes
-                // prepaid fields; otherwise only the weekly pool is shown.
+                // Prepaid balance may surface later as a secondary meter; the
+                // main product surface is the weekly usage pool.
                 supports_credits: true,
                 default_enabled: true,
                 is_primary: true,
@@ -641,10 +645,11 @@ fn result_from_billing(
         billing.resets_at,
         None,
     ));
-    // When prepaid/extra credits are present, surface a second meter as used%
-    // of a synthetic window is not meaningful (balance is absolute). Show 0%
-    // used when balance > 0 so the bar reads as "have credits", matching other
-    // credit-balance providers that only know remaining funds.
+    // Optional prepaid balance (not yet decoded from the RPC). When present,
+    // surface it as a secondary meter. Absolute balances have no used%; show
+    // 0% used when balance > 0 so the bar reads as "have credits". The secondary
+    // UI label still comes from metadata.weekly_label ("Weekly") today — the
+    // dollar amount is carried in reset_description until prepaid is productized.
     if let Some(cents) = billing.prepaid_balance_cents.filter(|c| *c > 0) {
         let dollars = cents as f64 / 100.0;
         usage = usage.with_secondary(RateWindow::with_details(
@@ -1026,6 +1031,32 @@ mod tests {
             plan_name_from_subscriptions(&json).as_deref(),
             Some("SuperGrok Heavy")
         );
+    }
+
+    #[test]
+    fn metadata_labels_weekly_pool_as_weekly() {
+        let provider = GrokProvider::new();
+        assert_eq!(provider.metadata().session_label, "Weekly");
+        assert_eq!(provider.metadata().weekly_label, "Weekly");
+    }
+
+    #[test]
+    fn billing_snapshot_marks_primary_as_weekly_window() {
+        let result = result_from_billing(
+            GrokBillingSnapshot {
+                used_percent: 12.0,
+                resets_at: Some(Utc::now() + chrono::Duration::days(3)),
+                window_minutes: Some(WEEKLY_MINUTES),
+                prepaid_balance_cents: None,
+            },
+            "oidc",
+            None,
+            None,
+            Some("SuperGrok".into()),
+        );
+        assert_eq!(result.usage.primary.window_minutes, Some(WEEKLY_MINUTES));
+        assert!(result.usage.secondary.is_none());
+        assert!((result.usage.primary.used_percent - 12.0).abs() < f64::EPSILON);
     }
 
     fn write_key(buf: &mut Vec<u8>, field: u64, wire: u64) {


### PR DESCRIPTION
## Summary
- Label Grok's primary weekly pool as **Weekly** on the strip/popout (was **Extra credits** because weekly-cadence windows use `weekly_label`).
- Scan `~/.grok/sessions` `updates.jsonl` turn completions for local Charts usage: tokens over time, cache vs fresh input, reasoning tokens + effort tiers, and project rollups.
- SuperGrok pool usage stays unpriced (no fabricated API dollars). Weekly pool samples and local session scans both feed Grok charts.

## Test plan
- [x] `cargo test -p codexbar --lib grok_` (parser, discovery, report rollup)
- [x] `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml grok_token`
- [x] Manual: `.\scripts\dev.ps1` — Charts → Grok shows local usage card with token mix, effort, projects; bar label reads Weekly

## Notes
Release train next: squash to main, then prepare **1.5.6** + signed draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Grok local-session usage data to charts, including token, cache, reasoning, effort, project, and model breakdowns.
  - Added a dedicated Reasoning category to token-mix charts when available.
  - Grok charts now support weekly reset boundaries and background data enrichment.

- **Improvements**
  - Updated Grok usage labels to consistently display “Weekly.”
  - Clarified chart descriptions and local-log estimates, including that Grok figures are not dollar-billed values.

- **Documentation**
  - Expanded Grok data-source documentation to describe local session logs and available usage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->