### PR TITLE
Shrink On strip chip; drop account tag from taskbar tile

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -32,9 +32,6 @@ struct ProviderReadout {
     provider_id: String,
     percent: Option<u8>,
     window_label: String,
-    /// Short multi-account tag (label/email local-part) when the provider has
-    /// more than one reading; keeps the strip tile identifiable.
-    account_tag: Option<String>,
     reset: Option<String>,
 }
 
@@ -107,32 +104,6 @@ where
             .total_cmp(&b.primary.used_percent)
             .then_with(|| b.account_id.cmp(&a.account_id))
     })
-}
-
-/// Short multi-account tag for the strip detail line: custom label, else the
-/// local-part of the email. Keeps tiles readable without the full identity.
-fn short_account_tag(snapshot: &crate::commands::ProviderUsageSnapshot) -> Option<String> {
-    if let Some(label) = snapshot
-        .account_label
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-    {
-        return Some(label.to_string());
-    }
-    snapshot
-        .account_email
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(|email| {
-            email
-                .split_once('@')
-                .map(|(local, _)| local)
-                .unwrap_or(email)
-                .to_string()
-        })
-        .filter(|s| !s.is_empty())
 }
 
 fn layout_is_enabled(layout: &TaskbarLayout, all_monitors: bool) -> bool {
@@ -616,12 +587,6 @@ mod windows_host {
                 // its limit (stable across fetch order). Users can pin a
                 // specific Codex/Claude account in Settings → Taskbar Usage.
                 let preferred = settings.taskbar_account_for(&provider_id);
-                let multi_account = guard
-                    .provider_cache
-                    .iter()
-                    .filter(|snapshot| snapshot.provider_id == provider_id)
-                    .count()
-                    > 1;
                 let snapshot = super::select_strip_snapshot(
                     guard.provider_cache.iter(),
                     &provider_id,
@@ -641,13 +606,13 @@ mod windows_host {
                 ProviderReadout {
                     provider_id,
                     percent,
+                    // Window label only (Weekly / 5h). Account identity lives in
+                    // the flyout (On strip + account line); long tags collide
+                    // with the next tile on the compact strip.
                     window_label: compact_window_label(
                         snapshot.and_then(|snapshot| snapshot.primary_label.as_deref()),
                         snapshot.and_then(|snapshot| snapshot.primary.window_minutes),
                     ),
-                    account_tag: multi_account
-                        .then(|| snapshot.and_then(short_account_tag))
-                        .flatten(),
                     reset: settings
                         .float_bar_show_reset_inline
                         .then(|| {
@@ -720,11 +685,6 @@ mod windows_host {
             Some(minutes) if minutes >= 40_320 => "Monthly".to_string(),
             _ => "Usage".to_string(),
         }
-    }
-
-    /// Short account identity for the strip detail line (multi-account only).
-    fn short_account_tag(snapshot: &crate::commands::ProviderUsageSnapshot) -> Option<String> {
-        super::short_account_tag(snapshot)
     }
 
     fn hide_existing() {
@@ -1131,16 +1091,13 @@ mod windows_host {
                 );
             }
 
-            let detail = match (provider.account_tag.as_deref(), provider.reset.as_deref()) {
-                (Some(tag), Some(reset)) => {
-                    format!("{} · {tag} · {reset}", provider.window_label)
-                }
-                (Some(tag), None) => format!("{} · {tag}", provider.window_label),
-                (None, Some(reset)) => format!("{} · {reset}", provider.window_label),
-                (None, None) => provider.window_label.clone(),
+            // Window label (+ optional reset). Account identity is flyout-only
+            // so long tags don't collide with the next tile.
+            let detail = match provider.reset.as_deref() {
+                Some(reset) => format!("{} · {reset}", provider.window_label),
+                None => provider.window_label.clone(),
             };
-            // Multi-account tags need a bit more room than the old 15-char cap.
-            let detail: String = detail.chars().take(20).collect();
+            let detail: String = detail.chars().take(15).collect();
             let detail = wide_without_nul(&detail);
             unsafe {
                 SelectObject(hdc, detail_font);
@@ -2024,16 +1981,4 @@ mod tests {
         assert_eq!(picked.account_id.as_deref(), Some("work"));
     }
 
-    #[test]
-    fn short_account_tag_prefers_label_then_email_local_part() {
-        let mut labeled = snap("codex", Some("id"), 10.0);
-        labeled.account_label = Some("Work".into());
-        labeled.account_email = Some("me@job.test".into());
-        assert_eq!(short_account_tag(&labeled).as_deref(), Some("Work"));
-
-        let mut emailed = snap("codex", Some("id"), 10.0);
-        emailed.account_label = None;
-        emailed.account_email = Some("me@job.test".into());
-        assert_eq!(short_account_tag(&emailed).as_deref(), Some("me"));
-    }
 }

--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -1980,5 +1980,4 @@ mod tests {
         let picked = select_strip_snapshot(cache.iter(), "codex", Some("gone")).unwrap();
         assert_eq!(picked.account_id.as_deref(), Some("work"));
     }
-
 }

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -1359,18 +1359,19 @@ body:has(.taskbar-flyout-frame) #root {
   white-space: nowrap;
 }
 
+/* Secondary to banked-resets: identity cue only, keep it quieter and smaller. */
 .taskbar-flyout__on-strip {
   flex-shrink: 0;
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.03em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--provider-brand, #6ea8fe) 90%, white);
-  background: color-mix(in srgb, var(--provider-brand, #6ea8fe) 24%, transparent);
-  border: 1px solid color-mix(in srgb, var(--provider-brand, #6ea8fe) 42%, transparent);
+  color: color-mix(in srgb, var(--provider-brand, #6ea8fe) 78%, white);
+  background: color-mix(in srgb, var(--provider-brand, #6ea8fe) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--provider-brand, #6ea8fe) 30%, transparent);
   border-radius: 999px;
-  padding: 1px 7px;
-  line-height: 1.4;
+  padding: 0 5px;
+  line-height: 1.35;
 }
 
 .taskbar-flyout__provider--on-strip {
@@ -1386,16 +1387,17 @@ body:has(.taskbar-flyout-frame) #root {
   font-weight: 600;
 }
 
+/* Primary action cue: slightly larger than the On strip marker. */
 .taskbar-flyout__reset-credit {
   flex-shrink: 0;
-  padding: 2px 7px;
-  border: 1px solid rgba(128, 221, 255, 0.25);
+  padding: 2px 8px;
+  border: 1px solid rgba(128, 221, 255, 0.28);
   border-radius: 999px;
-  background: rgba(91, 201, 238, 0.1);
-  color: rgba(224, 247, 255, 0.9);
-  font-size: 10px;
+  background: rgba(91, 201, 238, 0.12);
+  color: rgba(224, 247, 255, 0.94);
+  font-size: 11px;
   font-weight: 600;
-  line-height: 14px;
+  line-height: 15px;
 }
 
 /* No banked resets: keep the indicator visible but quiet — nothing to act on. */


### PR DESCRIPTION
## Summary
- Flyout chip hierarchy: On strip smaller/quieter (9px, less pad, softer brand tint); banked-resets chip slightly larger (11px, more pad).
- Native strip detail line no longer includes multi-account tags. Tiles show window label only (Weekly / 5h) plus optional reset when that setting is on. Account identity stays in the flyout via On strip + the account line.

## Why
Long account names on the strip collided with the next provider tile. The On strip chip already marks which account is pinned in the popout, so the compact strip should stay short.

## Test plan
- [ ] Multi-account Codex/Claude: strip shows Weekly or 5h (and reset if enabled), not the account name
- [ ] Flyout: On strip chip smaller than banked-resets chip; banked resets still readable
- [ ] Pin a specific account in Settings > Taskbar: correct account still drives strip percent; flyout still shows On strip on that account
- [ ] Single-account providers unchanged

## Commands
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml taskbar_widget` (18 passed)