### PR TITLE
Fix Claude Pro plan label and the wrong "On strip" badge

### DIFF
--- a/apps/desktop-tauri/src/floatbar/FloatBar.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.tsx
@@ -558,7 +558,9 @@ export default function FloatBar({ state }: { state: BootstrapState }) {
           floatBarWindow(b).window.usedPercent -
           floatBarWindow(a).window.usedPercent;
         if (delta !== 0) return delta;
-        return (b.accountId ?? "").localeCompare(a.accountId ?? "");
+        // Lowest account id, matching the native strip and the flyout so all
+        // three name the same seat when two accounts read the same pressure.
+        return (a.accountId ?? "").localeCompare(b.accountId ?? "");
       })[0];
     };
     if (filterIds && filterIds.length > 0) {

--- a/apps/desktop-tauri/src/floatbar/FloatBar.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.tsx
@@ -41,6 +41,7 @@ import {
   type CapacityFreshness,
   type ConstrainingWindow,
 } from "../lib/capacityPresentation";
+import { compareAccountIds } from "../lib/providerRow";
 import type { FloatBarInformationMode } from "../types/bridge";
 import "./FloatBar.css";
 
@@ -560,7 +561,7 @@ export default function FloatBar({ state }: { state: BootstrapState }) {
         if (delta !== 0) return delta;
         // Lowest account id, matching the native strip and the flyout so all
         // three name the same seat when two accounts read the same pressure.
-        return (a.accountId ?? "").localeCompare(b.accountId ?? "");
+        return compareAccountIds(a.accountId, b.accountId);
       })[0];
     };
     if (filterIds && filterIds.length > 0) {

--- a/apps/desktop-tauri/src/lib/providerRow.test.ts
+++ b/apps/desktop-tauri/src/lib/providerRow.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ProviderUsageSnapshot } from "../types/bridge";
 import {
+  compareAccountIds,
   hasMultipleAccounts,
   orderFlyoutProviders,
   representativeForProvider,
@@ -149,6 +150,27 @@ describe("selectStripAccount", () => {
 
     expect(selectStripAccount(forward)?.accountId).toBe("a");
     expect(selectStripAccount(reversed)?.accountId).toBe("a");
+  });
+
+  it("breaks ties by byte order, so mixed case matches the native strip", () => {
+    // Rust compares account ids as bytes, where "B" sorts before "a".
+    // `localeCompare` reverses that, which would badge a different seat than
+    // the tile shows.
+    const rows = [snap("codex", "apex", 50), snap("codex", "Beta", 50)];
+    expect(selectStripAccount(rows)?.accountId).toBe("Beta");
+  });
+});
+
+describe("compareAccountIds", () => {
+  it("orders by code unit, not locale collation", () => {
+    expect(compareAccountIds("Beta", "apex")).toBeLessThan(0);
+    expect(compareAccountIds("apex", "Beta")).toBeGreaterThan(0);
+    expect(compareAccountIds("same", "same")).toBe(0);
+  });
+
+  it("treats a missing id as empty, so it sorts first", () => {
+    expect(compareAccountIds(null, "a")).toBeLessThan(0);
+    expect(compareAccountIds(undefined, null)).toBe(0);
   });
 });
 

--- a/apps/desktop-tauri/src/lib/providerRow.test.ts
+++ b/apps/desktop-tauri/src/lib/providerRow.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { ProviderUsageSnapshot } from "../types/bridge";
 import {
   hasMultipleAccounts,
   orderFlyoutProviders,
@@ -12,11 +13,20 @@ import {
 const row = (providerId: string, accountId?: string) =>
   ({ providerId, accountId: accountId ?? null }) as never;
 
-const snap = (providerId: string, accountId: string | null, used: number) => ({
-  providerId,
-  accountId,
-  primary: { usedPercent: used },
-});
+const snap = (
+  providerId: string,
+  accountId: string | null,
+  used: number,
+  // Second lane, e.g. Claude's weekly beside its 5h session.
+  secondaryUsed?: number,
+) =>
+  ({
+    providerId,
+    accountId,
+    primary: { usedPercent: used },
+    secondary:
+      secondaryUsed === undefined ? null : { usedPercent: secondaryUsed },
+  }) as unknown as ProviderUsageSnapshot;
 
 describe("providerRowKey", () => {
   it("separates two accounts on one provider", () => {
@@ -120,6 +130,25 @@ describe("selectStripAccount", () => {
       snap("codex", "work", 80),
     ];
     expect(selectStripAccount(rows, "gone")?.accountId).toBe("work");
+  });
+
+  it("ranks on the constraining window, not the primary one", () => {
+    // The strip tile shows the constraining window, so ranking seats by their
+    // primary made the flyout badge "On strip" the account the tile was not
+    // showing: a maxed weekly outranks a freshly reset 5h session.
+    const rows = [
+      snap("claude", "maxed-weekly", 0, 100),
+      snap("claude", "busy-session", 40, 0),
+    ];
+    expect(selectStripAccount(rows)?.accountId).toBe("maxed-weekly");
+  });
+
+  it("breaks ties on the lowest account id, as the native strip does", () => {
+    const forward = [snap("codex", "a", 50), snap("codex", "z", 50)];
+    const reversed = [snap("codex", "z", 50), snap("codex", "a", 50)];
+
+    expect(selectStripAccount(forward)?.accountId).toBe("a");
+    expect(selectStripAccount(reversed)?.accountId).toBe("a");
   });
 });
 

--- a/apps/desktop-tauri/src/lib/providerRow.ts
+++ b/apps/desktop-tauri/src/lib/providerRow.ts
@@ -114,6 +114,24 @@ function stripHeat(provider: Pick<ProviderUsageSnapshot, "primary">): number {
 }
 
 /**
+ * Account-id order, matching Rust's `String: Ord` so the strip tie-break lands
+ * on the same seat as the native one.
+ *
+ * Deliberately not `localeCompare`: collation sorts "a" before "B" where a byte
+ * comparison does the reverse, so a mixed-case id could tie-break one way in
+ * the flyout and the other way on the tile.
+ */
+export function compareAccountIds(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): number {
+  const left = a ?? "";
+  const right = b ?? "";
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
+
+/**
  * Which account the compact taskbar/float strip should show for a provider.
  *
  * Matches the native strip: an explicit pin wins when that account is present,
@@ -134,7 +152,7 @@ export function selectStripAccount<T extends ProviderUsageSnapshot>(
   return [...candidates].sort((a, b) => {
     const delta = stripHeat(b) - stripHeat(a);
     if (delta !== 0) return delta;
-    return (a.accountId ?? "").localeCompare(b.accountId ?? "");
+    return compareAccountIds(a.accountId, b.accountId);
   })[0];
 }
 
@@ -176,7 +194,7 @@ export function orderFlyoutProviders<T extends ProviderUsageSnapshot>(
       .sort((a, b) => {
         const delta = stripHeat(b) - stripHeat(a);
         if (delta !== 0) return delta;
-        return (a.accountId ?? "").localeCompare(b.accountId ?? "");
+        return compareAccountIds(a.accountId, b.accountId);
       });
     result.push(...rest);
   }

--- a/apps/desktop-tauri/src/lib/providerRow.ts
+++ b/apps/desktop-tauri/src/lib/providerRow.ts
@@ -1,3 +1,4 @@
+import { constrainingWindow } from "./capacityPresentation";
 import type { ProviderUsageSnapshot } from "../types/bridge";
 
 /**
@@ -97,16 +98,30 @@ export function representativeForProvider<
 }
 
 /**
+ * How hot an account reads on a one-tile-per-provider strip.
+ *
+ * The strip shows the *constraining* window, so ranking accounts by their
+ * primary window disagreed with it: a Claude seat whose 5h session is fresh but
+ * whose weekly is maxed ranks last on primary and first on the strip. That is
+ * what made the flyout badge "On strip" the wrong account while the tile showed
+ * the right one.
+ *
+ * Mirrors `select_strip_snapshot` in `taskbar_widget.rs`.
+ */
+function stripHeat(provider: Pick<ProviderUsageSnapshot, "primary">): number {
+  if (!provider.primary) return -1;
+  return constrainingWindow(provider as ProviderUsageSnapshot).window.usedPercent;
+}
+
+/**
  * Which account the compact taskbar/float strip should show for a provider.
  *
  * Matches the native strip: an explicit pin wins when that account is present,
- * otherwise the hottest primary window (stable account-id tiebreak).
+ * otherwise the account closest to its constraining limit. Ties resolve on the
+ * lowest account id so the choice is stable between refreshes rather than
+ * flickering with fetch order.
  */
-export function selectStripAccount<
-  T extends Pick<ProviderUsageSnapshot, "accountId"> & {
-    primary?: { usedPercent: number } | null;
-  },
->(
+export function selectStripAccount<T extends ProviderUsageSnapshot>(
   candidates: T[],
   preferredAccountId?: string | null,
 ): T | undefined {
@@ -117,10 +132,9 @@ export function selectStripAccount<
     if (hit) return hit;
   }
   return [...candidates].sort((a, b) => {
-    const delta =
-      (b.primary?.usedPercent ?? -1) - (a.primary?.usedPercent ?? -1);
+    const delta = stripHeat(b) - stripHeat(a);
     if (delta !== 0) return delta;
-    return (b.accountId ?? "").localeCompare(a.accountId ?? "");
+    return (a.accountId ?? "").localeCompare(b.accountId ?? "");
   })[0];
 }
 
@@ -128,11 +142,7 @@ export function selectStripAccount<
  * Flyout list order: strip providers in strip order, and within each multi-
  * account provider put the strip account first so it matches the tile.
  */
-export function orderFlyoutProviders<
-  T extends Pick<ProviderUsageSnapshot, "providerId" | "accountId"> & {
-    primary?: { usedPercent: number } | null;
-  },
->(
+export function orderFlyoutProviders<T extends ProviderUsageSnapshot>(
   providers: T[],
   stripProviderIds: string[],
   pinnedAccounts: Record<string, string>,
@@ -164,8 +174,7 @@ export function orderFlyoutProviders<
     const rest = group
       .filter((row) => providerRowKey(row) !== providerRowKey(strip))
       .sort((a, b) => {
-        const delta =
-          (b.primary?.usedPercent ?? -1) - (a.primary?.usedPercent ?? -1);
+        const delta = stripHeat(b) - stripHeat(a);
         if (delta !== 0) return delta;
         return (a.accountId ?? "").localeCompare(b.accountId ?? "");
       });

--- a/apps/desktop-tauri/src/surfaces/TaskbarFlyout.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/TaskbarFlyout.test.tsx
@@ -150,6 +150,51 @@ describe("TaskbarFlyout", () => {
     expect(accounts[1].textContent).toContain("me@job.test");
   });
 
+  it("badges the seat the strip actually shows, not the hottest session", async () => {
+    // Reported bug: on "auto (closest to limit)" the tile showed the maxed
+    // weekly seat while the flyout badged the other one, because the flyout
+    // ranked accounts on the 5h session and both read 0%.
+    const maxedWeekly = provider("claude", "Claude", 0, 300, "Session (5h)");
+    maxedWeekly.accountId = "acct-work";
+    maxedWeekly.accountEmail = "me@job.test";
+    maxedWeekly.secondary = {
+      ...maxedWeekly.primary,
+      usedPercent: 100,
+      remainingPercent: 0,
+      windowMinutes: 10_080,
+    };
+    maxedWeekly.secondaryLabel = "Weekly";
+    const fresh = provider("claude", "Claude", 0, 295, "Session (5h)");
+    fresh.accountId = "acct-zpersonal";
+    fresh.accountEmail = "me@home.test";
+    fresh.secondary = {
+      ...fresh.primary,
+      usedPercent: 0,
+      remainingPercent: 100,
+      windowMinutes: 10_080,
+    };
+    fresh.secondaryLabel = "Weekly";
+    providerState.providers = [maxedWeekly, fresh];
+    const autoState = {
+      ...state,
+      settings: {
+        ...state.settings,
+        floatBarProviderIds: ["claude"],
+        taskbarAccountByProvider: {},
+      },
+    } as BootstrapState;
+
+    render(<TaskbarFlyout state={autoState} />);
+
+    await screen.findByText("On strip");
+    const accounts = screen.getAllByText(/me@/);
+    expect(accounts[0].textContent).toContain("me@job.test");
+    // The badge sits in the same row as the maxed-weekly seat.
+    const badgedRow = screen.getByText("On strip").closest(".taskbar-flyout__provider");
+    expect(badgedRow?.textContent).toContain("me@job.test");
+    expect(badgedRow?.textContent).not.toContain("me@home.test");
+  });
+
   it("shows at-a-glance usage and the soonest provider reset", async () => {
     providerState.providers[0].resetCreditsAvailable = 1;
     render(<TaskbarFlyout state={state} />);

--- a/rust/src/providers/claude/mod.rs
+++ b/rust/src/providers/claude/mod.rs
@@ -115,20 +115,64 @@ impl UtilizationScale {
 }
 
 fn claude_plan_label(tier: &str) -> String {
+    claude_plan_label_opt(tier).unwrap_or_else(|| claude_plan_label_from_unknown(tier))
+}
+
+/// The plan a rate limit tier names, or `None` when the tier does not name one.
+///
+/// Anthropic bills Pro and Free against the same shared `default_claude_ai`
+/// tier, so that value says "claude.ai limits" and nothing about the plan — it
+/// is not an unrecognised tier to be echoed raw.
+fn claude_plan_label_opt(tier: &str) -> Option<String> {
     let normalized = tier.to_lowercase();
     if normalized.contains("claude_max_5x") || normalized.contains("claude_max_5") {
-        "Claude Max 5x".to_string()
-    } else if normalized.contains("claude_max_20x") || normalized.contains("claude_max_20") {
-        "Claude Max 20x".to_string()
+        return Some("Claude Max 5x".to_string());
+    }
+    if normalized.contains("claude_max_20x") || normalized.contains("claude_max_20") {
+        return Some("Claude Max 20x".to_string());
+    }
+    match normalized.as_str() {
+        "free" | "claude_free" => Some("Claude Free".to_string()),
+        "pro" | "claude_pro" => Some("Claude Pro".to_string()),
+        "max" | "claude_max" => Some("Claude Max".to_string()),
+        "team" | "claude_team" => Some("Claude Team".to_string()),
+        "enterprise" | "claude_enterprise" => Some("Claude Enterprise".to_string()),
+        _ => None,
+    }
+}
+
+/// The plan label for an account, reading the subscription type when the rate
+/// limit tier is not plan-specific.
+///
+/// A $20 Pro seat reports `rateLimitTier: "default_claude_ai"` alongside
+/// `subscriptionType: "pro"`, so tier alone rendered it as the raw
+/// "Claude (default_claude_ai)". The tier still wins when it *is* specific: it
+/// distinguishes Max 5x from Max 20x, which `subscriptionType: "max"` cannot.
+fn claude_plan_label_with_subscription(
+    tier: Option<&str>,
+    subscription_type: Option<&str>,
+) -> Option<String> {
+    let tier = tier.map(str::trim).filter(|value| !value.is_empty());
+    let subscription = subscription_type
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    tier.and_then(claude_plan_label_opt)
+        .or_else(|| subscription.and_then(claude_plan_label_opt))
+        // A tier we have never seen is still worth showing verbatim; a known
+        // non-specific one (`default_claude_ai`) reads better as its brand name.
+        .or_else(|| tier.map(claude_plan_label_from_unknown))
+        .or_else(|| subscription.map(|value| format!("Claude ({})", value)))
+}
+
+/// Label for a tier that named no plan: the claude.ai default reads as the
+/// product, anything genuinely unrecognised is echoed so it can be reported.
+fn claude_plan_label_from_unknown(tier: &str) -> String {
+    let normalized = tier.to_lowercase();
+    if normalized == "default_claude_ai" || normalized == "claude_ai" {
+        "Claude AI".to_string()
     } else {
-        match normalized.as_str() {
-            "free" => "Claude Free".to_string(),
-            "pro" | "claude_pro" => "Claude Pro".to_string(),
-            "max" => "Claude Max".to_string(),
-            "team" => "Claude Team".to_string(),
-            "enterprise" => "Claude Enterprise".to_string(),
-            _ => format!("Claude ({})", tier),
-        }
+        format!("Claude ({})", tier)
     }
 }
 
@@ -971,6 +1015,47 @@ mod tests {
     use chrono::{DateTime, Utc};
 
     use super::*;
+
+    #[test]
+    fn names_a_pro_seat_from_its_subscription_type() {
+        // Pro and Free share `default_claude_ai`, which used to render raw as
+        // "Claude (default_claude_ai)" on every card and the taskbar flyout.
+        assert_eq!(
+            claude_plan_label_with_subscription(Some("default_claude_ai"), Some("pro")).as_deref(),
+            Some("Claude Pro")
+        );
+        assert_eq!(
+            claude_plan_label_with_subscription(Some("default_claude_ai"), Some("free")).as_deref(),
+            Some("Claude Free")
+        );
+    }
+
+    #[test]
+    fn a_specific_tier_outranks_the_subscription_type() {
+        // `subscriptionType: "max"` cannot tell 5x from 20x; the tier can.
+        assert_eq!(
+            claude_plan_label_with_subscription(Some("default_claude_max_20x"), Some("max"))
+                .as_deref(),
+            Some("Claude Max 20x")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_the_brand_name_without_a_subscription_type() {
+        assert_eq!(
+            claude_plan_label_with_subscription(Some("default_claude_ai"), None).as_deref(),
+            Some("Claude AI")
+        );
+        assert_eq!(claude_plan_label_with_subscription(None, None), None);
+    }
+
+    #[test]
+    fn echoes_a_genuinely_unknown_tier() {
+        assert_eq!(
+            claude_plan_label_with_subscription(Some("some_new_tier"), None).as_deref(),
+            Some("Claude (some_new_tier)")
+        );
+    }
 
     #[test]
     fn parses_current_cli_usage_screen() {

--- a/rust/src/providers/claude/oauth/credentials_store.rs
+++ b/rust/src/providers/claude/oauth/credentials_store.rs
@@ -58,6 +58,10 @@ struct OAuthData {
     scopes: Option<Vec<String>>,
     #[serde(rename = "rateLimitTier")]
     rate_limit_tier: Option<String>,
+    /// "pro" / "max" / "free". The only signal that separates a Pro seat from a
+    /// Free one, since both report the same `rateLimitTier`.
+    #[serde(rename = "subscriptionType")]
+    subscription_type: Option<String>,
 }
 
 fn refreshed_cache() -> &'static Mutex<HashMap<CredentialSource, ClaudeOAuthCredentials>> {
@@ -155,6 +159,7 @@ fn load_from_environment() -> Option<ClaudeOAuthCredentials> {
         expires_at: None, // Environment tokens don't expire
         scopes,
         rate_limit_tier: None,
+        subscription_type: None,
     })
 }
 
@@ -304,6 +309,7 @@ fn credentials_from_oauth_data(oauth: OAuthData) -> Result<ClaudeOAuthCredential
         expires_at,
         scopes: oauth.scopes.unwrap_or_default(),
         rate_limit_tier: oauth.rate_limit_tier,
+        subscription_type: oauth.subscription_type,
     })
 }
 
@@ -633,6 +639,25 @@ mod tests {
     }
 
     #[test]
+    fn reads_subscription_type_from_claude_code_credentials() {
+        // A Pro seat shares `default_claude_ai` with Free, so `subscriptionType`
+        // is the only thing that says which plan it is.
+        let credentials = parse_credentials_json(
+            r#"{
+                "claudeAiOauth": {
+                    "accessToken": "token",
+                    "scopes": ["user:profile"],
+                    "rateLimitTier": "default_claude_ai",
+                    "subscriptionType": "pro"
+                }
+            }"#,
+        )
+        .expect("Claude Code credential payload should parse");
+
+        assert_eq!(credentials.subscription_type.as_deref(), Some("pro"));
+    }
+
+    #[test]
     fn parses_direct_oauth_credentials_payload() {
         let credentials = parse_credentials_json(
             r#"{
@@ -687,6 +712,7 @@ mod tests {
             expires_at: chrono::DateTime::from_timestamp(2_000, 0),
             scopes: vec!["user:profile".to_string(), "user:inference".to_string()],
             rate_limit_tier: None,
+            subscription_type: None,
         };
 
         apply_refresh_to_credentials_json(&mut root, &creds).unwrap();
@@ -725,6 +751,7 @@ mod tests {
             expires_at: Some(chrono::Utc::now() + chrono::Duration::hours(1)),
             scopes: vec!["user:profile".to_string()],
             rate_limit_tier: None,
+            subscription_type: None,
         };
         store_refreshed(&file_source, &file_cached_creds);
 
@@ -734,6 +761,7 @@ mod tests {
             expires_at: None,
             scopes: vec!["user:profile".to_string()],
             rate_limit_tier: None,
+            subscription_type: None,
         };
 
         // Looking up under the Environment source must not see the File
@@ -752,6 +780,7 @@ mod tests {
             expires_at: None,
             scopes: vec!["user:profile".to_string()],
             rate_limit_tier: None,
+            subscription_type: None,
         };
         let same_source_result = cached_refreshed_if_fresher(&file_source, &file_disk_creds);
         assert_eq!(

--- a/rust/src/providers/claude/oauth/mod.rs
+++ b/rust/src/providers/claude/oauth/mod.rs
@@ -604,6 +604,24 @@ mod tests {
         assert!((rate.used_percent - 23.0).abs() < f64::EPSILON);
     }
 
+    /// End to end for the reported bug: a Pro seat's credentials must reach the
+    /// snapshot as "Claude Pro", not the raw shared tier.
+    #[test]
+    fn a_pro_seat_reaches_the_snapshot_as_claude_pro() {
+        let response: OAuthUsageResponse =
+            serde_json::from_str(r#"{"five_hour": {"utilization": 0}}"#).expect("response parses");
+
+        let mut credentials = test_credentials();
+        credentials.subscription_type = Some("pro".to_string());
+        let usage = ClaudeOAuthFetcher::new().build_usage_snapshot(&response, &credentials);
+        assert_eq!(usage.login_method.as_deref(), Some("Claude Pro"));
+
+        // Without the subscription type the shared tier still reads as the
+        // product rather than leaking `default_claude_ai` to the UI.
+        let usage = ClaudeOAuthFetcher::new().build_usage_snapshot(&response, &test_credentials());
+        assert_eq!(usage.login_method.as_deref(), Some("Claude AI"));
+    }
+
     /// SOU-286: a freshly reset window reports `1` (1% used). Read per value it
     /// resolved to 100%, which also fired a false "limit reached" notification.
     #[test]

--- a/rust/src/providers/claude/oauth/mod.rs
+++ b/rust/src/providers/claude/oauth/mod.rs
@@ -28,6 +28,11 @@ pub struct ClaudeOAuthCredentials {
     pub expires_at: Option<DateTime<Utc>>,
     pub scopes: Vec<String>,
     pub rate_limit_tier: Option<String>,
+    /// Claude Code's `subscriptionType` ("pro" / "max" / "free"), which names
+    /// the plan when `rate_limit_tier` does not. Same field `ClaudeIdentity`
+    /// reads for account labels, kept here so the plan name is derived from the
+    /// credentials the reading was actually fetched with.
+    pub subscription_type: Option<String>,
 }
 
 impl ClaudeOAuthCredentials {
@@ -178,6 +183,7 @@ impl ClaudeOAuthFetcher {
             expires_at: None,
             scopes: vec!["user:profile".to_string()],
             rate_limit_tier: None,
+            subscription_type: None,
         };
 
         self.fetch_with_credentials(credentials).await
@@ -468,11 +474,15 @@ impl ClaudeOAuthFetcher {
                 ));
         }
 
-        // Login method from rate limit tier or default
-        if let Some(ref tier) = credentials.rate_limit_tier {
-            usage = usage.with_login_method(super::claude_plan_label(tier));
-        } else {
-            usage = usage.with_login_method("Claude (OAuth)");
+        // Plan name from the rate limit tier, falling back to the subscription
+        // type when the tier is shared across plans (Pro and Free both report
+        // `default_claude_ai`).
+        match super::claude_plan_label_with_subscription(
+            credentials.rate_limit_tier.as_deref(),
+            credentials.subscription_type.as_deref(),
+        ) {
+            Some(plan) => usage = usage.with_login_method(plan),
+            None => usage = usage.with_login_method("Claude (OAuth)"),
         }
 
         usage
@@ -562,6 +572,7 @@ mod tests {
             expires_at: None,
             scopes: vec!["user:profile".to_string()],
             rate_limit_tier: Some("default_claude_ai".to_string()),
+            subscription_type: None,
         }
     }
 
@@ -679,6 +690,7 @@ mod tests {
             expires_at: None,
             scopes: vec!["user:profile".to_string()],
             rate_limit_tier: Some("default_claude_ai".to_string()),
+            subscription_type: None,
         };
         let usage = ClaudeOAuthFetcher::new().build_usage_snapshot(&response, &credentials);
 

--- a/rust/src/providers/claude/oauth/refresh.rs
+++ b/rust/src/providers/claude/oauth/refresh.rs
@@ -102,6 +102,7 @@ pub(super) async fn refresh_access_token(
         expires_at,
         scopes,
         rate_limit_tier: current.rate_limit_tier.clone(),
+        subscription_type: current.subscription_type.clone(),
     })
 }
 


### PR DESCRIPTION
Two unrelated bugs from one report: a second Claude account (a $20 Pro seat) showed as `Claude (default_claude_ai)`, and the taskbar flyout badged "On strip" on the account the strip was *not* showing.

## Claude Pro seats rendered as a raw rate limit tier

Anthropic bills Pro and Free against the same `default_claude_ai` tier, so the tier alone never names the plan:

| account | `rateLimitTier` | `subscriptionType` |
|---|---|---|
| Max seat | `default_claude_max_5x` | `max` |
| Pro seat | `default_claude_ai` | `pro` |

`claude_plan_label` only recognised the Max variants and echoed anything else verbatim as `Claude ({tier})`. The frontend had five copies of a `default_claude_ai` → "Claude AI" fallback, but none of them matched — the value arriving was already `Claude (default_claude_ai)`, not the bare tier.

`subscriptionType` is the missing signal, and `ClaudeIdentity` already parsed it for account labels. It is now carried through the OAuth credentials so the plan name can use it: a plan-specific tier still wins (only the tier separates Max 5x from Max 20x), otherwise the subscription type names the plan, otherwise `default_claude_ai` reads as "Claude AI" and a genuinely unknown tier is still echoed so it can be reported.

## Flyout badged the wrong account as "On strip"

Two independent implementations of the same rule had drifted:

- Native strip (`taskbar_widget.rs` `select_strip_snapshot`) ranks accounts by their **constraining** window — the max across session/weekly/model lanes.
- Flyout (`providerRow.ts` `selectStripAccount`) ranked by **`primary.usedPercent` only**, and its account-id tiebreak ran the opposite direction from the native one.

For Claude the primary window is the 5h session. With two seats whose sessions were both freshly reset, the ranking fell straight to the mismatched tiebreak: the tile correctly showed the seat with a maxed weekly, the flyout badged the other one. Pinning an account hid the bug, because an explicit pin short-circuits the ranking in both implementations.

`selectStripAccount` now ranks on `constrainingWindow()` with a lowest-account-id tiebreak, mirroring the native code, and `orderFlyoutProviders` uses the same heat so row order matches the badge. `FloatBar`'s tiebreak is flipped to match so all three surfaces name the same seat.

## Testing

- `cargo test --lib` (rust) — 743 passed
- `cargo test taskbar` (src-tauri) — 41 passed
- `npx vitest run` — 314 passed across 51 files
- `cargo fmt --check`, `cargo clippy`, `tsc --noEmit` — clean

The three new tests were verified to fail against the previous ranking before the fix was restored.

Not included, and worth a separate decision: `representativeForProvider` has the same primary-only ranking despite a docstring saying it picks "the most-constrained account". It drives which account Settings, Charts, the tray and the pop-out summarise — not the strip, so it is outside this bug, but changing it would change what those surfaces show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
