### PR TITLE
Taskbar strip account pin for multi-account providers

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
@@ -602,6 +602,9 @@ pub struct SettingsSnapshot {
     float_bar_contrast: String,
     float_bar_click_through: bool,
     float_bar_provider_ids: Vec<String>,
+    /// Provider CLI name → directory-account id for the compact strip. Empty
+    /// map means Auto (hottest) for every provider.
+    taskbar_account_by_provider: std::collections::HashMap<String, String>,
     float_bar_dark_text: bool,
     float_bar_show_reset_inline: bool,
     float_bar_show_cost: bool,
@@ -707,6 +710,7 @@ impl From<Settings> for SettingsSnapshot {
             float_bar_contrast,
             float_bar_click_through: settings.float_bar_click_through,
             float_bar_provider_ids: settings.float_bar_provider_ids,
+            taskbar_account_by_provider: settings.taskbar_account_by_provider,
             float_bar_dark_text: settings.float_bar_dark_text,
             float_bar_show_reset_inline: settings.float_bar_show_reset_inline,
             float_bar_show_cost: settings.float_bar_show_cost,

--- a/apps/desktop-tauri/src-tauri/src/commands/settings.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/settings.rs
@@ -66,6 +66,9 @@ pub struct SettingsUpdate {
     pub float_bar_contrast: Option<String>,
     pub float_bar_click_through: Option<bool>,
     pub float_bar_provider_ids: Option<Vec<String>>,
+    /// Provider CLI name → directory-account id. Pass `""` for a provider to
+    /// clear a pin and restore Auto (hottest).
+    pub taskbar_account_by_provider: Option<std::collections::HashMap<String, String>>,
     pub float_bar_dark_text: Option<bool>,
     pub float_bar_show_reset_inline: Option<bool>,
     pub float_bar_show_cost: Option<bool>,
@@ -317,6 +320,7 @@ impl SettingsUpdate {
             contrast: self.float_bar_contrast.clone(),
             click_through: self.float_bar_click_through,
             provider_ids: self.float_bar_provider_ids.clone(),
+            taskbar_account_by_provider: self.taskbar_account_by_provider.clone(),
             dark_text: self.float_bar_dark_text,
             show_reset_inline: self.float_bar_show_reset_inline,
             show_cost: self.float_bar_show_cost,

--- a/apps/desktop-tauri/src-tauri/src/floatbar/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/mod.rs
@@ -111,6 +111,7 @@ pub struct SettingsPatch {
     pub contrast: Option<String>,
     pub click_through: Option<bool>,
     pub provider_ids: Option<Vec<String>>,
+    pub taskbar_account_by_provider: Option<std::collections::HashMap<String, String>>,
     pub dark_text: Option<bool>,
     pub show_reset_inline: Option<bool>,
     pub show_cost: Option<bool>,
@@ -131,6 +132,7 @@ impl SettingsPatch {
             && self.contrast.is_none()
             && self.click_through.is_none()
             && self.provider_ids.is_none()
+            && self.taskbar_account_by_provider.is_none()
             && self.dark_text.is_none()
             && self.show_reset_inline.is_none()
             && self.show_cost.is_none()
@@ -178,6 +180,22 @@ impl SettingsPatch {
         }
         if let Some(v) = &self.provider_ids {
             settings.float_bar_provider_ids = v.clone();
+        }
+        if let Some(v) = &self.taskbar_account_by_provider {
+            // Merge keys so a partial update can clear one provider with "" and
+            // leave others alone when the client sends the full next map.
+            settings.taskbar_account_by_provider = v
+                .iter()
+                .filter_map(|(provider, account)| {
+                    let provider = provider.trim().to_ascii_lowercase();
+                    let account = account.trim();
+                    if provider.is_empty() || account.is_empty() {
+                        None
+                    } else {
+                        Some((provider, account.to_string()))
+                    }
+                })
+                .collect();
         }
         if let Some(v) = self.dark_text {
             settings.float_bar_dark_text = v;

--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -89,7 +89,9 @@ where
     if candidates.is_empty() {
         return None;
     }
-    if let Some(want) = preferred_account_id.map(str::trim).filter(|id| !id.is_empty())
+    if let Some(want) = preferred_account_id
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
         && let Some(hit) = candidates
             .iter()
             .find(|snapshot| snapshot.account_id.as_deref() == Some(want))

--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -70,6 +70,40 @@ fn native_mode_has_configured_provider(settings: &codexbar::settings::Settings) 
     !taskbar_strip_provider_ids(settings).is_empty()
 }
 
+/// Pick the reading to show on a one-tile-per-provider strip.
+///
+/// When `preferred_account_id` is set and that account is in the cache, use it.
+/// Otherwise pick the account closest to its limit (stable across fetch order).
+fn select_strip_snapshot<'a, I>(
+    cache: I,
+    provider_id: &str,
+    preferred_account_id: Option<&str>,
+) -> Option<&'a crate::commands::ProviderUsageSnapshot>
+where
+    I: IntoIterator<Item = &'a crate::commands::ProviderUsageSnapshot>,
+{
+    let candidates: Vec<_> = cache
+        .into_iter()
+        .filter(|snapshot| snapshot.provider_id == provider_id)
+        .collect();
+    if candidates.is_empty() {
+        return None;
+    }
+    if let Some(want) = preferred_account_id.map(str::trim).filter(|id| !id.is_empty())
+        && let Some(hit) = candidates
+            .iter()
+            .find(|snapshot| snapshot.account_id.as_deref() == Some(want))
+    {
+        return Some(*hit);
+    }
+    candidates.into_iter().max_by(|a, b| {
+        a.primary
+            .used_percent
+            .total_cmp(&b.primary.used_percent)
+            .then_with(|| b.account_id.cmp(&a.account_id))
+    })
+}
+
 fn layout_is_enabled(layout: &TaskbarLayout, all_monitors: bool) -> bool {
     all_monitors || layout.primary
 }
@@ -547,20 +581,15 @@ mod windows_host {
         let providers = preferred_ids
             .into_iter()
             .map(|provider_id| {
-                // One tile per provider, showing the account closest to its
-                // limit. `.find` returned whichever account sat first in the
-                // cache, which changes as fetches finish in different orders,
-                // so the tile flipped between accounts between refreshes.
-                let snapshot = guard
-                    .provider_cache
-                    .iter()
-                    .filter(|snapshot| snapshot.provider_id == provider_id)
-                    .max_by(|a, b| {
-                        a.primary
-                            .used_percent
-                            .total_cmp(&b.primary.used_percent)
-                            .then_with(|| b.account_id.cmp(&a.account_id))
-                    });
+                // One tile per provider. Default picks the account closest to
+                // its limit (stable across fetch order). Users can pin a
+                // specific Codex/Claude account in Settings → Taskbar Usage.
+                let preferred = settings.taskbar_account_for(&provider_id);
+                let snapshot = super::select_strip_snapshot(
+                    guard.provider_cache.iter(),
+                    &provider_id,
+                    preferred,
+                );
                 let percent =
                     snapshot
                         .filter(|snapshot| snapshot.error.is_none())
@@ -1867,5 +1896,81 @@ mod tests {
 
         assert_eq!(placement.x, 454);
         assert_eq!(placement.width, 312);
+    }
+
+    fn snap(
+        provider_id: &str,
+        account_id: Option<&str>,
+        used: f64,
+    ) -> crate::commands::ProviderUsageSnapshot {
+        crate::commands::ProviderUsageSnapshot {
+            provider_id: provider_id.into(),
+            display_name: provider_id.into(),
+            primary: crate::commands::RateWindowSnapshot {
+                used_percent: used,
+                remaining_percent: 100.0 - used,
+                window_minutes: Some(300),
+                resets_at: None,
+                reset_description: None,
+                is_exhausted: false,
+                reserve_percent: None,
+                reserve_description: None,
+                reserve_will_last_to_reset: false,
+                reserve_eta_seconds: None,
+            },
+            primary_label: Some("Session".into()),
+            secondary: None,
+            secondary_label: None,
+            model_specific: None,
+            tertiary: None,
+            extra_rate_windows: Vec::new(),
+            inactive_rate_windows: Vec::new(),
+            promo_signals: Vec::new(),
+            reset_credits_available: None,
+            cost: None,
+            plan_name: None,
+            account_email: None,
+            source_label: "test".into(),
+            updated_at: String::new(),
+            error: None,
+            pace: None,
+            account_organization: None,
+            tray_status_label: None,
+            account_id: account_id.map(str::to_string),
+            account_label: account_id.map(str::to_string),
+            account_tint: None,
+            fetch_duration_ms: None,
+            wayfinder_usage: None,
+        }
+    }
+
+    #[test]
+    fn strip_snapshot_defaults_to_hottest_account() {
+        let cache = [
+            snap("codex", Some("personal"), 20.0),
+            snap("codex", Some("work"), 80.0),
+        ];
+        let picked = select_strip_snapshot(cache.iter(), "codex", None).unwrap();
+        assert_eq!(picked.account_id.as_deref(), Some("work"));
+    }
+
+    #[test]
+    fn strip_snapshot_respects_pinned_account() {
+        let cache = [
+            snap("codex", Some("personal"), 20.0),
+            snap("codex", Some("work"), 80.0),
+        ];
+        let picked = select_strip_snapshot(cache.iter(), "codex", Some("personal")).unwrap();
+        assert_eq!(picked.account_id.as_deref(), Some("personal"));
+    }
+
+    #[test]
+    fn strip_snapshot_falls_back_to_hottest_when_pin_missing() {
+        let cache = [
+            snap("codex", Some("personal"), 20.0),
+            snap("codex", Some("work"), 80.0),
+        ];
+        let picked = select_strip_snapshot(cache.iter(), "codex", Some("gone")).unwrap();
+        assert_eq!(picked.account_id.as_deref(), Some("work"));
     }
 }

--- a/apps/desktop-tauri/src/App.test.tsx
+++ b/apps/desktop-tauri/src/App.test.tsx
@@ -115,6 +115,7 @@ function settings(overrides: Partial<SettingsSnapshot> = {}): SettingsSnapshot {
     floatBarContrast: "auto",
     floatBarClickThrough: false,
     floatBarProviderIds: [],
+    taskbarAccountByProvider: {},
     floatBarDarkText: false,
     floatBarShowResetInline: false,
     floatBarShowCost: false,

--- a/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
@@ -140,6 +140,7 @@ function settings(overrides: Partial<SettingsSnapshot> = {}): SettingsSnapshot {
     floatBarContrast: "light-text",
     floatBarClickThrough: false,
     floatBarProviderIds: [],
+    taskbarAccountByProvider: {},
     floatBarDarkText: false,
     floatBarShowResetInline: false,
     floatBarShowCost: false,

--- a/apps/desktop-tauri/src/floatbar/FloatBar.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.tsx
@@ -509,24 +509,47 @@ export default function FloatBar({ state }: { state: BootstrapState }) {
   const filterIds = settings.floatBarProviderIds;
   const scale = Math.max(0.75, Math.min(2, settings.floatBarScale / 100));
   const showResetInline = settings.floatBarShowResetInline || density === "detailed";
+  const pinnedAccounts = settings.taskbarAccountByProvider ?? {};
   const visible = useMemo(() => {
     const enabled = new Set(settings.enabledProviders);
-    let list = providers.filter((p) => enabled.has(p.providerId));
+    const eligible = providers.filter((p) => enabled.has(p.providerId));
+    // One pill per provider: pin wins, else hottest account.
+    const byProvider = new Map<string, typeof eligible>();
+    for (const row of eligible) {
+      const group = byProvider.get(row.providerId) ?? [];
+      group.push(row);
+      byProvider.set(row.providerId, group);
+    }
+    const pick = (providerId: string) => {
+      const group = byProvider.get(providerId) ?? [];
+      if (group.length === 0) return undefined;
+      const want = pinnedAccounts[providerId]?.trim();
+      if (want) {
+        const hit = group.find((row) => row.accountId === want);
+        if (hit) return hit;
+      }
+      return [...group].sort((a, b) => {
+        const delta =
+          floatBarWindow(b).window.usedPercent -
+          floatBarWindow(a).window.usedPercent;
+        if (delta !== 0) return delta;
+        return (b.accountId ?? "").localeCompare(a.accountId ?? "");
+      })[0];
+    };
     if (filterIds && filterIds.length > 0) {
-      // Explicit Display order from Settings → Taskbar Usage / Floating Bar.
-      const byId = new Map(list.map((p) => [p.providerId, p]));
-      list = filterIds
-        .map((id) => byId.get(id))
-        .filter((p): p is (typeof list)[number] => p !== undefined);
-    } else {
-      list = [...list].sort(
+      return filterIds
+        .map((id) => pick(id))
+        .filter((p): p is (typeof eligible)[number] => p !== undefined);
+    }
+    return [...byProvider.keys()]
+      .map((id) => pick(id))
+      .filter((p): p is (typeof eligible)[number] => p !== undefined)
+      .sort(
         (a, b) =>
           floatBarWindow(b).window.usedPercent -
           floatBarWindow(a).window.usedPercent,
       );
-    }
-    return list;
-  }, [providers, settings.enabledProviders, filterIds]);
+  }, [providers, settings.enabledProviders, filterIds, pinnedAccounts]);
 
   // Keep the native floatbar window fitted when late data/fonts/icons change layout.
   const lastResizeRef = useRef<{ w: number; h: number } | null>(null);

--- a/apps/desktop-tauri/src/floatbar/SettingsSection.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/SettingsSection.test.tsx
@@ -1,10 +1,15 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SettingsSnapshot } from "../types/bridge";
 import FloatBarSettingsSection from "./SettingsSection";
 
 vi.mock("../hooks/useLocale", () => ({
   useLocale: () => ({ t: (key: string) => key }),
+}));
+
+const getDirectoryAccounts = vi.fn();
+vi.mock("../lib/tauri", () => ({
+  getDirectoryAccounts: () => getDirectoryAccounts(),
 }));
 
 const settings = {
@@ -24,11 +29,16 @@ const settings = {
   floatBarDarkText: false,
   floatBarClickThrough: false,
   floatBarProviderIds: [],
+    taskbarAccountByProvider: {},
   enabledProviders: ["codex", "claude", "cursor", "grok"],
   providerOrder: ["codex", "claude", "cursor", "grok"],
 } as unknown as SettingsSnapshot;
 
 describe("FloatBar settings", () => {
+  beforeEach(() => {
+    getDirectoryAccounts.mockResolvedValue([]);
+  });
+
   it("does not offer the legacy API-equivalent cost toggle", () => {
     render(
       <FloatBarSettingsSection settings={settings} saving={false} set={vi.fn()} />,
@@ -126,5 +136,97 @@ describe("FloatBar settings", () => {
 
     fireEvent.click(screen.getByRole("checkbox", { name: "Show on All Monitors" }));
     expect(set).toHaveBeenCalledWith({ taskbarWidgetAllMonitors: true });
+  });
+
+  it("lets multi-account Codex pin which seat the strip shows", async () => {
+    getDirectoryAccounts.mockResolvedValue([
+      {
+        providerId: "codex",
+        displayName: "Codex",
+        envVar: "CODEX_HOME",
+        activeIndex: 0,
+        followingCli: false,
+        ambientDir: "C:\\codex",
+        accounts: [
+          {
+            id: "personal-id",
+            label: "Personal",
+            configDir: "C:\\codex-personal",
+            tint: null,
+            isActive: true,
+            signedIn: true,
+            email: "me@home.test",
+            organization: null,
+            plan: "plus",
+            addedAt: "Jan 1, 2026",
+            lastUsed: null,
+          },
+          {
+            id: "work-id",
+            label: "Work",
+            configDir: "C:\\codex-work",
+            tint: null,
+            isActive: false,
+            signedIn: true,
+            email: "me@job.test",
+            organization: null,
+            plan: "team",
+            addedAt: "Jan 1, 2026",
+            lastUsed: null,
+          },
+        ],
+      },
+    ]);
+    const set = vi.fn();
+    render(
+      <FloatBarSettingsSection settings={settings} saving={false} set={set} />,
+    );
+
+    const select = await screen.findByRole("combobox", {
+      name: "Taskbar account for Codex",
+    });
+    fireEvent.change(select, { target: { value: "work-id" } });
+    expect(set).toHaveBeenCalledWith({
+      taskbarAccountByProvider: { codex: "work-id" },
+    });
+  });
+
+  it("does not show an account picker for single-account providers", async () => {
+    getDirectoryAccounts.mockResolvedValue([
+      {
+        providerId: "codex",
+        displayName: "Codex",
+        envVar: "CODEX_HOME",
+        activeIndex: 0,
+        followingCli: false,
+        ambientDir: "C:\\codex",
+        accounts: [
+          {
+            id: "only",
+            label: "Only",
+            configDir: "C:\\codex",
+            tint: null,
+            isActive: true,
+            signedIn: true,
+            email: null,
+            organization: null,
+            plan: null,
+            addedAt: "Jan 1, 2026",
+            lastUsed: null,
+          },
+        ],
+      },
+    ]);
+    render(
+      <FloatBarSettingsSection
+        settings={settings}
+        saving={false}
+        set={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(getDirectoryAccounts).toHaveBeenCalled());
+    expect(
+      screen.queryByRole("combobox", { name: /Taskbar account/ }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop-tauri/src/floatbar/SettingsSection.tsx
+++ b/apps/desktop-tauri/src/floatbar/SettingsSection.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Field, Select, Toggle } from "../components/FormControls";
 import { ProviderIcon } from "../components/providers/ProviderIcon";
+import { getDirectoryAccounts } from "../lib/tauri";
 import type {
   FloatBarOrientation,
   FloatBarContrast,
   FloatBarDensity,
   FloatBarInformationMode,
+  ProviderAccountsBridge,
   SettingsSnapshot,
   SettingsUpdate,
 } from "../types/bridge";
@@ -31,6 +33,20 @@ interface Props {
 
 function providerLabel(id: string): string {
   return PROVIDER_LABELS[id] ?? id.charAt(0).toUpperCase() + id.slice(1);
+}
+
+/** Providers that can track more than one config-directory account. */
+const MULTI_ACCOUNT_PROVIDER_IDS = new Set(["codex", "claude"]);
+
+function accountOptionLabel(account: {
+  label: string;
+  email?: string | null;
+}): string {
+  const email = account.email?.trim();
+  if (email && email !== account.label) {
+    return `${account.label} · ${email}`;
+  }
+  return account.label;
 }
 
 /** Enabled providers in Providers-tab order (fallback: settings.enabled list). */
@@ -83,6 +99,36 @@ export default function FloatBarSettingsSection({ settings, saving, set }: Props
     scale.commit(scale.draft, (value) => set({ floatBarScale: value }));
   };
 
+  const [directoryAccounts, setDirectoryAccounts] = useState<
+    ProviderAccountsBridge[]
+  >([]);
+  useEffect(() => {
+    let cancelled = false;
+    getDirectoryAccounts()
+      .then((rows) => {
+        if (!cancelled) setDirectoryAccounts(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setDirectoryAccounts([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [settings.enabledProviders, settings.taskbarAccountByProvider]);
+
+  const multiAccountByProvider = useMemo(() => {
+    const map = new Map<string, ProviderAccountsBridge>();
+    for (const row of directoryAccounts) {
+      if (
+        MULTI_ACCOUNT_PROVIDER_IDS.has(row.providerId) &&
+        row.accounts.length > 1
+      ) {
+        map.set(row.providerId, row);
+      }
+    }
+    return map;
+  }, [directoryAccounts]);
+
   const enabledOrdered = useMemo(
     () => enabledProvidersInDisplayOrder(settings),
     [settings],
@@ -130,6 +176,17 @@ export default function FloatBarSettingsSection({ settings, saving, set }: Props
     const [row] = copy.splice(index, 1);
     copy.splice(next, 0, row);
     commitStripIds(copy);
+  };
+
+  const pinnedAccounts = settings.taskbarAccountByProvider ?? {};
+  const setPinnedAccount = (providerId: string, accountId: string) => {
+    const next: Record<string, string> = { ...pinnedAccounts };
+    if (!accountId) {
+      delete next[providerId];
+    } else {
+      next[providerId] = accountId;
+    }
+    set({ taskbarAccountByProvider: next });
   };
 
   return (
@@ -217,56 +274,99 @@ export default function FloatBarSettingsSection({ settings, saving, set }: Props
                 const rank = selectedStripIds.indexOf(id);
                 const atCap =
                   !checked && selectedStripIds.length >= MAX_STRIP_PROVIDERS;
+                const multi = multiAccountByProvider.get(id);
                 return (
                   <li key={id} className="taskbar-provider-picker__row">
-                    <label className="taskbar-provider-picker__label">
-                      <input
-                        type="checkbox"
-                        className="toggle"
-                        checked={checked}
-                        disabled={
-                          saving ||
-                          !settings.taskbarWidgetEnabled ||
-                          (atCap && !checked)
-                        }
-                        aria-label={`Show ${providerLabel(id)} on taskbar strip`}
-                        onChange={(e) => toggleStripProvider(id, e.target.checked)}
-                      />
-                      <ProviderIcon providerId={id} size={16} title={providerLabel(id)} />
-                      <span>{providerLabel(id)}</span>
-                      {checked && rank >= 0 && (
-                        <span className="taskbar-provider-picker__rank">{rank + 1}</span>
-                      )}
-                    </label>
-                    <span className="providers-sidebar__reorder-controls">
-                      <button
-                        type="button"
-                        className="providers-sidebar__reorder-button"
-                        aria-label={`Move ${providerLabel(id)} up`}
-                        disabled={saving || !checked || rank <= 0}
-                        onClick={() => moveStripProvider(id, -1)}
-                      >
-                        ↑
-                      </button>
-                      <button
-                        type="button"
-                        className="providers-sidebar__reorder-button"
-                        aria-label={`Move ${providerLabel(id)} down`}
-                        disabled={
-                          saving ||
-                          !checked ||
-                          rank < 0 ||
-                          rank >= selectedStripIds.length - 1
-                        }
-                        onClick={() => moveStripProvider(id, 1)}
-                      >
-                        ↓
-                      </button>
-                    </span>
+                    <div className="taskbar-provider-picker__main">
+                      <label className="taskbar-provider-picker__label">
+                        <input
+                          type="checkbox"
+                          className="toggle"
+                          checked={checked}
+                          disabled={
+                            saving ||
+                            !settings.taskbarWidgetEnabled ||
+                            (atCap && !checked)
+                          }
+                          aria-label={`Show ${providerLabel(id)} on taskbar strip`}
+                          onChange={(e) =>
+                            toggleStripProvider(id, e.target.checked)
+                          }
+                        />
+                        <ProviderIcon
+                          providerId={id}
+                          size={16}
+                          title={providerLabel(id)}
+                        />
+                        <span>{providerLabel(id)}</span>
+                        {checked && rank >= 0 && (
+                          <span className="taskbar-provider-picker__rank">
+                            {rank + 1}
+                          </span>
+                        )}
+                      </label>
+                      <span className="providers-sidebar__reorder-controls">
+                        <button
+                          type="button"
+                          className="providers-sidebar__reorder-button"
+                          aria-label={`Move ${providerLabel(id)} up`}
+                          disabled={saving || !checked || rank <= 0}
+                          onClick={() => moveStripProvider(id, -1)}
+                        >
+                          ↑
+                        </button>
+                        <button
+                          type="button"
+                          className="providers-sidebar__reorder-button"
+                          aria-label={`Move ${providerLabel(id)} down`}
+                          disabled={
+                            saving ||
+                            !checked ||
+                            rank < 0 ||
+                            rank >= selectedStripIds.length - 1
+                          }
+                          onClick={() => moveStripProvider(id, 1)}
+                        >
+                          ↓
+                        </button>
+                      </span>
+                    </div>
+                    {multi && checked && (
+                      <label className="taskbar-provider-picker__account">
+                        <span className="taskbar-provider-picker__account-label">
+                          Taskbar shows
+                        </span>
+                        <select
+                          className="select"
+                          aria-label={`Taskbar account for ${providerLabel(id)}`}
+                          disabled={saving || !settings.taskbarWidgetEnabled}
+                          value={pinnedAccounts[id] ?? ""}
+                          onChange={(e) =>
+                            setPinnedAccount(id, e.target.value)
+                          }
+                        >
+                          <option value="">
+                            Auto (closest to limit)
+                          </option>
+                          {multi.accounts.map((account) => (
+                            <option key={account.id} value={account.id}>
+                              {accountOptionLabel(account)}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    )}
                   </li>
                 );
               })}
             </ul>
+          )}
+          {multiAccountByProvider.size > 0 && (
+            <p className="settings-section__hint">
+              With two Codex or Claude accounts, pick which one the compact strip
+              shows. Auto keeps the account closest to its limit. This does not
+              change which account is active in the Accounts tab.
+            </p>
           )}
         </div>
       </section>

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -569,12 +569,19 @@ html {
 
 .taskbar-provider-picker__row {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
   padding: 6px 8px;
   border-radius: 8px;
   background: var(--surface-elevated, rgba(255, 255, 255, 0.04));
+}
+
+.taskbar-provider-picker__main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
 }
 
 .taskbar-provider-picker__label {
@@ -592,6 +599,23 @@ html {
   font-size: 11px;
   opacity: 0.65;
   font-variant-numeric: tabular-nums;
+}
+
+.taskbar-provider-picker__account {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-left: 28px;
+}
+
+.taskbar-provider-picker__account-label {
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.taskbar-provider-picker__account .select {
+  width: 100%;
+  max-width: 100%;
 }
 
 .settings-section__hint {

--- a/apps/desktop-tauri/src/surfaces/PopOutPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/PopOutPanel.test.tsx
@@ -169,6 +169,7 @@ function settings(): SettingsSnapshot {
     floatBarContrast: "auto",
     floatBarClickThrough: false,
     floatBarProviderIds: [],
+    taskbarAccountByProvider: {},
     floatBarDarkText: false,
     floatBarShowResetInline: false,
     floatBarShowCost: false,

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
@@ -151,6 +151,7 @@ function settings(overrides: Partial<SettingsSnapshot> = {}): SettingsSnapshot {
     floatBarContrast: "auto",
     floatBarClickThrough: false,
     floatBarProviderIds: [],
+    taskbarAccountByProvider: {},
     floatBarDarkText: false,
     floatBarShowResetInline: false,
     floatBarShowCost: false,

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/AboutTab.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/AboutTab.test.tsx
@@ -87,6 +87,7 @@ const settings: SettingsSnapshot = {
   floatBarContrast: "auto",
   floatBarClickThrough: false,
   floatBarProviderIds: [],
+    taskbarAccountByProvider: {},
   floatBarDarkText: false,
   floatBarShowResetInline: false,
   floatBarShowCost: false,

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
@@ -70,6 +70,7 @@ const settings: SettingsSnapshot = {
   floatBarContrast: "auto",
   floatBarClickThrough: false,
   floatBarProviderIds: [],
+    taskbarAccountByProvider: {},
   floatBarDarkText: false,
   floatBarShowResetInline: false,
   floatBarShowCost: false,

--- a/apps/desktop-tauri/src/types/bridge.test.ts
+++ b/apps/desktop-tauri/src/types/bridge.test.ts
@@ -88,6 +88,7 @@ describe("Language type", () => {
       floatBarContrast: "auto",
       floatBarClickThrough: false,
       floatBarProviderIds: [],
+    taskbarAccountByProvider: {},
       floatBarDarkText: false,
       floatBarShowResetInline: false,
       floatBarShowCost: false,

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -278,6 +278,12 @@ export interface SettingsSnapshot {
   floatBarClickThrough: boolean;
   /** Empty array = show all enabled providers. */
   floatBarProviderIds: string[];
+  /**
+   * Provider CLI name → directory-account id for the compact taskbar/float
+   * strip. Missing provider = Auto (account closest to its limit). Does not
+   * change which account is active for CLI identity.
+   */
+  taskbarAccountByProvider: Record<string, string>;
   /** When true, render with dark text/glass for light desktops. */
   floatBarDarkText: boolean;
   /** When true, render the next primary reset inline in each provider pill. */
@@ -346,6 +352,8 @@ export interface SettingsUpdate {
   floatBarContrast?: FloatBarContrast;
   floatBarClickThrough?: boolean;
   floatBarProviderIds?: string[];
+  /** Full next map of provider → account id. Omit a provider (or use "") for Auto. */
+  taskbarAccountByProvider?: Record<string, string>;
   floatBarDarkText?: boolean;
   floatBarShowResetInline?: boolean;
   floatBarShowCost?: boolean;

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -279,6 +279,15 @@ pub struct Settings {
     #[serde(default)]
     pub float_bar_provider_ids: Vec<String>,
 
+    /// Per-provider account id for the compact taskbar / float-bar strip.
+    ///
+    /// Key is the provider CLI name (`codex`, `claude`, …); value is a
+    /// directory-account UUID. Missing or empty means Auto: show the account
+    /// closest to its limit. This is a display preference for the strip only —
+    /// it does not change which account is "active" for CLI/fetch identity.
+    #[serde(default)]
+    pub taskbar_account_by_provider: std::collections::HashMap<String, String>,
+
     /// When true, the floating bar uses a dark-on-light palette so it
     /// stays legible on light desktop backgrounds. Defaults to false
     /// (light-on-dark, the original look).
@@ -570,6 +579,7 @@ impl Default for Settings {
             float_bar_contrast: Some("auto".to_string()),
             float_bar_click_through: false,
             float_bar_provider_ids: Vec::new(),
+            taskbar_account_by_provider: std::collections::HashMap::new(),
             float_bar_dark_text: false,
             float_bar_show_reset_inline: true,
             float_bar_show_cost: false,
@@ -578,6 +588,15 @@ impl Default for Settings {
 }
 
 impl Settings {
+    /// Preferred strip account for `provider_id`, if the user pinned one.
+    pub fn taskbar_account_for(&self, provider_id: &str) -> Option<&str> {
+        self.taskbar_account_by_provider
+            .get(provider_id)
+            .map(String::as_str)
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+    }
+
     /// Get the settings file path
     pub fn settings_path() -> Option<PathBuf> {
         dirs::config_dir().map(|p| p.join("Ceiling").join("settings.json"))

--- a/rust/src/settings/raw.rs
+++ b/rust/src/settings/raw.rs
@@ -160,6 +160,8 @@ pub(super) struct RawSettings {
     #[serde(default)]
     float_bar_provider_ids: Vec<String>,
     #[serde(default)]
+    taskbar_account_by_provider: std::collections::HashMap<String, String>,
+    #[serde(default)]
     float_bar_dark_text: bool,
     #[serde(default)]
     float_bar_show_reset_inline: bool,
@@ -257,6 +259,7 @@ impl Default for RawSettings {
             float_bar_contrast: s.float_bar_contrast,
             float_bar_click_through: s.float_bar_click_through,
             float_bar_provider_ids: s.float_bar_provider_ids,
+            taskbar_account_by_provider: s.taskbar_account_by_provider,
             float_bar_dark_text: s.float_bar_dark_text,
             float_bar_show_reset_inline: s.float_bar_show_reset_inline,
             float_bar_show_cost: s.float_bar_show_cost,
@@ -570,9 +573,29 @@ impl From<RawSettings> for Settings {
                 .map(|value| normalize_float_bar_contrast(&value)),
             float_bar_click_through: raw.float_bar_click_through,
             float_bar_provider_ids: raw.float_bar_provider_ids,
+            taskbar_account_by_provider: sanitize_taskbar_account_map(
+                raw.taskbar_account_by_provider,
+            ),
             float_bar_dark_text: raw.float_bar_dark_text,
             float_bar_show_reset_inline: raw.float_bar_show_reset_inline,
             float_bar_show_cost: raw.float_bar_show_cost,
         }
     }
+}
+
+/// Drop empty keys/values so "Auto" stays represented by a missing map entry.
+fn sanitize_taskbar_account_map(
+    map: std::collections::HashMap<String, String>,
+) -> std::collections::HashMap<String, String> {
+    map.into_iter()
+        .filter_map(|(provider, account)| {
+            let provider = provider.trim().to_ascii_lowercase();
+            let account = account.trim().to_string();
+            if provider.is_empty() || account.is_empty() {
+                None
+            } else {
+                Some((provider, account))
+            }
+        })
+        .collect()
 }

--- a/rust/src/settings/tests.rs
+++ b/rust/src/settings/tests.rs
@@ -152,6 +152,7 @@ fn float_bar_defaults_are_safe() {
     assert_eq!(resolved_float_bar_contrast(&settings), "auto");
     assert!(!settings.float_bar_click_through);
     assert!(settings.float_bar_provider_ids.is_empty());
+    assert!(settings.taskbar_account_by_provider.is_empty());
     assert!(!settings.float_bar_dark_text);
     assert!(settings.float_bar_show_reset_inline);
     assert!(!settings.float_bar_show_cost);
@@ -307,6 +308,9 @@ fn float_bar_settings_round_trip_through_raw() {
         float_bar_contrast: Some("dark-text".to_string()),
         float_bar_click_through: true,
         float_bar_provider_ids: vec!["claude".into(), "codex".into()],
+        taskbar_account_by_provider: [("codex".into(), "work-id".into())]
+            .into_iter()
+            .collect(),
         float_bar_dark_text: true,
         float_bar_show_reset_inline: true,
         float_bar_show_cost: true,
@@ -328,6 +332,8 @@ fn float_bar_settings_round_trip_through_raw() {
     assert_eq!(resolved_float_bar_contrast(&back), "dark-text");
     assert!(back.float_bar_click_through);
     assert_eq!(back.float_bar_provider_ids, vec!["claude", "codex"]);
+    assert_eq!(back.taskbar_account_for("codex"), Some("work-id"));
+    assert_eq!(back.taskbar_account_for("claude"), None);
     assert!(back.float_bar_dark_text);
     assert!(back.float_bar_show_reset_inline);
     assert!(back.float_bar_show_cost);

--- a/rust/src/settings/tests.rs
+++ b/rust/src/settings/tests.rs
@@ -308,9 +308,7 @@ fn float_bar_settings_round_trip_through_raw() {
         float_bar_contrast: Some("dark-text".to_string()),
         float_bar_click_through: true,
         float_bar_provider_ids: vec!["claude".into(), "codex".into()],
-        taskbar_account_by_provider: [("codex".into(), "work-id".into())]
-            .into_iter()
-            .collect(),
+        taskbar_account_by_provider: [("codex".into(), "work-id".into())].into_iter().collect(),
         float_bar_dark_text: true,
         float_bar_show_reset_inline: true,
         float_bar_show_cost: true,


### PR DESCRIPTION
## Summary
- When Codex or Claude has two+ directory accounts, Settings → Taskbar Usage shows a **Taskbar shows** picker per provider.
- Default remains **Auto** (account closest to its limit).
- Pin is a strip display preference only; it does not change Accounts-tab active account or CLI identity.
- Applies to the native taskbar strip and floating bar (one tile per provider).

## Test plan
- [x] `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml strip_snapshot`
- [x] `cargo test -p codexbar --lib float_bar_settings --manifest-path rust/Cargo.toml`
- [x] `pnpm test -- src/floatbar/SettingsSection.test.tsx`
- [ ] Manual: two Codex accounts → pin Work on strip → tile follows Work; Auto follows hottest

## Notes
No release cut with this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-provider taskbar account selection for providers with multiple accounts.
  * Added an “Auto” option that selects the account closest to its usage limit.
  * Taskbar and float-bar views now honor pinned account selections and fall back automatically when unavailable.
  * Account preferences are saved and restored across sessions.
* **Style**
  * Improved taskbar provider settings layout and account selector presentation.
* **Tests**
  * Added coverage for account selection, fallback behavior, persistence, and settings controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->