### PR TITLE
Add quota-run efficiency metrics on Charts (SOU-299)

### DIFF
--- a/apps/desktop-tauri/src-tauri/permissions/commands.toml
+++ b/apps/desktop-tauri/src-tauri/permissions/commands.toml
@@ -61,6 +61,7 @@ commands.allow = [
   "get_app_info",
   "get_provider_chart_data",
   "get_quota_run_history",
+  "get_quota_run_efficiency",
   "get_provider_local_usage_summary",
   "get_local_api_value_totals",
   "get_cursor_model_activity",

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -349,13 +349,22 @@ struct PersistedChartCache {
     entries: HashMap<String, CachedProviderChartData>,
 }
 
-/// Completed quota-run snapshots for a provider/account (SOU-298), newest last.
+/// Completed quota-run snapshots for a provider/account (SOU-298), oldest first.
 #[tauri::command]
 pub fn get_quota_run_history(
     provider_id: String,
     account_email: Option<String>,
 ) -> Vec<crate::quota_run_history::QuotaRunSnapshot> {
     crate::quota_run_history::list_runs(&provider_id, account_email.as_deref())
+}
+
+/// Latest quota-run efficiency cards per window (SOU-299).
+#[tauri::command]
+pub fn get_quota_run_efficiency(
+    provider_id: String,
+    account_email: Option<String>,
+) -> Vec<crate::quota_run_history::QuotaRunEfficiency> {
+    crate::quota_run_history::efficiency_for_provider(&provider_id, account_email.as_deref())
 }
 
 #[tauri::command]

--- a/apps/desktop-tauri/src-tauri/src/main.rs
+++ b/apps/desktop-tauri/src-tauri/src/main.rs
@@ -194,6 +194,7 @@ fn main() {
             commands::get_app_info,
             commands::get_provider_chart_data,
             commands::get_quota_run_history,
+            commands::get_quota_run_efficiency,
             commands::get_provider_local_usage_summary,
             commands::get_local_api_value_totals,
             commands::get_cursor_model_activity,

--- a/apps/desktop-tauri/src-tauri/src/quota_run_history.rs
+++ b/apps/desktop-tauri/src-tauri/src/quota_run_history.rs
@@ -4,7 +4,7 @@
 //! after a prior reset) until a confirmed capacity reset ends it. Snapshots are
 //! local, bounded, and honest about partial observation (app restart / away).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use crate::capacity_events::{CapacityEventKind, CapacityEventPayload};
 use crate::commands::{ProviderUsageSnapshot, RateWindowSnapshot};
 
-const STORE_VERSION: u8 = 1;
+const STORE_VERSION: u8 = 2;
 /// Keep enough history for run-over-run efficiency (SOU-299) without unbounded growth.
 const MAX_RUNS_PER_SCOPE: usize = 40;
 const RETENTION_DAYS: i64 = 120;
@@ -24,6 +24,10 @@ const MID_CYCLE_START_USED: f64 = 15.0;
 /// Used-percent drop that closes an open run even without a capacity event
 /// (defensive; capacity_events is the primary closer).
 const USED_DROP_CLOSE: f64 = 20.0;
+/// Need a real climb on the meter before tokens-per-1% is meaningful.
+const MIN_PEAK_FOR_TOKENS_PER_PERCENT: f64 = 5.0;
+/// Suppress wild extrapolations early in a run (SOU-299).
+const MIN_PEAK_FOR_PROJECTION: f64 = 25.0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -85,6 +89,42 @@ pub struct QuotaRunSnapshot {
     /// True when the open run was resumed after a process restart.
     #[serde(default)]
     pub interrupted: bool,
+    /// Best-effort local processed tokens for this window during the run.
+    /// Machine-wide when logs lack account identity (see Charts disclosure).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub processed_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fresh_input_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_write_tokens: Option<u64>,
+}
+
+/// Efficiency read derived from a completed run (SOU-299).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct QuotaRunEfficiency {
+    pub run: QuotaRunSnapshot,
+    /// Locally observed processed tokens per 1% of provider-reported used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens_per_percent: Option<f64>,
+    /// Cache-read share of processed tokens during the run (0–100).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read_percent: Option<f64>,
+    /// Extrapolated processed tokens if the meter reached 100% at this rate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projected_tokens_at_100: Option<u64>,
+    /// Relative change vs previous complete run on the same window
+    /// (`-0.2` = 20% fewer tokens per 1%).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vs_previous_tokens_per_percent: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_run_id: Option<String>,
+    /// Honesty label for the UI.
+    pub note: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -110,6 +150,16 @@ struct OpenRun {
     /// Loaded from disk after a previous process exit.
     #[serde(default)]
     interrupted: bool,
+    #[serde(default)]
+    processed_tokens: Option<u64>,
+    #[serde(default)]
+    fresh_input_tokens: Option<u64>,
+    #[serde(default)]
+    output_tokens: Option<u64>,
+    #[serde(default)]
+    cache_read_tokens: Option<u64>,
+    #[serde(default)]
+    cache_write_tokens: Option<u64>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -166,24 +216,9 @@ pub fn record_snapshot(snapshot: &ProviderUsageSnapshot) {
                 push_run(&mut guard, &scope, finished);
                 guard.open.remove(&open_key);
                 // Start a new cycle from the low post-drop reading.
-                guard.open.insert(
-                    open_key,
-                    OpenRun {
-                        provider_id: snapshot.provider_id.clone(),
-                        display_name: snapshot.display_name.clone(),
-                        account_id: snapshot.account_id.clone(),
-                        account_email: snapshot.account_email.clone(),
-                        window_id: window.id.clone(),
-                        window_label: window.label.clone(),
-                        started_at: observed_at,
-                        last_observed_at: observed_at,
-                        peak_used_percent: window.used_percent,
-                        last_used_percent: window.used_percent,
-                        window_minutes: window.window_minutes,
-                        mid_cycle_start: window.used_percent > MID_CYCLE_START_USED,
-                        interrupted: false,
-                    },
-                );
+                let mut next = new_open(snapshot, &window, observed_at);
+                attach_local_tokens(&mut next);
+                guard.open.insert(open_key, next);
                 continue;
             }
             open.last_observed_at = observed_at;
@@ -201,25 +236,12 @@ pub fn record_snapshot(snapshot: &ProviderUsageSnapshot) {
             if open.account_email.is_none() {
                 open.account_email = snapshot.account_email.clone();
             }
+            // Keep last pre-reset local totals (post-reset windows read near 0).
+            attach_local_tokens(open);
         } else {
-            guard.open.insert(
-                open_key,
-                OpenRun {
-                    provider_id: snapshot.provider_id.clone(),
-                    display_name: snapshot.display_name.clone(),
-                    account_id: snapshot.account_id.clone(),
-                    account_email: snapshot.account_email.clone(),
-                    window_id: window.id.clone(),
-                    window_label: window.label.clone(),
-                    started_at: observed_at,
-                    last_observed_at: observed_at,
-                    peak_used_percent: window.used_percent,
-                    last_used_percent: window.used_percent,
-                    window_minutes: window.window_minutes,
-                    mid_cycle_start: window.used_percent > MID_CYCLE_START_USED,
-                    interrupted: false,
-                },
-            );
+            let mut open = new_open(snapshot, &window, observed_at);
+            attach_local_tokens(&mut open);
+            guard.open.insert(open_key, open);
         }
     }
     persist_store(&guard);
@@ -276,24 +298,9 @@ pub fn record_capacity_events(events: &[CapacityEventPayload], snapshot: &Provid
             let observed_at = DateTime::parse_from_rfc3339(&snapshot.updated_at)
                 .map(|value| value.with_timezone(&Utc))
                 .unwrap_or(ended_at);
-            guard.open.insert(
-                open_key,
-                OpenRun {
-                    provider_id: snapshot.provider_id.clone(),
-                    display_name: snapshot.display_name.clone(),
-                    account_id: snapshot.account_id.clone(),
-                    account_email: snapshot.account_email.clone(),
-                    window_id: window.id,
-                    window_label: window.label,
-                    started_at: observed_at,
-                    last_observed_at: observed_at,
-                    peak_used_percent: window.used_percent,
-                    last_used_percent: window.used_percent,
-                    window_minutes: window.window_minutes,
-                    mid_cycle_start: window.used_percent > MID_CYCLE_START_USED,
-                    interrupted: false,
-                },
-            );
+            let mut next = new_open(snapshot, &window, observed_at);
+            attach_local_tokens(&mut next);
+            guard.open.insert(open_key, next);
         }
     }
     if wrote {
@@ -301,7 +308,7 @@ pub fn record_capacity_events(events: &[CapacityEventPayload], snapshot: &Provid
     }
 }
 
-/// Completed runs for a provider/account, newest first.
+/// Completed runs for a provider/account, chronological (oldest first).
 pub fn list_runs(provider_id: &str, account_email: Option<&str>) -> Vec<QuotaRunSnapshot> {
     let Ok(guard) = store().lock() else {
         return Vec::new();
@@ -318,6 +325,125 @@ pub fn list_runs(provider_id: &str, account_email: Option<&str>) -> Vec<QuotaRun
         }
     }
     Vec::new()
+}
+
+/// Efficiency cards for Charts: latest complete runs per window, newest first.
+pub fn efficiency_for_provider(
+    provider_id: &str,
+    account_email: Option<&str>,
+) -> Vec<QuotaRunEfficiency> {
+    let runs = list_runs(provider_id, account_email);
+    if runs.is_empty() {
+        return Vec::new();
+    }
+
+    // Index previous complete run per window for deltas.
+    let mut previous_complete: HashMap<String, &QuotaRunSnapshot> = HashMap::new();
+    let mut rows: Vec<QuotaRunEfficiency> = Vec::new();
+
+    for run in &runs {
+        let prev = previous_complete.get(&run.window_id).copied();
+        let row = efficiency_for_run(run, prev);
+        if run.complete {
+            previous_complete.insert(run.window_id.clone(), run);
+        }
+        // Surface complete runs, plus incomplete ones that still have tokens so
+        // the user sees something while history accumulates.
+        if run.complete || run.processed_tokens.is_some() {
+            rows.push(row);
+        }
+    }
+
+    // Newest first for the UI; keep one card per window (latest complete preferred).
+    rows.reverse();
+    let mut seen_windows = HashSet::new();
+    rows.retain(|row| {
+        if !row.run.complete && row.run.processed_tokens.is_none() {
+            return false;
+        }
+        // Prefer first occurrence after reverse = newest.
+        if seen_windows.contains(&row.run.window_id) {
+            return false;
+        }
+        seen_windows.insert(row.run.window_id.clone());
+        true
+    });
+    rows
+}
+
+fn efficiency_for_run(
+    run: &QuotaRunSnapshot,
+    previous: Option<&QuotaRunSnapshot>,
+) -> QuotaRunEfficiency {
+    let rate = tokens_per_percent(run.processed_tokens, run.peak_used_percent);
+    let cache_share = cache_read_percent(
+        run.processed_tokens,
+        run.cache_read_tokens,
+        run.fresh_input_tokens,
+        run.output_tokens,
+        run.cache_write_tokens,
+    );
+    let projected_tokens_at_100 = if run.peak_used_percent >= MIN_PEAK_FOR_PROJECTION {
+        rate.map(|value| (value * 100.0).round() as u64)
+    } else {
+        None
+    };
+
+    let mut vs_previous = None;
+    let mut previous_run_id = None;
+    if let (Some(rate), Some(prev)) = (rate, previous)
+        && let Some(prev_rate) = tokens_per_percent(prev.processed_tokens, prev.peak_used_percent)
+        && prev_rate > 0.0
+    {
+        vs_previous = Some((rate - prev_rate) / prev_rate);
+        previous_run_id = Some(prev.id.clone());
+    }
+
+    QuotaRunEfficiency {
+        run: run.clone(),
+        tokens_per_percent: rate,
+        cache_read_percent: cache_share,
+        projected_tokens_at_100,
+        vs_previous_tokens_per_percent: vs_previous,
+        previous_run_id,
+        note: efficiency_note(run),
+    }
+}
+
+fn tokens_per_percent(processed: Option<u64>, peak_used: f64) -> Option<f64> {
+    let tokens = processed.filter(|value| *value > 0)?;
+    if peak_used < MIN_PEAK_FOR_TOKENS_PER_PERCENT {
+        return None;
+    }
+    Some(tokens as f64 / peak_used)
+}
+
+fn cache_read_percent(
+    processed: Option<u64>,
+    cache_read: Option<u64>,
+    fresh: Option<u64>,
+    output: Option<u64>,
+    cache_write: Option<u64>,
+) -> Option<f64> {
+    let cache = cache_read.unwrap_or(0);
+    let total = processed.unwrap_or_else(|| {
+        fresh.unwrap_or(0) + output.unwrap_or(0) + cache + cache_write.unwrap_or(0)
+    });
+    if total == 0 {
+        return None;
+    }
+    Some((cache as f64 / total as f64) * 100.0)
+}
+
+fn efficiency_note(run: &QuotaRunSnapshot) -> String {
+    if run.processed_tokens.is_none() {
+        return "No local token sample was captured for this run yet.".into();
+    }
+    if !run.complete {
+        return "Partial observation · locally observed tokens vs this account's quota %. Not a published allowance.".into();
+    }
+    "Locally observed tokens vs this account's quota %. Not a published allowance or token cap."
+        .into()
 }
 
 #[cfg(test)]
@@ -363,6 +489,11 @@ fn finalize_open(
         complete,
         while_away,
         interrupted: open.interrupted,
+        processed_tokens: open.processed_tokens,
+        fresh_input_tokens: open.fresh_input_tokens,
+        output_tokens: open.output_tokens,
+        cache_read_tokens: open.cache_read_tokens,
+        cache_write_tokens: open.cache_write_tokens,
     }
 }
 
@@ -405,7 +536,78 @@ fn partial_from_event(
         complete: false,
         while_away: event.while_away,
         interrupted: true,
+        processed_tokens: None,
+        fresh_input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
     }
+}
+
+fn new_open(
+    snapshot: &ProviderUsageSnapshot,
+    window: &LiveWindow,
+    observed_at: DateTime<Utc>,
+) -> OpenRun {
+    OpenRun {
+        provider_id: snapshot.provider_id.clone(),
+        display_name: snapshot.display_name.clone(),
+        account_id: snapshot.account_id.clone(),
+        account_email: snapshot.account_email.clone(),
+        window_id: window.id.clone(),
+        window_label: window.label.clone(),
+        started_at: observed_at,
+        last_observed_at: observed_at,
+        peak_used_percent: window.used_percent,
+        last_used_percent: window.used_percent,
+        window_minutes: window.window_minutes,
+        mid_cycle_start: window.used_percent > MID_CYCLE_START_USED,
+        interrupted: false,
+        processed_tokens: None,
+        fresh_input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+    }
+}
+
+/// Capture local window tokens while the run is open (pre-reset).
+fn attach_local_tokens(open: &mut OpenRun) {
+    let Some(summary) = crate::commands::cached_provider_local_usage_summary(&open.provider_id)
+    else {
+        return;
+    };
+    for window in &summary.current_windows {
+        if !local_window_matches(open, window) {
+            continue;
+        }
+        // Prefer a non-zero sample; after reset the window restarts near 0.
+        if window.tokens == 0 && open.processed_tokens.is_some() {
+            return;
+        }
+        open.processed_tokens = Some(window.tokens);
+        open.fresh_input_tokens = Some(window.token_breakdown.fresh_input_tokens);
+        open.output_tokens = Some(window.token_breakdown.output_tokens);
+        open.cache_read_tokens = Some(window.token_breakdown.cache_read_tokens);
+        open.cache_write_tokens = Some(window.token_breakdown.cache_write_tokens);
+        return;
+    }
+}
+
+fn local_window_matches(open: &OpenRun, window: &crate::commands::LocalUsageWindowSummary) -> bool {
+    if window.id.eq_ignore_ascii_case(&open.window_id) {
+        return true;
+    }
+    let from_label = crate::capacity_events::semantic_window_id(&window.label, open.window_minutes);
+    if from_label == open.window_id {
+        return true;
+    }
+    let open_label =
+        crate::capacity_events::semantic_window_id(&open.window_label, open.window_minutes);
+    from_label == open_label
+        || window
+            .label
+            .eq_ignore_ascii_case(open.window_label.as_str())
 }
 
 fn push_run(store: &mut QuotaRunStore, scope: &str, run: QuotaRunSnapshot) {
@@ -820,5 +1022,58 @@ mod tests {
 
         assert_eq!(list_runs(provider, Some("me@job.test")).len(), 1);
         assert!(list_runs(provider, Some("other@home.test")).is_empty());
+    }
+
+    #[test]
+    fn tokens_per_percent_and_projection_require_enough_peak() {
+        assert!(tokens_per_percent(Some(1_000_000), 4.0).is_none());
+        let rate = tokens_per_percent(Some(9_500_000), 95.0).unwrap();
+        assert!((rate - 100_000.0).abs() < 0.01);
+        assert_eq!(
+            cache_read_percent(Some(100), Some(80), None, None, None),
+            Some(80.0)
+        );
+    }
+
+    #[test]
+    fn efficiency_compares_complete_runs_on_same_window() {
+        let prev = QuotaRunSnapshot {
+            id: "prev".into(),
+            provider_id: "codex".into(),
+            display_name: "Codex".into(),
+            account_id: None,
+            account_email: None,
+            window_id: "session".into(),
+            window_label: "Session".into(),
+            started_at: "2026-07-01T00:00:00Z".into(),
+            ended_at: "2026-07-01T05:00:00Z".into(),
+            peak_used_percent: 100.0,
+            end_used_percent: 100.0,
+            after_reset_used_percent: Some(0.0),
+            reset_kind: QuotaRunResetKind::Scheduled,
+            window_minutes: Some(300),
+            observed_duration_seconds: 18_000,
+            complete: true,
+            while_away: false,
+            interrupted: false,
+            processed_tokens: Some(20_000_000),
+            fresh_input_tokens: Some(2_000_000),
+            output_tokens: Some(1_000_000),
+            cache_read_tokens: Some(16_000_000),
+            cache_write_tokens: Some(1_000_000),
+        };
+        let next = QuotaRunSnapshot {
+            id: "next".into(),
+            processed_tokens: Some(10_000_000),
+            peak_used_percent: 100.0,
+            end_used_percent: 100.0,
+            ..prev.clone()
+        };
+        let eff = efficiency_for_run(&next, Some(&prev));
+        assert!((eff.tokens_per_percent.unwrap() - 100_000.0).abs() < 0.01);
+        assert!((eff.vs_previous_tokens_per_percent.unwrap() - (-0.5)).abs() < 0.001);
+        assert_eq!(eff.previous_run_id.as_deref(), Some("prev"));
+        assert_eq!(eff.projected_tokens_at_100, Some(10_000_000));
+        assert!(eff.note.contains("Locally observed"));
     }
 }

--- a/apps/desktop-tauri/src/lib/tauri.ts
+++ b/apps/desktop-tauri/src/lib/tauri.ts
@@ -285,6 +285,17 @@ export function exportCostCsv(providerId: string): Promise<string> {
   return invoke<string>("export_cost_csv", { providerId });
 }
 
+/** Latest quota-run efficiency cards per window (SOU-299). */
+export function getQuotaRunEfficiency(
+  providerId: string,
+  accountEmail?: string | null,
+): Promise<import("../types/bridge").QuotaRunEfficiency[]> {
+  return invoke("get_quota_run_efficiency", {
+    providerId,
+    accountEmail: accountEmail ?? null,
+  });
+}
+
 // ── Token account bridge ─────────────────────────────────────────────
 
 export function getDirectoryAccounts(): Promise<ProviderAccountsBridge[]> {

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -7883,6 +7883,89 @@ body:has(.dashboard-shell) #root {
   font-size: 10.5px;
   flex-wrap: wrap;
 }
+/* SOU-299: tokens per 1% and run-over-run efficiency for completed quota runs. */
+.quota-efficiency {
+  grid-column: 1 / -1;
+  margin-top: 4px;
+  padding: 10px 11px;
+  border: 1px solid color-mix(in srgb, var(--ceiling-glass-border) 80%, transparent);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--text-primary) 3%, transparent);
+}
+.quota-efficiency__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 4px 12px;
+  margin-bottom: 8px;
+}
+.quota-efficiency__title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.quota-efficiency__subtitle {
+  font-size: 10.5px;
+  color: var(--text-secondary);
+}
+.quota-efficiency__rows {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.quota-efficiency__row-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+.quota-efficiency__badge {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary);
+  border: 1px solid color-mix(in srgb, var(--text-secondary) 35%, transparent);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+.quota-efficiency__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 8px;
+}
+.quota-efficiency__metrics span {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.quota-efficiency__metrics small {
+  color: var(--text-secondary);
+  font-size: 10.5px;
+}
+.quota-efficiency__metrics strong {
+  color: var(--text-primary);
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+.quota-efficiency__metrics strong[data-delta="down"] {
+  color: color-mix(in srgb, var(--usage-bar-high) 85%, white);
+}
+.quota-efficiency__metrics strong[data-delta="up"] {
+  color: color-mix(in srgb, var(--ceiling-cyan) 80%, white);
+}
+.quota-efficiency__note {
+  display: block;
+  margin-top: 6px;
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  line-height: 1.4;
+}
+
 /* A caveat, not decoration: the totals beside it are not account-scoped. */
 .usage-periods__note--warn {
   margin: 8px 0 0;

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.test.tsx
@@ -5,6 +5,7 @@ const tauriMocks = vi.hoisted(() => ({
   getProviderChartData: vi.fn(),
   getSettingsSnapshot: vi.fn(),
   getCursorModelActivity: vi.fn(),
+  getQuotaRunEfficiency: vi.fn(),
   exportCostCsv: vi.fn(),
 }));
 
@@ -105,6 +106,30 @@ describe("ChartsSection local usage summary", () => {
     tauriMocks.getSettingsSnapshot.mockResolvedValue({ enableAnimations: false });
     tauriMocks.getProviderChartData.mockResolvedValue(enrichedData);
     tauriMocks.getCursorModelActivity.mockResolvedValue([]);
+    tauriMocks.getQuotaRunEfficiency.mockResolvedValue([
+      {
+        run: {
+          id: "run-1",
+          providerId: "claude",
+          displayName: "Claude",
+          windowId: "session",
+          windowLabel: "5-hour window",
+          startedAt: new Date().toISOString(),
+          endedAt: new Date().toISOString(),
+          peakUsedPercent: 95,
+          endUsedPercent: 95,
+          resetKind: "scheduled",
+          observedDurationSeconds: 14_000,
+          complete: true,
+          processedTokens: 19_000_000,
+        },
+        tokensPerPercent: 200_000,
+        cacheReadPercent: 88,
+        projectedTokensAt100: 20_000_000,
+        vsPreviousTokensPerPercent: -0.12,
+        note: "Locally observed tokens vs this account's quota %.",
+      },
+    ]);
     tauriMocks.exportCostCsv.mockResolvedValue("C:/Users/me/Downloads/ceiling-claude-spend.csv");
   });
 
@@ -112,10 +137,11 @@ describe("ChartsSection local usage summary", () => {
     const { getByText, getAllByText, getByLabelText } = render(
       <ChartsSection providerId="claude" accountEmail={null} t={(key) => key} />,
     );
+    // getAllByText used below: period card + efficiency row share "5-hour window".
 
     await waitFor(() => expect(getByText("4.9B")).toBeTruthy());
     expect(getByText("23.6B")).toBeTruthy();
-    expect(getByText("5-hour window")).toBeTruthy();
+    expect(getAllByText("5-hour window").length).toBeGreaterThan(0);
     expect(getByText("Weekly window")).toBeTruthy();
     // Tokens and dollars are separate elements so the value never breaks
     // mid-string and the detail line can wrap inside its own card.
@@ -126,6 +152,11 @@ describe("ChartsSection local usage summary", () => {
     // Partial pricing on the weekly card; fully-priced 5-hour stays quiet.
     expect(getByText("80% of tokens priced")).toBeTruthy();
     expect(getByText("81% of tokens priced")).toBeTruthy(); // 7-day calendar
+    // SOU-299 efficiency card from completed quota runs.
+    expect(getByText("Quota run efficiency")).toBeTruthy();
+    expect(getByText("Tokens / 1%")).toBeTruthy();
+    expect(getByText("200.0K")).toBeTruthy();
+    expect(getByText("-12% vs prior run")).toBeTruthy();
     expect(() => getByText("Last session")).toThrow();
     expect(getByText("99.7% cache traffic")).toBeTruthy();
     expect(getAllByText(/Processed tokens · calendar/)).toHaveLength(2);

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -3,6 +3,7 @@ import {
   exportCostCsv,
   getCursorModelActivity,
   getProviderChartData,
+  getQuotaRunEfficiency,
   getSettingsSnapshot,
 } from "../../../../../lib/tauri";
 import {
@@ -19,6 +20,7 @@ import type {
   LocalTokenBreakdown,
   ProviderChartData,
   ProviderUsageSnapshot,
+  QuotaRunEfficiency,
   SettingsSnapshot,
 } from "../../../../../types/bridge";
 import type { useLocale } from "../../../../../hooks/useLocale";
@@ -140,6 +142,71 @@ function pricingCoverageNote(
   if (total <= 0 || priced >= total) return null;
   const percent = Math.round((priced / total) * 100);
   return `${percent}% of tokens priced`;
+}
+
+function formatCompactTokens(value: number): string {
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(Math.round(value));
+}
+
+function formatDeltaPercent(value: number): string {
+  const pct = Math.round(value * 100);
+  if (pct > 0) return `+${pct}% vs prior run`;
+  if (pct < 0) return `${pct}% vs prior run`;
+  return "Same as prior run";
+}
+
+function QuotaEfficiencyCard({ rows }: { rows: QuotaRunEfficiency[] }) {
+  if (rows.length === 0) return null;
+  return (
+    <div className="quota-efficiency" aria-label="Quota run efficiency">
+      <div className="quota-efficiency__header">
+        <span className="quota-efficiency__title">Quota run efficiency</span>
+        <span className="quota-efficiency__subtitle">Local observation · not a published allowance</span>
+      </div>
+      <div className="quota-efficiency__rows">
+        {rows.map((row) => (
+          <div className="quota-efficiency__row" key={row.run.id}>
+            <div className="quota-efficiency__row-head">
+              <strong>{row.run.windowLabel}</strong>
+              {!row.run.complete && <span className="quota-efficiency__badge">Partial</span>}
+            </div>
+            <div className="quota-efficiency__metrics">
+              {row.tokensPerPercent != null && (
+                <span>
+                  <small>Tokens / 1%</small>
+                  <strong>{formatCompactTokens(row.tokensPerPercent)}</strong>
+                </span>
+              )}
+              {row.cacheReadPercent != null && (
+                <span>
+                  <small>Cache read</small>
+                  <strong>{row.cacheReadPercent.toFixed(0)}%</strong>
+                </span>
+              )}
+              {row.projectedTokensAt100 != null && (
+                <span>
+                  <small>Projected @ 100%</small>
+                  <strong>{formatCompactTokens(row.projectedTokensAt100)}</strong>
+                </span>
+              )}
+              {row.vsPreviousTokensPerPercent != null && (
+                <span>
+                  <small>Run-over-run</small>
+                  <strong data-delta={row.vsPreviousTokensPerPercent < 0 ? "down" : "up"}>
+                    {formatDeltaPercent(row.vsPreviousTokensPerPercent)}
+                  </strong>
+                </span>
+              )}
+            </div>
+            <small className="quota-efficiency__note">{row.note}</small>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 /** Backend bucket for records whose rollout never declared a plan. */
@@ -409,12 +476,33 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
   const [enriching, setEnriching] = useState(false);
   const [failed, setFailed] = useState(false);
   const [cursorActivity, setCursorActivity] = useState<CursorModelActivity[] | null>(null);
+  const [efficiency, setEfficiency] = useState<QuotaRunEfficiency[]>([]);
   const usageWindows = providerLocalUsageWindows(providerSnapshot);
   const sourceLabel = providerSnapshot?.sourceLabel;
   const resetBoundaryUnavailable = providerHasUnavailableResetBoundary(providerSnapshot);
   const usageWindowsKey = usageWindows
     .map((window) => `${window.id}:${window.startsAt}:${window.endsAt}`)
     .join("|");
+
+  useEffect(() => {
+    let cancelled = false;
+    setEfficiency([]);
+    if (!providerSupportsChartData(providerId)) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    getQuotaRunEfficiency(providerId, accountEmail)
+      .then((rows) => {
+        if (!cancelled) setEfficiency(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setEfficiency([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [providerId, accountEmail]);
 
   useEffect(() => {
     let cancelled = false;
@@ -719,6 +807,7 @@ export function ChartsSection({ providerId, accountEmail, providerSnapshot, t }:
             )}
             <span>Processed includes fresh input, output, cache reads, and cache writes.</span>
           </div>
+          <QuotaEfficiencyCard rows={efficiency} />
           {/* Local logs carry no account identity, so these totals cover every
               account that has used this machine. Disclose that rather than let
               the figures read as belonging to the signed-in account. */}

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -786,6 +786,44 @@ export interface LocalTokenBreakdown {
   reasoningTokens?: number;
 }
 
+/** Completed rate-window run (SOU-298). */
+export interface QuotaRunSnapshot {
+  id: string;
+  providerId: string;
+  displayName: string;
+  accountId?: string | null;
+  accountEmail?: string | null;
+  windowId: string;
+  windowLabel: string;
+  startedAt: string;
+  endedAt: string;
+  peakUsedPercent: number;
+  endUsedPercent: number;
+  afterResetUsedPercent?: number | null;
+  resetKind: "scheduled" | "surprise" | "partial" | "observedDrop";
+  windowMinutes?: number | null;
+  observedDurationSeconds: number;
+  complete: boolean;
+  whileAway?: boolean;
+  interrupted?: boolean;
+  processedTokens?: number | null;
+  freshInputTokens?: number | null;
+  outputTokens?: number | null;
+  cacheReadTokens?: number | null;
+  cacheWriteTokens?: number | null;
+}
+
+/** Efficiency card derived from a run (SOU-299). */
+export interface QuotaRunEfficiency {
+  run: QuotaRunSnapshot;
+  tokensPerPercent?: number | null;
+  cacheReadPercent?: number | null;
+  projectedTokensAt100?: number | null;
+  vsPreviousTokensPerPercent?: number | null;
+  previousRunId?: string | null;
+  note: string;
+}
+
 export interface ProviderChartData {
   providerId: string;
   costHistory: DailyCostPoint[];


### PR DESCRIPTION
## Summary
- Extend SOU-298 run snapshots with best-effort local token samples captured **while the run is open** (pre-reset).
- Derive **tokens / 1%**, **cache-read %**, **projected @ 100%** (only when peak ≥ 25%), and **run-over-run delta** vs the previous complete run on the same window.
- Charts card: **Quota run efficiency**, labeled as local observation (not a published allowance).
- IPC: `get_quota_run_efficiency` (+ ACL).

## Honesty
Provider % stays authoritative. Token totals may still be machine-wide for some providers; the card copy says so. Projection is suppressed early in a run.

## Test plan
- [x] Rust `quota_run` tests (6)
- [x] ChartsSection vitest
- [x] clippy -D warnings, tsc
- [ ] Live: complete a window reset with local logs; confirm card fills after a second run for deltas

Closes SOU-299. No release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quota-run efficiency cards to provider usage charts.
  * Displays tokens per 1% usage, cache-read share, projected token capacity, and changes versus prior runs.
  * Captures local token samples to improve efficiency insights across quota windows.
* **Bug Fixes**
  * Clarified quota-run history ordering in documentation.
* **Tests**
  * Added coverage for efficiency metrics, projections, comparisons, and displayed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->