### PR TITLE
Polish strip multi-account flyout and tile tags

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -32,6 +32,9 @@ struct ProviderReadout {
     provider_id: String,
     percent: Option<u8>,
     window_label: String,
+    /// Short multi-account tag (label/email local-part) when the provider has
+    /// more than one reading; keeps the strip tile identifiable.
+    account_tag: Option<String>,
     reset: Option<String>,
 }
 
@@ -104,6 +107,32 @@ where
             .total_cmp(&b.primary.used_percent)
             .then_with(|| b.account_id.cmp(&a.account_id))
     })
+}
+
+/// Short multi-account tag for the strip detail line: custom label, else the
+/// local-part of the email. Keeps tiles readable without the full identity.
+fn short_account_tag(snapshot: &crate::commands::ProviderUsageSnapshot) -> Option<String> {
+    if let Some(label) = snapshot
+        .account_label
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return Some(label.to_string());
+    }
+    snapshot
+        .account_email
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|email| {
+            email
+                .split_once('@')
+                .map(|(local, _)| local)
+                .unwrap_or(email)
+                .to_string()
+        })
+        .filter(|s| !s.is_empty())
 }
 
 fn layout_is_enabled(layout: &TaskbarLayout, all_monitors: bool) -> bool {
@@ -587,6 +616,12 @@ mod windows_host {
                 // its limit (stable across fetch order). Users can pin a
                 // specific Codex/Claude account in Settings → Taskbar Usage.
                 let preferred = settings.taskbar_account_for(&provider_id);
+                let multi_account = guard
+                    .provider_cache
+                    .iter()
+                    .filter(|snapshot| snapshot.provider_id == provider_id)
+                    .count()
+                    > 1;
                 let snapshot = super::select_strip_snapshot(
                     guard.provider_cache.iter(),
                     &provider_id,
@@ -610,6 +645,9 @@ mod windows_host {
                         snapshot.and_then(|snapshot| snapshot.primary_label.as_deref()),
                         snapshot.and_then(|snapshot| snapshot.primary.window_minutes),
                     ),
+                    account_tag: multi_account
+                        .then(|| snapshot.and_then(short_account_tag))
+                        .flatten(),
                     reset: settings
                         .float_bar_show_reset_inline
                         .then(|| {
@@ -682,6 +720,11 @@ mod windows_host {
             Some(minutes) if minutes >= 40_320 => "Monthly".to_string(),
             _ => "Usage".to_string(),
         }
+    }
+
+    /// Short account identity for the strip detail line (multi-account only).
+    fn short_account_tag(snapshot: &crate::commands::ProviderUsageSnapshot) -> Option<String> {
+        super::short_account_tag(snapshot)
     }
 
     fn hide_existing() {
@@ -1088,11 +1131,16 @@ mod windows_host {
                 );
             }
 
-            let detail = match provider.reset.as_deref() {
-                Some(reset) => format!("{} · {reset}", provider.window_label),
-                None => provider.window_label.clone(),
+            let detail = match (provider.account_tag.as_deref(), provider.reset.as_deref()) {
+                (Some(tag), Some(reset)) => {
+                    format!("{} · {tag} · {reset}", provider.window_label)
+                }
+                (Some(tag), None) => format!("{} · {tag}", provider.window_label),
+                (None, Some(reset)) => format!("{} · {reset}", provider.window_label),
+                (None, None) => provider.window_label.clone(),
             };
-            let detail: String = detail.chars().take(15).collect();
+            // Multi-account tags need a bit more room than the old 15-char cap.
+            let detail: String = detail.chars().take(20).collect();
             let detail = wide_without_nul(&detail);
             unsafe {
                 SelectObject(hdc, detail_font);
@@ -1974,5 +2022,18 @@ mod tests {
         ];
         let picked = select_strip_snapshot(cache.iter(), "codex", Some("gone")).unwrap();
         assert_eq!(picked.account_id.as_deref(), Some("work"));
+    }
+
+    #[test]
+    fn short_account_tag_prefers_label_then_email_local_part() {
+        let mut labeled = snap("codex", Some("id"), 10.0);
+        labeled.account_label = Some("Work".into());
+        labeled.account_email = Some("me@job.test".into());
+        assert_eq!(short_account_tag(&labeled).as_deref(), Some("Work"));
+
+        let mut emailed = snap("codex", Some("id"), 10.0);
+        emailed.account_label = None;
+        emailed.account_email = Some("me@job.test".into());
+        assert_eq!(short_account_tag(&emailed).as_deref(), Some("me"));
     }
 }

--- a/apps/desktop-tauri/src/lib/providerRow.test.ts
+++ b/apps/desktop-tauri/src/lib/providerRow.test.ts
@@ -1,14 +1,22 @@
 import { describe, expect, it } from "vitest";
 import {
   hasMultipleAccounts,
+  orderFlyoutProviders,
   representativeForProvider,
   providerIdFromRowKey,
   providerRowKey,
   rowKeyIsProvider,
+  selectStripAccount,
 } from "./providerRow";
 
 const row = (providerId: string, accountId?: string) =>
   ({ providerId, accountId: accountId ?? null }) as never;
+
+const snap = (providerId: string, accountId: string | null, used: number) => ({
+  providerId,
+  accountId,
+  primary: { usedPercent: used },
+});
 
 describe("providerRowKey", () => {
   it("separates two accounts on one provider", () => {
@@ -60,12 +68,6 @@ describe("hasMultipleAccounts", () => {
 });
 
 describe("representativeForProvider", () => {
-  const snap = (providerId: string, accountId: string | null, used: number) => ({
-    providerId,
-    accountId,
-    primary: { usedPercent: used },
-  });
-
   it("picks the most-constrained account", () => {
     const rows = [
       snap("codex", "acct-personal", 12),
@@ -92,5 +94,49 @@ describe("representativeForProvider", () => {
     expect(
       representativeForProvider([snap("claude", null, 10)], "codex"),
     ).toBeNull();
+  });
+});
+
+describe("selectStripAccount", () => {
+  it("defaults to the hottest account", () => {
+    const rows = [
+      snap("codex", "personal", 20),
+      snap("codex", "work", 80),
+    ];
+    expect(selectStripAccount(rows)?.accountId).toBe("work");
+  });
+
+  it("honors an explicit pin when present", () => {
+    const rows = [
+      snap("codex", "personal", 20),
+      snap("codex", "work", 80),
+    ];
+    expect(selectStripAccount(rows, "personal")?.accountId).toBe("personal");
+  });
+
+  it("falls back to hottest when the pin is missing from cache", () => {
+    const rows = [
+      snap("codex", "personal", 20),
+      snap("codex", "work", 80),
+    ];
+    expect(selectStripAccount(rows, "gone")?.accountId).toBe("work");
+  });
+});
+
+describe("orderFlyoutProviders", () => {
+  it("puts the strip account first within a multi-account provider", () => {
+    const rows = [
+      snap("codex", "work", 80),
+      snap("codex", "personal", 20),
+      snap("claude", "only", 10),
+    ];
+    const ordered = orderFlyoutProviders(rows, ["codex", "claude"], {
+      codex: "personal",
+    });
+    expect(ordered.map((row) => row.accountId)).toEqual([
+      "personal",
+      "work",
+      "only",
+    ]);
   });
 });

--- a/apps/desktop-tauri/src/lib/providerRow.ts
+++ b/apps/desktop-tauri/src/lib/providerRow.ts
@@ -128,12 +128,16 @@ export function selectStripAccount<
  * Flyout list order: strip providers in strip order, and within each multi-
  * account provider put the strip account first so it matches the tile.
  */
-export function orderFlyoutProviders(
-  providers: ProviderUsageSnapshot[],
+export function orderFlyoutProviders<
+  T extends Pick<ProviderUsageSnapshot, "providerId" | "accountId"> & {
+    primary?: { usedPercent: number } | null;
+  },
+>(
+  providers: T[],
   stripProviderIds: string[],
   pinnedAccounts: Record<string, string>,
-): ProviderUsageSnapshot[] {
-  const byProvider = new Map<string, ProviderUsageSnapshot[]>();
+): T[] {
+  const byProvider = new Map<string, T[]>();
   for (const row of providers) {
     const group = byProvider.get(row.providerId) ?? [];
     group.push(row);
@@ -151,7 +155,7 @@ export function orderFlyoutProviders(
     if (!providerOrder.includes(id)) providerOrder.push(id);
   }
 
-  const result: ProviderUsageSnapshot[] = [];
+  const result: T[] = [];
   for (const providerId of providerOrder) {
     const group = byProvider.get(providerId) ?? [];
     const strip = selectStripAccount(group, pinnedAccounts[providerId]);

--- a/apps/desktop-tauri/src/lib/providerRow.ts
+++ b/apps/desktop-tauri/src/lib/providerRow.ts
@@ -97,6 +97,80 @@ export function representativeForProvider<
 }
 
 /**
+ * Which account the compact taskbar/float strip should show for a provider.
+ *
+ * Matches the native strip: an explicit pin wins when that account is present,
+ * otherwise the hottest primary window (stable account-id tiebreak).
+ */
+export function selectStripAccount<
+  T extends Pick<ProviderUsageSnapshot, "accountId"> & {
+    primary?: { usedPercent: number } | null;
+  },
+>(
+  candidates: T[],
+  preferredAccountId?: string | null,
+): T | undefined {
+  if (candidates.length === 0) return undefined;
+  const want = preferredAccountId?.trim();
+  if (want) {
+    const hit = candidates.find((row) => row.accountId === want);
+    if (hit) return hit;
+  }
+  return [...candidates].sort((a, b) => {
+    const delta =
+      (b.primary?.usedPercent ?? -1) - (a.primary?.usedPercent ?? -1);
+    if (delta !== 0) return delta;
+    return (b.accountId ?? "").localeCompare(a.accountId ?? "");
+  })[0];
+}
+
+/**
+ * Flyout list order: strip providers in strip order, and within each multi-
+ * account provider put the strip account first so it matches the tile.
+ */
+export function orderFlyoutProviders(
+  providers: ProviderUsageSnapshot[],
+  stripProviderIds: string[],
+  pinnedAccounts: Record<string, string>,
+): ProviderUsageSnapshot[] {
+  const byProvider = new Map<string, ProviderUsageSnapshot[]>();
+  for (const row of providers) {
+    const group = byProvider.get(row.providerId) ?? [];
+    group.push(row);
+    byProvider.set(row.providerId, group);
+  }
+
+  const providerOrder =
+    stripProviderIds.length > 0
+      ? stripProviderIds.filter((id) => byProvider.has(id))
+      : [...byProvider.keys()];
+
+  // Append any remaining providers not in the strip list (should be rare after
+  // the flyout's own filter, but keeps the helper total).
+  for (const id of byProvider.keys()) {
+    if (!providerOrder.includes(id)) providerOrder.push(id);
+  }
+
+  const result: ProviderUsageSnapshot[] = [];
+  for (const providerId of providerOrder) {
+    const group = byProvider.get(providerId) ?? [];
+    const strip = selectStripAccount(group, pinnedAccounts[providerId]);
+    if (!strip) continue;
+    result.push(strip);
+    const rest = group
+      .filter((row) => providerRowKey(row) !== providerRowKey(strip))
+      .sort((a, b) => {
+        const delta =
+          (b.primary?.usedPercent ?? -1) - (a.primary?.usedPercent ?? -1);
+        if (delta !== 0) return delta;
+        return (a.accountId ?? "").localeCompare(b.accountId ?? "");
+      });
+    result.push(...rest);
+  }
+  return result;
+}
+
+/**
  * How an account is named on a usage card: its email, plus plan when known.
  *
  * Deliberately the email, not `accountLabel`. The label is what the user typed

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -1345,7 +1345,8 @@ body:has(.taskbar-flyout-frame) #root {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .taskbar-flyout__provider-name {
@@ -1356,6 +1357,27 @@ body:has(.taskbar-flyout-frame) #root {
   line-height: 18px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.taskbar-flyout__on-strip {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--provider-brand, #6ea8fe) 90%, white);
+  background: color-mix(in srgb, var(--provider-brand, #6ea8fe) 24%, transparent);
+  border: 1px solid color-mix(in srgb, var(--provider-brand, #6ea8fe) 42%, transparent);
+  border-radius: 999px;
+  padding: 1px 7px;
+  line-height: 1.4;
+}
+
+.taskbar-flyout__provider--on-strip {
+  background: color-mix(in srgb, var(--provider-brand, #6ea8fe) 10%, transparent);
+  border-radius: 10px;
+  margin: 0 -6px;
+  padding: 6px;
 }
 
 .taskbar-flyout__provider-unavailable {

--- a/apps/desktop-tauri/src/surfaces/TaskbarFlyout.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/TaskbarFlyout.test.tsx
@@ -124,6 +124,32 @@ describe("TaskbarFlyout", () => {
     expect(screen.getByText("16%")).toBeInTheDocument();
   });
 
+  it("marks the strip account and lists it first when multi-account", async () => {
+    const personal = provider("codex", "Codex", 20, 6 * 24 * 60, "Weekly");
+    personal.accountId = "acct-personal";
+    personal.accountEmail = "me@home.test";
+    const work = provider("codex", "Codex", 80, 6 * 24 * 60, "Weekly");
+    work.accountId = "acct-work";
+    work.accountEmail = "me@job.test";
+    providerState.providers = [work, personal];
+    const pinnedState = {
+      ...state,
+      settings: {
+        ...state.settings,
+        floatBarProviderIds: ["codex"],
+        taskbarAccountByProvider: { codex: "acct-personal" },
+      },
+    } as BootstrapState;
+
+    render(<TaskbarFlyout state={pinnedState} />);
+
+    expect(await screen.findByText("On strip")).toBeInTheDocument();
+    const accounts = screen.getAllByText(/me@/);
+    // Pinned personal seat leads even though work is hotter.
+    expect(accounts[0].textContent).toContain("me@home.test");
+    expect(accounts[1].textContent).toContain("me@job.test");
+  });
+
   it("shows at-a-glance usage and the soonest provider reset", async () => {
     providerState.providers[0].resetCreditsAvailable = 1;
     render(<TaskbarFlyout state={state} />);

--- a/apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx
+++ b/apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx
@@ -18,7 +18,9 @@ import type { BootstrapState, ProviderUsageSnapshot, RateWindowSnapshot } from "
 import {
   accountIdentityLabel,
   hasMultipleAccounts,
+  orderFlyoutProviders,
   providerRowKey,
+  selectStripAccount,
 } from "../lib/providerRow";
 
 const FLYOUT_WIDTH = 344;
@@ -96,11 +98,13 @@ function flyoutWindows(provider: ProviderUsageSnapshot): ConstrainingWindow[] {
   return [...preferred, ...remaining].slice(0, MAX_VISIBLE_WINDOWS_PER_PROVIDER);
 }
 
-function ProviderRow({ provider, showAccount, showAsUsed, now }: {
+function ProviderRow({ provider, showAccount, onStrip, showAsUsed, now }: {
   provider: ProviderUsageSnapshot;
   // True when this provider has more than one account, so the account name is
   // needed to tell its rows apart. With one account it would be noise.
   showAccount: boolean;
+  /** This row is the account currently driving the compact strip tile. */
+  onStrip: boolean;
   showAsUsed: boolean;
   now: number;
 }) {
@@ -108,11 +112,17 @@ function ProviderRow({ provider, showAccount, showAsUsed, now }: {
   const icon = getProviderIcon(provider.providerId);
   if (provider.error) {
     return (
-      <div className="taskbar-flyout__provider taskbar-flyout__provider--error" style={{ "--provider-brand": icon.brandColor } as CSSProperties}>
+      <div
+        className={`taskbar-flyout__provider taskbar-flyout__provider--error${onStrip ? " taskbar-flyout__provider--on-strip" : ""}`}
+        style={{ "--provider-brand": icon.brandColor } as CSSProperties}
+      >
         <ProviderIcon providerId={provider.providerId} size={27} className="taskbar-flyout__provider-icon" />
         <div className="taskbar-flyout__provider-content">
           <div className="taskbar-flyout__provider-topline">
             <span className="taskbar-flyout__provider-name">{provider.displayName}</span>
+            {onStrip && (
+              <span className="taskbar-flyout__on-strip">On strip</span>
+            )}
             <span className="taskbar-flyout__provider-unavailable">Unavailable</span>
           </div>
           {accountName && (
@@ -132,11 +142,17 @@ function ProviderRow({ provider, showAccount, showAsUsed, now }: {
     allMeasuredWindows(provider).filter(isUtilityWindow).length - windows.length,
   );
   return (
-    <div className="taskbar-flyout__provider" style={{ "--provider-brand": icon.brandColor } as CSSProperties}>
+    <div
+      className={`taskbar-flyout__provider${onStrip ? " taskbar-flyout__provider--on-strip" : ""}`}
+      style={{ "--provider-brand": icon.brandColor } as CSSProperties}
+    >
       <ProviderIcon providerId={provider.providerId} size={27} className="taskbar-flyout__provider-icon" />
       <div className="taskbar-flyout__provider-content">
         <div className="taskbar-flyout__provider-topline">
           <span className="taskbar-flyout__provider-name">{provider.displayName}</span>
+          {onStrip && (
+            <span className="taskbar-flyout__on-strip">On strip</span>
+          )}
           {resetCredits != null && (
             <span
               className={`taskbar-flyout__reset-credit${resetCredits === 0 ? " taskbar-flyout__reset-credit--empty" : ""}`}
@@ -200,10 +216,25 @@ export default function TaskbarFlyout({ state }: { state: BootstrapState }) {
       settings.providerOrder,
     );
     const selected = settings.floatBarProviderIds ?? [];
-    if (selected.length === 0) return ordered;
-    const selectedIds = new Set(selected);
-    return ordered.filter((provider) => selectedIds.has(provider.providerId));
-  }, [providers, settings.enabledProviders, settings.floatBarProviderIds, settings.providerOrder, state.providers]);
+    const filtered =
+      selected.length === 0
+        ? ordered
+        : ordered.filter((provider) => selected.includes(provider.providerId));
+    // Strip account first within each multi-account provider so the flyout
+    // matches the tile the user is looking at.
+    return orderFlyoutProviders(
+      filtered,
+      selected,
+      settings.taskbarAccountByProvider ?? {},
+    );
+  }, [
+    providers,
+    settings.enabledProviders,
+    settings.floatBarProviderIds,
+    settings.providerOrder,
+    settings.taskbarAccountByProvider,
+    state.providers,
+  ]);
   const visibleProviders = taskbarProviders.slice(0, MAX_VISIBLE_PROVIDERS);
   const hiddenProviderCount = Math.max(0, taskbarProviders.length - visibleProviders.length);
   const visibleWindowCount = visibleProviders.reduce(
@@ -299,15 +330,34 @@ export default function TaskbarFlyout({ state }: { state: BootstrapState }) {
         </header>
 
         <div className="taskbar-flyout__providers">
-          {visibleProviders.map((provider) => (
+          {visibleProviders.map((provider) => {
+            const multi = hasMultipleAccounts(
+              taskbarProviders,
+              provider.providerId,
+            );
+            const stripAccount = multi
+              ? selectStripAccount(
+                  taskbarProviders.filter(
+                    (row) => row.providerId === provider.providerId,
+                  ),
+                  settings.taskbarAccountByProvider?.[provider.providerId],
+                )
+              : null;
+            const onStrip =
+              multi &&
+              stripAccount != null &&
+              providerRowKey(stripAccount) === providerRowKey(provider);
+            return (
             <ProviderRow
               key={providerRowKey(provider)}
               provider={provider}
-              showAccount={hasMultipleAccounts(taskbarProviders, provider.providerId)}
+              showAccount={multi}
+              onStrip={onStrip}
               showAsUsed={settings.showAsUsed}
               now={now}
             />
-          ))}
+            );
+          })}
           {visibleProviders.length === 0 && (
             <div className="taskbar-flyout__empty">Syncing provider usage…</div>
           )}


### PR DESCRIPTION
## Summary
- Taskbar flyout lists the strip account first within each multi-account provider and marks it with an **On strip** badge so the expanded view matches the compact tile.
- Native strip detail line shows a short account tag (custom label, else email local-part) when a provider has more than one reading: e.g. `Weekly · Work · 2d 4h`.
- Shared `selectStripAccount` / `orderFlyoutProviders` helpers keep TS float/flyout selection aligned with the existing pin + hottest fallback from #139.

## Test plan
- [x] `npx vitest run src/lib/providerRow.test.ts src/surfaces/TaskbarFlyout.test.tsx` (20 passed)
- [x] `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml short_account` / `strip_snapshot`
- [x] `cargo fmt` + `cargo clippy --all-targets -- -D warnings` on desktop-tauri
- [ ] Manual: pin a second Codex/Claude account in Settings → Taskbar, confirm flyout order + badge and strip detail tag

No release in this PR (follow-up after 1.5.6).