### PR TITLE
feat(grok): price Charts from session costUsdTicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Signed draft of everything since public **1.5.6**: multi-account strip controls, Charts trust/efficiency, strip density polish, and flyout alignment. Supersedes draft tags **1.5.7**–**1.5.9** (1.5.9 was tagged off main and cannot be moved).
 
+### Added
+- Price Grok Charts from local session `costUsdTicks` (same API-equivalent Cost as Grok Build `/usage`). Token/cache/effort/project rollups still apply; partial sessions without ticks stay unpriced with coverage disclosure.
+
 ### Fixed
 - Taskbar flyout **On strip** row no longer shifts left of the other providers. The strip seat keeps the brand tint without rewriting margin/padding, so icons and meters share one left edge.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Price Grok Charts from local session `costUsdTicks` (same API-equivalent Cost as Grok Build `/usage`), including the Estimated API value card. Token/cache/effort/project rollups still apply; partial sessions without ticks stay unpriced with coverage disclosure.
+
 ## [Ceiling] 1.5.10 - 2026-07-25
 
 Signed draft of everything since public **1.5.6**: multi-account strip controls, Charts trust/efficiency, strip density polish, and flyout alignment. Supersedes draft tags **1.5.7**–**1.5.9** (1.5.9 was tagged off main and cannot be moved).
-
-### Added
-- Price Grok Charts from local session `costUsdTicks` (same API-equivalent Cost as Grok Build `/usage`). Token/cache/effort/project rollups still apply; partial sessions without ticks stay unpriced with coverage disclosure.
 
 ### Fixed
 - Taskbar flyout **On strip** row no longer shifts left of the other providers. The strip seat keeps the brand tint without rewriting margin/padding, so icons and meters share one left edge.

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -587,7 +587,8 @@ fn persist_chart_cache(cache: &PersistedChartCache) {
 
 /// Providers that expose token-derived local usage for the aggregate card.
 /// Inclusion is by capability, not by merely having some other dollar balance.
-const API_VALUE_PROVIDERS: [&str; 2] = ["codex", "claude"];
+// Grok dollars come from session costUsdTicks (API-equivalent), same as provider Charts.
+const API_VALUE_PROVIDERS: [&str; 3] = ["codex", "claude", "grok"];
 
 /// Priced vs total model-token counts for pricing-coverage disclosure.
 ///

--- a/apps/desktop-tauri/src/lib/providerCharts.ts
+++ b/apps/desktop-tauri/src/lib/providerCharts.ts
@@ -6,7 +6,7 @@ import type {
 
 // Providers whose live snapshots are sampled into local quota history, and/or
 // that have transcript/cost scanners. Grok also has local session logs under
-// ~/.grok/sessions (tokens, cache, effort, projects).
+// ~/.grok/sessions (tokens, cache, effort, projects, API-equivalent $).
 const PROVIDER_CHART_DATA_IDS = new Set([
   "claude",
   "codex",

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -35,7 +35,7 @@ App-Bound Encryption details.
 | **Cursor** | Your signed-in Cursor IDE session (`state.vscdb`), or cursor.com cookies you provide | cursor.com |
 | **GitHub Copilot** | Your GitHub CLI / Git Credential Manager token (or a device-flow sign-in) | api.github.com, or your GitHub Enterprise host |
 | **Gemini** | The OAuth token from the Gemini CLI (`~/.gemini/oauth_creds.json`) | Google Code Assist and OAuth endpoints |
-| **Grok** | The OIDC session from Grok Build (`~/.grok/auth.json` via `grok login`), or grok.com cookies you provide; tokens refresh via auth.x.ai; plus local `~/.grok/sessions` logs for tokens / cache / effort / projects | grok.com, auth.x.ai |
+| **Grok** | The OIDC session from Grok Build (`~/.grok/auth.json` via `grok login`), or grok.com cookies you provide; tokens refresh via auth.x.ai; plus local `~/.grok/sessions` logs for tokens / cache / effort / projects / API-equivalent $ (`costUsdTicks`) | grok.com, auth.x.ai |
 | Other providers | A local session or token on this PC, or the provider's own usage endpoint | The provider's own domain only |
 
 ## Network policy

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -20,8 +20,8 @@ Ceiling is a local-first Windows companion for AI-subscription capacity. First-c
 - Concurrent multi-account for Codex/Claude (and other multi-seat providers): cache and UI keyed by `(provider, account)`, not switch-active-only.
 - Compact taskbar-adjacent floating bar **and** native taskbar strip widget, plus tray/dashboard views.
 - Taskbar strip can pin which account drives a multi-account provider tile; flyout marks that seat **On strip**.
-- Grok: SuperGrok weekly pool meter, plan detection from `~/.grok/auth.json` / cookies, local session token analytics on Charts (cache mix, reasoning/effort, projects).
-- Persistent local quota history and processed-token summaries from local logs (Codex/Claude dollars; Grok tokens; unpriced models stay excluded from $ totals with coverage disclosure).
+- Grok: SuperGrok weekly pool meter, plan detection from `~/.grok/auth.json` / cookies, local session analytics on Charts (tokens, cache mix, reasoning/effort, projects, API-equivalent $ from `costUsdTicks`).
+- Persistent local quota history and processed-token summaries from local logs (Codex/Claude dollars; Grok API-equivalent $ from session ticks when present; unpriced/partial rows stay excluded from $ totals with coverage disclosure).
 - Credential discovery and setup paths for the focused providers.
 - A persistent capacity-event observer keyed by provider, account, source, and semantic window identity (including resets that happened while closed).
 - Startup re-baselining, confirmation for surprising changes, alert de-duplication, and a toast burst circuit breaker.

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -1,4 +1,7 @@
-//! Local cost-usage scanner for Codex, Claude, and Grok Build
+//! Local cost-usage scanner for Codex, Claude, and Grok Build.
+//!
+//! Grok dollars come from session `costUsdTicks` (API-equivalent), not a
+//! fabricated SuperGrok rate card.
 //!
 //! Scans local JSONL log files to aggregate token usage and calculate costs
 
@@ -1496,22 +1499,32 @@ fn scan_codex_report(
 }
 
 fn add_grok_record_to_summary(summary: &mut CostSummary, record: &GrokUsageRecord) {
-    // No public SuperGrok API rate card — keep dollars unset, still track tokens.
+    // Prefer Grok's logged costUsdTicks (API-equivalent $). Partial / bare
+    // fallback rows have no ticks and stay unpriced — never invent a rate.
     if record.partial {
-        // Grok omitted the full usage block; totals may under-count main-agent
-        // work. Keep the model marked unknown so charts never invent a price.
         tracing::trace!(
             model = %record.model,
             project = ?record.project,
             "Grok local usage row is partial (fallback telemetry)"
         );
     }
-    summary.unknown_models.insert(record.model.clone());
+
     summary.input_tokens += record.input;
     summary.output_tokens += record.output;
     summary.cached_tokens += record.cache_read;
     summary.cache_read_tokens += record.cache_read;
     summary.reasoning_tokens += record.reasoning;
+
+    // modelCalls when present; else one call per usage row with tokens so
+    // cost-per-call averages stay defined for older logs.
+    let calls = if record.model_calls > 0 {
+        record.model_calls
+    } else if record.input > 0 || record.output > 0 || record.cache_read > 0 || record.reasoning > 0
+    {
+        1
+    } else {
+        0
+    };
 
     let model_tokens = summary
         .by_model_tokens
@@ -1521,7 +1534,7 @@ fn add_grok_record_to_summary(summary: &mut CostSummary, record: &GrokUsageRecor
     model_tokens.output_tokens += record.output;
     model_tokens.cached_tokens += record.cache_read;
     model_tokens.cache_read_tokens += record.cache_read;
-    model_tokens.calls += 1;
+    model_tokens.calls += calls;
 
     let effort = match record
         .effort
@@ -1532,20 +1545,33 @@ fn add_grok_record_to_summary(summary: &mut CostSummary, record: &GrokUsageRecor
         Some(effort) => effort.to_ascii_lowercase(),
         None => "unknown".to_string(),
     };
-    let effort_tokens = summary.by_effort_tokens.entry(effort).or_default();
+    let effort_tokens = summary.by_effort_tokens.entry(effort.clone()).or_default();
     effort_tokens.input_tokens += record.input;
     effort_tokens.output_tokens += record.output;
     effort_tokens.cached_tokens += record.cache_read;
     effort_tokens.cache_read_tokens += record.cache_read;
-    effort_tokens.calls += 1;
+    effort_tokens.calls += calls;
 
     let project = project_bucket(record.project.as_deref());
-    let project_tokens = summary.by_project_tokens.entry(project).or_default();
+    let project_tokens = summary
+        .by_project_tokens
+        .entry(project.clone())
+        .or_default();
     project_tokens.input_tokens += record.input;
     project_tokens.output_tokens += record.output;
     project_tokens.cached_tokens += record.cache_read;
     project_tokens.cache_read_tokens += record.cache_read;
-    project_tokens.calls += 1;
+    project_tokens.calls += calls;
+
+    if let Some(cost) = record.cost_usd.filter(|c| *c > 0.0) {
+        summary.total_cost_usd += cost;
+        *summary.by_model.entry(record.model.clone()).or_insert(0.0) += cost;
+        *summary.by_effort.entry(effort).or_insert(0.0) += cost;
+        *summary.by_project.entry(project).or_insert(0.0) += cost;
+    } else {
+        // No ticks (or partial fallback): tokens still count toward coverage.
+        summary.unknown_models.insert(record.model.clone());
+    }
 }
 
 fn scan_grok_report(
@@ -2401,8 +2427,9 @@ mod tests {
         let now = Utc::now();
         let ts = now.timestamp() as f64;
         let ms = now.timestamp_millis();
+        // 5_912_850_000 ticks = $0.591285
         let updates = format!(
-            r#"{{"timestamp":{ts},"method":"_x.ai/session/update","params":{{"sessionId":"s1","_meta":{{"eventId":"e1","agentTimestampMs":{ms}}},"update":{{"sessionUpdate":"turn_completed","prompt_id":"p1","usage":{{"inputTokens":1000,"outputTokens":100,"cachedReadTokens":800,"reasoningTokens":40,"modelUsage":{{"grok-4.5-build":{{"inputTokens":1000,"outputTokens":100,"cachedReadTokens":800,"reasoningTokens":40}}}}}}}}}}}}"#
+            r#"{{"timestamp":{ts},"method":"_x.ai/session/update","params":{{"sessionId":"s1","_meta":{{"eventId":"e1","agentTimestampMs":{ms}}},"update":{{"sessionUpdate":"turn_completed","prompt_id":"p1","usage":{{"inputTokens":1000,"outputTokens":100,"cachedReadTokens":800,"reasoningTokens":40,"modelCalls":17,"costUsdTicks":5912850000,"modelUsage":{{"grok-4.5-build":{{"inputTokens":1000,"outputTokens":100,"cachedReadTokens":800,"reasoningTokens":40,"modelCalls":17,"costUsdTicks":5912850000}}}}}}}}}}}}"#
         );
         std::fs::write(session.join("updates.jsonl"), updates).unwrap();
         std::fs::write(
@@ -2436,9 +2463,63 @@ mod tests {
                 .by_model_tokens
                 .contains_key("grok-4.5-build")
         );
-        assert_eq!(report.thirty_days.total_cost_usd, 0.0);
+        assert!(
+            (report.thirty_days.total_cost_usd - 0.591285).abs() < 1e-9,
+            "expected API-equivalent $ from costUsdTicks, got {}",
+            report.thirty_days.total_cost_usd
+        );
+        assert!(
+            !report.thirty_days.unknown_models.contains("grok-4.5-build"),
+            "priced Grok rows must not count as unpriced coverage"
+        );
+        assert!((report.thirty_days.by_model["grok-4.5-build"] - 0.591285).abs() < 1e-9);
+        assert!((report.thirty_days.by_effort["high"] - 0.591285).abs() < 1e-9);
+        assert!((report.thirty_days.by_project["ceiling"] - 0.591285).abs() < 1e-9);
+        assert_eq!(
+            report.thirty_days.by_model_tokens["grok-4.5-build"].calls,
+            17
+        );
         let normalized = report.thirty_days.normalized_tokens("grok");
         assert_eq!(normalized.fresh_input_tokens, 200);
         assert_eq!(normalized.cache_read_tokens, 800);
+
+        // Same GROK_HOME: partial session without ticks must not invent dollars
+        // and must keep those tokens in the unpriced coverage set.
+        let partial = home
+            .path()
+            .join("sessions")
+            .join("proj")
+            .join("019f-partial");
+        std::fs::create_dir_all(&partial).unwrap();
+        let bare = format!(
+            r#"{{"timestamp":{ts},"method":"_x.ai/session/update","params":{{"sessionId":"s2","_meta":{{"eventId":"bare","agentTimestampMs":{ms}}},"update":{{"sessionUpdate":"turn_completed","prompt_id":"p2","stop_reason":"end_turn"}}}}}}
+{{"timestamp":{ts},"method":"_x.ai/session/update","params":{{"sessionId":"s2","_meta":{{"eventId":"sa","agentTimestampMs":{ms}}},"update":{{"sessionUpdate":"subagent_finished","subagent_id":"c1","tokens_used":50000,"status":"ok"}}}}}}
+"#
+        );
+        std::fs::write(partial.join("updates.jsonl"), bare).unwrap();
+        std::fs::write(
+            partial.join("summary.json"),
+            r#"{"info":{"cwd":"C:\\projects\\personal\\toolport"},"current_model_id":"grok-4.5"}"#,
+        )
+        .unwrap();
+
+        // SAFETY: same test-only GROK_HOME isolation as above.
+        let prev = std::env::var_os("GROK_HOME");
+        unsafe {
+            std::env::set_var("GROK_HOME", home.path());
+        }
+        let mixed = scan_grok_report(&CostScanner::new(7), 7, &[]);
+        match prev {
+            Some(value) => unsafe { std::env::set_var("GROK_HOME", value) },
+            None => unsafe { std::env::remove_var("GROK_HOME") },
+        }
+
+        assert_eq!(mixed.thirty_days.input_tokens, 51_000);
+        // Only the priced turn contributes dollars.
+        assert!((mixed.thirty_days.total_cost_usd - 0.591285).abs() < 1e-9);
+        // Partial model id from summary is unpriced.
+        assert!(mixed.thirty_days.unknown_models.contains("grok-4.5"));
+        // Priced model remains priced / not unknown.
+        assert!(!mixed.thirty_days.unknown_models.contains("grok-4.5-build"));
     }
 }

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -1568,8 +1568,12 @@ fn add_grok_record_to_summary(summary: &mut CostSummary, record: &GrokUsageRecor
         *summary.by_model.entry(record.model.clone()).or_insert(0.0) += cost;
         *summary.by_effort.entry(effort).or_insert(0.0) += cost;
         *summary.by_project.entry(project).or_insert(0.0) += cost;
-    } else {
+        // A later priced row for the same model clears any earlier unpriced flag
+        // so coverage does not treat the whole model as unpriced when ticks exist.
+        summary.unknown_models.remove(&record.model);
+    } else if !summary.by_model.contains_key(&record.model) {
         // No ticks (or partial fallback): tokens still count toward coverage.
+        // Skip if this model already has logged dollars from another row.
         summary.unknown_models.insert(record.model.clone());
     }
 }

--- a/rust/src/grok_costs.rs
+++ b/rust/src/grok_costs.rs
@@ -376,10 +376,12 @@ fn records_from_turn_completed(
         return model_usage
             .iter()
             .map(|(model, counts)| {
-                let cost_usd = cost_usd_from_ticks(counts.cost_usd_ticks).or_else(|| {
-                    // Live logs put ticks on both levels for a single model;
-                    // fall back to the top-level total when the model row omits it.
-                    if single_model { top_level_cost } else { None }
+                // Live logs put ticks on both levels for a single model;
+                // fall back to the top-level total when the model row omits it.
+                let cost_usd = cost_usd_from_ticks(counts.cost_usd_ticks).or(if single_model {
+                    top_level_cost
+                } else {
+                    None
                 });
                 let model_calls = counts
                     .model_calls

--- a/rust/src/grok_costs.rs
+++ b/rust/src/grok_costs.rs
@@ -1,9 +1,12 @@
 //! Local Grok Build session usage scanner.
 //!
 //! Reads `~/.grok/sessions/<project>/<session-id>/updates.jsonl` turn_completed
-//! records (plus sibling `summary.json` for project + reasoning effort). Grok
-//! does not publish per-token API rates for SuperGrok pool usage, so costs stay
-//! unpriced; token / cache / effort / project rollups still feed charts.
+//! records (plus sibling `summary.json` for project + reasoning effort).
+//!
+//! When present, `usage.costUsdTicks` is Grok's API-equivalent dollar estimate
+//! (same figure `/usage` shows). Scale: USD = ticks / 10^10. SuperGrok weekly
+//! pool % is still a separate subscription meter — these dollars are not cash
+//! billed against the pool. Rows without ticks stay unpriced.
 
 use chrono::{DateTime, TimeZone, Utc};
 use serde::Deserialize;
@@ -12,6 +15,15 @@ use std::collections::HashSet;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
+
+/// Grok logs store USD cost as integer ticks: `usd = ticks / COST_USD_TICKS_PER_DOLLAR`.
+pub const COST_USD_TICKS_PER_DOLLAR: u64 = 10_000_000_000;
+
+/// Convert Grok `costUsdTicks` to USD. Returns `None` when ticks are zero/absent.
+pub fn cost_usd_from_ticks(ticks: Option<u64>) -> Option<f64> {
+    let ticks = ticks.filter(|t| *t > 0)?;
+    Some(ticks as f64 / COST_USD_TICKS_PER_DOLLAR as f64)
+}
 
 /// One turn-level usage row from a Grok session log.
 #[derive(Debug, Clone)]
@@ -24,6 +36,10 @@ pub struct GrokUsageRecord {
     pub output: u64,
     pub cache_read: u64,
     pub reasoning: u64,
+    /// API-equivalent USD from `costUsdTicks` when the log provides it.
+    pub cost_usd: Option<f64>,
+    /// Provider `modelCalls` for this row (0 when unknown / partial).
+    pub model_calls: u64,
     pub dedup_key: Option<String>,
     /// True when tokens came from a fallback signal (e.g. subagent_finished)
     /// because turn_completed omitted the full usage block.
@@ -285,6 +301,8 @@ pub fn parse_grok_updates_file(
             output: 0,
             cache_read: 0,
             reasoning: 0,
+            cost_usd: None,
+            model_calls: 0,
             dedup_key: dedup,
             partial: true,
         }];
@@ -307,6 +325,8 @@ pub fn parse_grok_updates_file(
             output: 0,
             cache_read: 0,
             reasoning: 0,
+            cost_usd: None,
+            model_calls: 0,
             dedup_key,
             partial: true,
         })
@@ -350,21 +370,53 @@ fn records_from_turn_completed(
     if let Some(model_usage) = usage.model_usage.as_ref()
         && !model_usage.is_empty()
     {
+        let single_model = model_usage.len() == 1;
+        let top_level_cost = cost_usd_from_ticks(usage.cost_usd_ticks);
+        let top_level_calls = usage.model_calls.unwrap_or(0);
         return model_usage
             .iter()
-            .map(|(model, counts)| GrokUsageRecord {
-                timestamp,
-                model: model.clone(),
-                effort: effort.clone(),
-                project: project.clone(),
-                input: counts.input_tokens.unwrap_or(0),
-                output: counts.output_tokens.unwrap_or(0),
-                cache_read: counts.cached_read_tokens.unwrap_or(0),
-                reasoning: counts.reasoning_tokens.unwrap_or(0),
-                dedup_key: dedup_key.as_ref().map(|key| format!("{key}:{model}")),
-                partial: false,
+            .map(|(model, counts)| {
+                let cost_usd = cost_usd_from_ticks(counts.cost_usd_ticks).or_else(|| {
+                    // Live logs put ticks on both levels for a single model;
+                    // fall back to the top-level total when the model row omits it.
+                    if single_model { top_level_cost } else { None }
+                });
+                let model_calls = counts
+                    .model_calls
+                    .or(if single_model {
+                        usage.model_calls
+                    } else {
+                        None
+                    })
+                    .unwrap_or(0);
+                GrokUsageRecord {
+                    timestamp,
+                    model: model.clone(),
+                    effort: effort.clone(),
+                    project: project.clone(),
+                    input: counts.input_tokens.unwrap_or(0),
+                    output: counts.output_tokens.unwrap_or(0),
+                    cache_read: counts.cached_read_tokens.unwrap_or(0),
+                    reasoning: counts.reasoning_tokens.unwrap_or(0),
+                    cost_usd,
+                    model_calls: if model_calls > 0 {
+                        model_calls
+                    } else if single_model {
+                        top_level_calls
+                    } else {
+                        0
+                    },
+                    dedup_key: dedup_key.as_ref().map(|key| format!("{key}:{model}")),
+                    partial: false,
+                }
             })
-            .filter(|r| r.input > 0 || r.output > 0 || r.cache_read > 0 || r.reasoning > 0)
+            .filter(|r| {
+                r.input > 0
+                    || r.output > 0
+                    || r.cache_read > 0
+                    || r.reasoning > 0
+                    || r.cost_usd.is_some()
+            })
             .collect();
     }
 
@@ -377,10 +429,17 @@ fn records_from_turn_completed(
         output: usage.output_tokens.unwrap_or(0),
         cache_read: usage.cached_read_tokens.unwrap_or(0),
         reasoning: usage.reasoning_tokens.unwrap_or(0),
+        cost_usd: cost_usd_from_ticks(usage.cost_usd_ticks),
+        model_calls: usage.model_calls.unwrap_or(0),
         dedup_key,
         partial: false,
     };
-    if record.input > 0 || record.output > 0 || record.cache_read > 0 || record.reasoning > 0 {
+    if record.input > 0
+        || record.output > 0
+        || record.cache_read > 0
+        || record.reasoning > 0
+        || record.cost_usd.is_some()
+    {
         vec![record]
     } else {
         Vec::new()
@@ -485,6 +544,11 @@ struct GrokUsageBlock {
     cached_read_tokens: Option<u64>,
     #[serde(default, rename = "reasoningTokens")]
     reasoning_tokens: Option<u64>,
+    /// API-equivalent USD × 10^10 (same units `/usage` displays as Cost).
+    #[serde(default, rename = "costUsdTicks")]
+    cost_usd_ticks: Option<u64>,
+    #[serde(default, rename = "modelCalls")]
+    model_calls: Option<u64>,
     #[serde(default, rename = "modelUsage")]
     model_usage: Option<std::collections::HashMap<String, GrokModelUsageCounts>>,
 }
@@ -499,6 +563,10 @@ struct GrokModelUsageCounts {
     cached_read_tokens: Option<u64>,
     #[serde(default, rename = "reasoningTokens")]
     reasoning_tokens: Option<u64>,
+    #[serde(default, rename = "costUsdTicks")]
+    cost_usd_ticks: Option<u64>,
+    #[serde(default, rename = "modelCalls")]
+    model_calls: Option<u64>,
 }
 
 #[cfg(test)]
@@ -523,8 +591,9 @@ mod tests {
             .unwrap()
             .timestamp() as f64;
         let ms = (ts * 1000.0) as i64;
+        // 591284544000 ticks = $59.1284544 (matches live /usage scale).
         let updates = format!(
-            r#"{{"timestamp":{ts},"method":"_x.ai/session/update","params":{{"sessionId":"s1","_meta":{{"eventId":"e1","agentTimestampMs":{ms}}},"update":{{"sessionUpdate":"turn_completed","prompt_id":"p1","usage":{{"inputTokens":1000,"outputTokens":100,"totalTokens":1100,"cachedReadTokens":800,"reasoningTokens":40,"modelUsage":{{"grok-4.5-build":{{"inputTokens":1000,"outputTokens":100,"cachedReadTokens":800,"reasoningTokens":40}}}}}}}}}}}}"#
+            r#"{{"timestamp":{ts},"method":"_x.ai/session/update","params":{{"sessionId":"s1","_meta":{{"eventId":"e1","agentTimestampMs":{ms}}},"update":{{"sessionUpdate":"turn_completed","prompt_id":"p1","usage":{{"inputTokens":1000,"outputTokens":100,"totalTokens":1100,"cachedReadTokens":800,"reasoningTokens":40,"modelCalls":17,"costUsdTicks":5912850000,"modelUsage":{{"grok-4.5-build":{{"inputTokens":1000,"outputTokens":100,"cachedReadTokens":800,"reasoningTokens":40,"modelCalls":17,"costUsdTicks":5912850000}}}}}}}}}}}}"#
         );
         let summary = r#"{
           "info": {"id": "s1", "cwd": "C:\\projects\\personal\\ceiling"},
@@ -546,9 +615,21 @@ mod tests {
         assert_eq!(r.output, 100);
         assert_eq!(r.cache_read, 800);
         assert_eq!(r.reasoning, 40);
+        assert_eq!(r.model_calls, 17);
         assert_eq!(r.effort.as_deref(), Some("high"));
         assert_eq!(r.project.as_deref(), Some("ceiling"));
         assert!(!r.partial);
+        let cost = r.cost_usd.expect("costUsdTicks should price the row");
+        assert!((cost - 0.591285).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cost_usd_from_ticks_matches_usage_scale() {
+        // Live toolport session: sum(costUsdTicks) / 1e10 == $59.1285
+        assert_eq!(cost_usd_from_ticks(None), None);
+        assert_eq!(cost_usd_from_ticks(Some(0)), None);
+        let cost = cost_usd_from_ticks(Some(591_285_440_000)).unwrap();
+        assert!((cost - 59.128544).abs() < 1e-9);
     }
 
     #[test]
@@ -563,6 +644,8 @@ mod tests {
             output: 1,
             cache_read: 0,
             reasoning: 0,
+            cost_usd: Some(0.01),
+            model_calls: 1,
             dedup_key: Some("e1:grok-4.5-build".into()),
             partial: false,
         };

--- a/rust/src/locale/en-US.ftl
+++ b/rust/src/locale/en-US.ftl
@@ -610,7 +610,7 @@ DataSourceCodex = Uses the OAuth token from your Codex CLI (~/.codex) plus local
 DataSourceCursor = Uses your signed-in Cursor IDE session, or cursor.com cookies you provide. Talks only to cursor.com.
 DataSourceCopilot = Uses your GitHub CLI or Git Credential Manager token, or a device-flow sign-in. Talks only to api.github.com, or your configured GitHub Enterprise host.
 DataSourceGemini = Reads the OAuth token from the Gemini CLI (~/.gemini). Talks only to Google's Code Assist and OAuth endpoints.
-DataSourceGrok = Uses ~/.grok/auth.json from `grok login` (Grok Build / SuperGrok), or grok.com browser cookies you provide. Talks only to grok.com and auth.x.ai. Weekly pool percent is sampled into local charts. Local Grok Build sessions under ~/.grok/sessions supply token, cache, reasoning, project, and API-equivalent dollar breakdowns (from session costUsdTicks — not SuperGrok pool billing).
+DataSourceGrok = Uses ~/.grok/auth.json from `grok login` (Grok Build / SuperGrok), or grok.com browser cookies you provide. Talks only to grok.com and auth.x.ai. Weekly pool percent is sampled into local charts. Local Grok Build sessions under ~/.grok/sessions supply token, cache, reasoning, project, and API-equivalent dollar breakdowns (from session costUsdTicks, not SuperGrok pool billing).
 DataSourceGeneric = Reads this provider's usage from a local session or token on this PC, or by calling the provider's own usage endpoint. Your credentials are stored only on this PC and are never sent to Ceiling-operated servers; usage requests go only to that provider (or, for Wayfinder, your configured gateway).
 
 # First-run checklist (SOU-157)

--- a/rust/src/locale/en-US.ftl
+++ b/rust/src/locale/en-US.ftl
@@ -481,7 +481,7 @@ PanelThirtyDayCostHistogram = 30 day cost histogram
 PanelTopModelPrefix = Top model
 PanelEstimatedFromLocalLogs = API-equivalent estimate from local logs; not subscription spend
 PanelEstimatedFromLocalLogsClaude = API-equivalent estimate from local Claude logs; not subscription spend
-PanelEstimatedFromLocalLogsGrok = Tokens from local Grok Build sessions (~/.grok/sessions). Some Grok sessions omit per-turn usage; those projects may show partial totals (subagent tokens only) or activity with 0 tokens. SuperGrok pool usage is not a dollar bill.
+PanelEstimatedFromLocalLogsGrok = API-equivalent estimate from local Grok Build sessions (~/.grok/sessions), same Cost figure as `/usage`. Not SuperGrok subscription spend. Some sessions omit per-turn usage; those projects may show partial token totals only.
 PanelExpected = Expected
 PanelActual = Actual
 PanelUsedSuffix = used
@@ -610,7 +610,7 @@ DataSourceCodex = Uses the OAuth token from your Codex CLI (~/.codex) plus local
 DataSourceCursor = Uses your signed-in Cursor IDE session, or cursor.com cookies you provide. Talks only to cursor.com.
 DataSourceCopilot = Uses your GitHub CLI or Git Credential Manager token, or a device-flow sign-in. Talks only to api.github.com, or your configured GitHub Enterprise host.
 DataSourceGemini = Reads the OAuth token from the Gemini CLI (~/.gemini). Talks only to Google's Code Assist and OAuth endpoints.
-DataSourceGrok = Uses ~/.grok/auth.json from `grok login` (Grok Build / SuperGrok), or grok.com browser cookies you provide. Talks only to grok.com and auth.x.ai. Weekly pool percent is sampled into local charts. Local Grok Build sessions under ~/.grok/sessions supply token, cache, reasoning, and project breakdowns (no public API-dollar rate for SuperGrok pool usage).
+DataSourceGrok = Uses ~/.grok/auth.json from `grok login` (Grok Build / SuperGrok), or grok.com browser cookies you provide. Talks only to grok.com and auth.x.ai. Weekly pool percent is sampled into local charts. Local Grok Build sessions under ~/.grok/sessions supply token, cache, reasoning, project, and API-equivalent dollar breakdowns (from session costUsdTicks — not SuperGrok pool billing).
 DataSourceGeneric = Reads this provider's usage from a local session or token on this PC, or by calling the provider's own usage endpoint. Your credentials are stored only on this PC and are never sent to Ceiling-operated servers; usage requests go only to that provider (or, for Wayfinder, your configured gateway).
 
 # First-run checklist (SOU-157)


### PR DESCRIPTION
## Summary
- Read Grok Build `/usage` API-equivalent dollars from local `~/.grok/sessions/**/updates.jsonl` (`costUsdTicks` / 1e10).
- Roll dollars into Grok Charts (daily / model / effort / project) and the Estimated API value card.
- Partial sessions without ticks stay unpriced with coverage disclosure.

## Review notes
- Scale verified against a live session: sum(costUsdTicks)/1e10 == `$59.1285` from `/usage`.
- Per-turn (not cumulative) usage; live audit found cost on all full usage turns.
- SuperGrok weekly pool % is unchanged; dollars are rate-card equivalent, not subscription bill.

## Test plan
- [x] `cargo test --manifest-path rust/Cargo.toml grok`
- [x] `cargo clippy` shared + desktop `-D warnings`
- [ ] CI green
- [ ] Manual: open Charts → Grok shows non-zero $ when local sessions exist; Estimated API value includes Grok slice