### PR TITLE
fix(cost): match ccusage Codex speed tiers and Claude day windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Codex local cost now matches ccusage speed tiers: `service_tier = "priority"` in `~/.codex/config.toml` prices at the fast (2×) rate, with `codexbar cost --codex-speed auto|standard|fast` and JSON `cost.codex_speed` / `cost.codex_service_tier` for fair A/B compares.
+- Claude local cost `--days N` uses the same inclusive local calendar window as Codex (and ccusage), instead of a rolling UTC duration that labeled N+1 calendar days.
+
 ## [Ceiling] 1.5.12 - 2026-07-26
 
 Patch release for reported Antigravity and multi-account bugs, plus a taskbar strip hygiene fix for providers that are enabled but not yet ready.

--- a/rust/src/cli/cost.rs
+++ b/rust/src/cli/cost.rs
@@ -149,14 +149,14 @@ fn print_text_output(results: &[CostResult], use_color: bool, days: u32) {
 
             // Codex speed tier (ccusage --speed parity) so Reddit/A-B compares
             // can say whether dollars are standard list or priority/fast 2×.
-            if result.provider == "codex" {
-                if let Some(speed) = result.summary.codex_cost_speed.as_deref() {
-                    match result.summary.codex_service_tier.as_deref() {
-                        Some(tier) => {
-                            println!("  Speed:    {} (config service_tier={})", speed, tier)
-                        }
-                        None => println!("  Speed:    {}", speed),
+            if result.provider == "codex"
+                && let Some(speed) = result.summary.codex_cost_speed.as_deref()
+            {
+                match result.summary.codex_service_tier.as_deref() {
+                    Some(tier) => {
+                        println!("  Speed:    {} (config service_tier={})", speed, tier)
                     }
+                    None => println!("  Speed:    {}", speed),
                 }
             }
 

--- a/rust/src/cli/cost.rs
+++ b/rust/src/cli/cost.rs
@@ -34,6 +34,13 @@ pub struct CostArgs {
     /// Number of days to scan (default: 30)
     #[arg(short, long, default_value = "30")]
     pub days: u32,
+
+    /// Codex cost speed tier (ccusage parity): auto | standard | fast.
+    ///
+    /// `auto` (default) reads `service_tier` from `~/.codex/config.toml`.
+    /// `priority` maps to fast (2× list rates), matching `ccusage codex --speed auto`.
+    #[arg(long = "codex-speed", default_value = "auto")]
+    pub codex_speed: String,
 }
 
 /// Run the cost command
@@ -46,13 +53,14 @@ pub async fn run(args: CostArgs) -> anyhow::Result<()> {
 
     let providers = ProviderSelection::from_arg(args.provider.as_deref())?;
     let use_color = !args.no_color && is_terminal();
-    let scanner = CostScanner::new(args.days);
+    let scanner = CostScanner::with_codex_speed(args.days, Some(args.codex_speed.as_str()));
 
     tracing::debug!(
-        "Running cost command: providers={:?}, format={:?}, days={}",
+        "Running cost command: providers={:?}, format={:?}, days={}, codex_speed={:?}",
         providers.as_list(),
         format,
-        args.days
+        args.days,
+        scanner.codex_speed()
     );
 
     // Collect cost data for requested providers
@@ -139,6 +147,19 @@ fn print_text_output(results: &[CostResult], use_color: bool, days: u32) {
                 println!("  Total:    {}", result.summary.format_total());
             }
 
+            // Codex speed tier (ccusage --speed parity) so Reddit/A-B compares
+            // can say whether dollars are standard list or priority/fast 2×.
+            if result.provider == "codex" {
+                if let Some(speed) = result.summary.codex_cost_speed.as_deref() {
+                    match result.summary.codex_service_tier.as_deref() {
+                        Some(tier) => {
+                            println!("  Speed:    {} (config service_tier={})", speed, tier)
+                        }
+                        None => println!("  Speed:    {}", speed),
+                    }
+                }
+            }
+
             // Token breakdown
             println!(
                 "  Tokens:   {} input, {} output, {} cached",
@@ -215,7 +236,9 @@ fn print_json_output(results: &[CostResult], pretty: bool, days: u32) -> anyhow:
                     "days_scanned": days,
                     "cost": {
                         "total_usd": r.summary.total_cost_usd,
-                        "currency": "USD"
+                        "currency": "USD",
+                        "codex_speed": r.summary.codex_cost_speed,
+                        "codex_service_tier": r.summary.codex_service_tier
                     },
                     "tokens": {
                         "input": r.summary.input_tokens,

--- a/rust/src/codex_cost_speed.rs
+++ b/rust/src/codex_cost_speed.rs
@@ -1,0 +1,274 @@
+//! Codex API-equivalent cost speed tier (standard vs fast/priority).
+//!
+//! Matches ccusage's `--speed` behavior:
+//! - `standard` uses list rates
+//! - `fast` multiplies those rates by 2.0 (OpenAI priority / fast tier)
+//! - `auto` reads `service_tier` from `~/.codex/config.toml` (or `$CODEX_HOME`)
+//!
+//! When `service_tier = "priority"`, ccusage auto mode prices at the fast tier.
+//! Ceiling used to always price standard, so totals looked ~half of default
+//! `npx ccusage codex` on priority machines.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Cost speed tier for Codex local-log pricing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CodexCostSpeed {
+    /// List / standard API rates (ccusage `--speed standard`).
+    #[default]
+    Standard,
+    /// Priority / fast tier (ccusage `--speed fast`): 2× standard rates.
+    Fast,
+}
+
+impl CodexCostSpeed {
+    /// Label used in CLI/JSON (`standard` / `fast`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Standard => "standard",
+            Self::Fast => "fast",
+        }
+    }
+
+    /// Multiplier applied to standard list-rate dollars.
+    pub fn multiplier(self) -> f64 {
+        match self {
+            Self::Standard => 1.0,
+            Self::Fast => 2.0,
+        }
+    }
+
+    /// Parse an explicit CLI/UI override (`standard`, `fast`, `priority`).
+    ///
+    /// Returns `None` for `auto` or unrecognized values so callers can fall
+    /// back to config discovery.
+    pub fn parse_override(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "standard" | "default" | "flex" => Some(Self::Standard),
+            "fast" | "priority" => Some(Self::Fast),
+            "auto" | "" => None,
+            _ => None,
+        }
+    }
+
+    /// Map a Codex `service_tier` config value to a cost speed.
+    pub fn from_service_tier(tier: &str) -> Self {
+        match tier.trim().to_ascii_lowercase().as_str() {
+            "priority" | "fast" => Self::Fast,
+            _ => Self::Standard,
+        }
+    }
+
+    /// Resolve like ccusage: explicit override, else config `service_tier`, else standard.
+    pub fn resolve(speed_override: Option<&str>) -> Self {
+        if let Some(raw) = speed_override
+            && let Some(parsed) = Self::parse_override(raw)
+        {
+            return parsed;
+        }
+        Self::from_config_file()
+    }
+
+    /// Read `service_tier` from the active Codex config and map it.
+    pub fn from_config_file() -> Self {
+        match read_codex_service_tier() {
+            Some(tier) => Self::from_service_tier(&tier),
+            None => Self::Standard,
+        }
+    }
+}
+
+/// Raw `service_tier` string from config, when present.
+pub fn read_codex_service_tier() -> Option<String> {
+    let path = codex_config_path()?;
+    let content = fs::read_to_string(path).ok()?;
+    parse_service_tier_from_toml(&content)
+}
+
+fn codex_config_path() -> Option<PathBuf> {
+    if let Ok(home) = std::env::var("CODEX_HOME") {
+        let trimmed = home.trim();
+        if !trimmed.is_empty() {
+            return Some(PathBuf::from(trimmed).join("config.toml"));
+        }
+    }
+    dirs::home_dir().map(|home| home.join(".codex").join("config.toml"))
+}
+
+/// Extract top-level `service_tier = "..."` from Codex config.toml content.
+fn parse_service_tier_from_toml(content: &str) -> Option<String> {
+    // Prefer full TOML parse; fall back to a line scan if the file has
+    // partial/invalid sections we still want to read past.
+    if let Ok(value) = content.parse::<toml::Value>()
+        && let Some(tier) = value.get("service_tier").and_then(|v| v.as_str())
+    {
+        let trimmed = tier.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        // Stop at first table header so we only read root-level keys.
+        if trimmed.starts_with('[') {
+            break;
+        }
+        let Some(rest) = trimmed.strip_prefix("service_tier") else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix('=') else {
+            continue;
+        };
+        let rest = rest.trim();
+        let value = rest
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .or_else(|| rest.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')))
+            .unwrap_or(rest)
+            .trim();
+        if !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+/// Apply the speed multiplier to every dollar field on a cost summary.
+pub fn apply_speed_to_summary(summary: &mut crate::cost_scanner::CostSummary, speed: CodexCostSpeed) {
+    summary.codex_cost_speed = Some(speed.as_str().to_string());
+    if let Some(tier) = read_codex_service_tier() {
+        summary.codex_service_tier = Some(tier);
+    }
+
+    let mult = speed.multiplier();
+    if (mult - 1.0).abs() < f64::EPSILON {
+        return;
+    }
+
+    summary.total_cost_usd *= mult;
+    for cost in summary.by_model.values_mut() {
+        *cost *= mult;
+    }
+    for cost in summary.by_effort.values_mut() {
+        *cost *= mult;
+    }
+    for cost in summary.by_project.values_mut() {
+        *cost *= mult;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_override_accepts_ccusage_names() {
+        assert_eq!(
+            CodexCostSpeed::parse_override("standard"),
+            Some(CodexCostSpeed::Standard)
+        );
+        assert_eq!(
+            CodexCostSpeed::parse_override("fast"),
+            Some(CodexCostSpeed::Fast)
+        );
+        assert_eq!(
+            CodexCostSpeed::parse_override("priority"),
+            Some(CodexCostSpeed::Fast)
+        );
+        assert_eq!(CodexCostSpeed::parse_override("auto"), None);
+    }
+
+    #[test]
+    fn service_tier_priority_maps_to_fast() {
+        assert_eq!(
+            CodexCostSpeed::from_service_tier("priority"),
+            CodexCostSpeed::Fast
+        );
+        assert_eq!(
+            CodexCostSpeed::from_service_tier("standard"),
+            CodexCostSpeed::Standard
+        );
+        assert_eq!(
+            CodexCostSpeed::from_service_tier("flex"),
+            CodexCostSpeed::Standard
+        );
+    }
+
+    #[test]
+    fn fast_multiplier_is_two() {
+        assert!((CodexCostSpeed::Fast.multiplier() - 2.0).abs() < 1e-12);
+        assert!((CodexCostSpeed::Standard.multiplier() - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn parses_service_tier_from_toml() {
+        let content = r#"
+model = "gpt-5.6-sol"
+model_reasoning_effort = "medium"
+service_tier = "priority"
+
+[tui]
+something = true
+"#;
+        assert_eq!(
+            parse_service_tier_from_toml(content).as_deref(),
+            Some("priority")
+        );
+    }
+
+    #[test]
+    fn ignores_service_tier_inside_tables() {
+        let content = r#"
+model = "gpt-5.6-sol"
+
+[experimental]
+service_tier = "priority"
+"#;
+        // Full TOML parse still sees nested keys; only root-level is intended.
+        // Our primary parse reads value.get("service_tier") at root — nested is ignored.
+        assert_eq!(parse_service_tier_from_toml(content), None);
+    }
+
+    #[test]
+    fn line_scan_stops_at_table() {
+        // Invalid TOML that still has a clear root assignment.
+        let content = "service_tier = \"fast\"\n[broken\n";
+        assert_eq!(
+            parse_service_tier_from_toml(content).as_deref(),
+            Some("fast")
+        );
+    }
+
+    #[test]
+    fn resolve_prefers_explicit_override() {
+        assert_eq!(
+            CodexCostSpeed::resolve(Some("standard")),
+            CodexCostSpeed::Standard
+        );
+        assert_eq!(CodexCostSpeed::resolve(Some("fast")), CodexCostSpeed::Fast);
+    }
+
+    #[test]
+    fn apply_speed_doubles_dollar_fields() {
+        use crate::cost_scanner::CostSummary;
+        use std::collections::HashMap;
+
+        let mut summary = CostSummary {
+            total_cost_usd: 10.0,
+            by_model: HashMap::from([("gpt-5.6-sol".into(), 8.0)]),
+            by_effort: HashMap::from([("medium".into(), 10.0)]),
+            by_project: HashMap::from([("ceiling".into(), 10.0)]),
+            ..CostSummary::default()
+        };
+        apply_speed_to_summary(&mut summary, CodexCostSpeed::Fast);
+        assert!((summary.total_cost_usd - 20.0).abs() < 1e-9);
+        assert!((summary.by_model["gpt-5.6-sol"] - 16.0).abs() < 1e-9);
+        assert_eq!(summary.codex_cost_speed.as_deref(), Some("fast"));
+    }
+}

--- a/rust/src/codex_cost_speed.rs
+++ b/rust/src/codex_cost_speed.rs
@@ -140,7 +140,10 @@ fn parse_service_tier_from_toml(content: &str) -> Option<String> {
 }
 
 /// Apply the speed multiplier to every dollar field on a cost summary.
-pub fn apply_speed_to_summary(summary: &mut crate::cost_scanner::CostSummary, speed: CodexCostSpeed) {
+pub fn apply_speed_to_summary(
+    summary: &mut crate::cost_scanner::CostSummary,
+    speed: CodexCostSpeed,
+) {
     summary.codex_cost_speed = Some(speed.as_str().to_string());
     if let Some(tier) = read_codex_service_tier() {
         summary.codex_service_tier = Some(tier);

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -13,9 +13,9 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use crate::codex_cost_speed::{self, CodexCostSpeed};
 #[cfg(test)]
 use crate::codex_costs::scan_codex_file_cost;
-use crate::codex_cost_speed::{self, CodexCostSpeed};
 use crate::codex_costs::{
     add_codex_record_to_summary, add_codex_records_to_summary, codex_period_start,
     codex_scan_dates, project_bucket, scan_codex_file_cost_for_range,
@@ -366,10 +366,12 @@ fn local_day_start_utc(day: NaiveDate) -> DateTime<Utc> {
                 .latest()
         })
         .map(|local| local.with_timezone(&Utc))
-        .unwrap_or_else(|| DateTime::<Utc>::from_naive_utc_and_offset(
-            day.and_hms_opt(0, 0, 0).expect("valid midnight"),
-            Utc,
-        ))
+        .unwrap_or_else(|| {
+            DateTime::<Utc>::from_naive_utc_and_offset(
+                day.and_hms_opt(0, 0, 0).expect("valid midnight"),
+                Utc,
+            )
+        })
 }
 
 /// Cheap date gate for the flat archived dir: files are `rollout-YYYY-MM-DD…`.

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -15,6 +15,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(test)]
 use crate::codex_costs::scan_codex_file_cost;
+use crate::codex_cost_speed::{self, CodexCostSpeed};
 use crate::codex_costs::{
     add_codex_record_to_summary, add_codex_records_to_summary, codex_period_start,
     codex_scan_dates, project_bucket, scan_codex_file_cost_for_range,
@@ -72,6 +73,11 @@ pub struct CostSummary {
     pub period_start: Option<NaiveDate>,
     /// Period end date
     pub period_end: Option<NaiveDate>,
+    /// Codex cost speed tier applied to dollar fields (`standard` / `fast`).
+    /// `None` for non-Codex summaries.
+    pub codex_cost_speed: Option<String>,
+    /// Raw `service_tier` from Codex config when discovered (e.g. `priority`).
+    pub codex_service_tier: Option<String>,
 }
 
 /// Cost and token usage assembled from one pass over a provider's local logs.
@@ -344,6 +350,28 @@ fn is_drive_root(segment: &str) -> bool {
     bytes.len() == 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
+/// Midnight at the start of `day` in the local timezone, as UTC.
+///
+/// Used so Claude `--days N` is an inclusive local calendar window (matching
+/// Codex / ccusage) instead of a rolling UTC duration.
+fn local_day_start_utc(day: NaiveDate) -> DateTime<Utc> {
+    day.and_hms_opt(0, 0, 0)
+        .expect("valid midnight")
+        .and_local_timezone(Local)
+        .earliest()
+        .or_else(|| {
+            day.and_hms_opt(0, 0, 0)
+                .expect("valid midnight")
+                .and_local_timezone(Local)
+                .latest()
+        })
+        .map(|local| local.with_timezone(&Utc))
+        .unwrap_or_else(|| DateTime::<Utc>::from_naive_utc_and_offset(
+            day.and_hms_opt(0, 0, 0).expect("valid midnight"),
+            Utc,
+        ))
+}
+
 /// Cheap date gate for the flat archived dir: files are `rollout-YYYY-MM-DD…`.
 /// An unrecognized name falls through to the parser's own timestamp filter.
 fn archived_rollout_day_in_range(name: &str, range: &CostUsageDayRange) -> bool {
@@ -541,14 +569,29 @@ pub struct CostScanner {
     /// every candidate home. This is what makes one account's charts distinct
     /// from another's: each account is its own directory.
     scoped_home: Option<PathBuf>,
+    /// Codex list-rate vs priority/fast pricing (ccusage `--speed` parity).
+    codex_speed: CodexCostSpeed,
 }
 
 impl CostScanner {
-    /// Create a new scanner for the last N days
+    /// Create a new scanner for the last N days.
+    ///
+    /// Codex dollars follow ccusage auto speed: `service_tier = "priority"` in
+    /// `~/.codex/config.toml` prices at the fast (2×) tier.
     pub fn new(days: u32) -> Self {
         Self {
             days,
             scoped_home: None,
+            codex_speed: CodexCostSpeed::resolve(None),
+        }
+    }
+
+    /// Scanner with an explicit Codex cost speed (`standard` / `fast` / `auto`).
+    pub fn with_codex_speed(days: u32, speed_override: Option<&str>) -> Self {
+        Self {
+            days,
+            scoped_home: None,
+            codex_speed: CodexCostSpeed::resolve(speed_override),
         }
     }
 
@@ -557,7 +600,13 @@ impl CostScanner {
         Self {
             days,
             scoped_home: Some(home),
+            codex_speed: CodexCostSpeed::resolve(None),
         }
+    }
+
+    /// Codex cost speed tier this scanner applies to dollar totals.
+    pub fn codex_speed(&self) -> CodexCostSpeed {
+        self.codex_speed
     }
 
     /// Scan Codex local logs
@@ -608,6 +657,7 @@ impl CostScanner {
             }
         }
 
+        codex_cost_speed::apply_speed_to_summary(&mut summary, self.codex_speed);
         summary
     }
 
@@ -624,9 +674,11 @@ impl CostScanner {
         }
 
         let mut summary = CostSummary::default();
-        let today = Utc::now().date_naive();
-        let start_date = today - Duration::days(self.days as i64);
-        let cutoff = Utc::now() - Duration::days(self.days as i64);
+        // Inclusive local calendar window — same semantics as Codex `--days N`
+        // and ccusage `--since`/`--until` on the local machine.
+        let today = Local::now().date_naive();
+        let start_date = codex_period_start(today, self.days);
+        let cutoff = local_day_start_utc(start_date);
 
         summary.period_start = Some(start_date);
         summary.period_end = Some(today);
@@ -997,9 +1049,11 @@ fn claude_usage_record_from_event(event: &ClaudeEvent) -> Option<ClaudeUsageReco
 
     let cache_create_1h = usage.one_hour_cache_creation_tokens(cache_create);
     let timestamp = event.parsed_timestamp();
+    // Price with the local calendar day so date-aware rates match the same
+    // window the scanner uses for inclusion (not the UTC date alone).
     let usage_date = timestamp
-        .map(|recorded_at| recorded_at.date_naive())
-        .unwrap_or_else(|| Utc::now().date_naive());
+        .map(|recorded_at| recorded_at.with_timezone(&Local).date_naive())
+        .unwrap_or_else(|| Local::now().date_naive());
     let cost = ClaudePricing::cost_usd_with_cache_ttl_on_date(
         model,
         input,
@@ -1495,7 +1549,21 @@ fn scan_codex_report(
         }
     }
 
-    rollups.finish(days)
+    let mut report = rollups.finish(days);
+    // Apply ccusage-compatible priority/fast multiplier to every Codex window.
+    codex_cost_speed::apply_speed_to_summary(&mut report.today, scanner.codex_speed);
+    codex_cost_speed::apply_speed_to_summary(&mut report.seven_days, scanner.codex_speed);
+    codex_cost_speed::apply_speed_to_summary(&mut report.thirty_days, scanner.codex_speed);
+    if let Some(latest) = report.latest_session.as_mut() {
+        codex_cost_speed::apply_speed_to_summary(latest, scanner.codex_speed);
+    }
+    for summary in report.current_windows.values_mut() {
+        codex_cost_speed::apply_speed_to_summary(summary, scanner.codex_speed);
+    }
+    for (_day, cost) in report.daily_costs.iter_mut() {
+        *cost *= scanner.codex_speed.multiplier();
+    }
+    report
 }
 
 fn add_grok_record_to_summary(summary: &mut CostSummary, record: &GrokUsageRecord) {
@@ -1688,7 +1756,9 @@ fn scan_claude_report(
 
     let today = Local::now().date_naive();
     let seven_day_start = today - Duration::days(6);
-    let cutoff = Utc::now() - Duration::days(days as i64);
+    // Inclusive local calendar window (matches CLI cost + Codex + ccusage).
+    let period_start = codex_period_start(today, days);
+    let cutoff = local_day_start_utc(period_start);
     let mut seen = HashSet::new();
     let mut undated = CostSummary::default();
     let mut latest: Option<(DateTime<Utc>, CostSummary)> = None;
@@ -1776,6 +1846,7 @@ pub fn get_daily_cost_history(provider: &str, days: u32) -> Vec<(String, f64)> {
         "codex" => {
             // Scan Codex logs by day across Windows and WSL session roots.
             let sessions_dirs = scanner.get_codex_sessions_dirs();
+            let speed_mult = scanner.codex_speed.multiplier();
             for days_ago in 0..days {
                 let date = today - Duration::days(days_ago as i64);
                 let date_str = date.format("%Y-%m-%d").to_string();
@@ -1801,7 +1872,7 @@ pub fn get_daily_cost_history(provider: &str, days: u32) -> Vec<(String, f64)> {
                         }
                     }
                 }
-                daily_costs.insert(date_str, day_cost);
+                daily_costs.insert(date_str, day_cost * speed_mult);
             }
         }
         "claude" => {
@@ -1809,7 +1880,8 @@ pub fn get_daily_cost_history(provider: &str, days: u32) -> Vec<(String, f64)> {
             // de-duplicating records across files.
             let projects_dir = scanner.get_claude_projects_dir();
             if projects_dir.exists() {
-                let cutoff = Utc::now() - Duration::days(days as i64);
+                let period_start = codex_period_start(today, days);
+                let cutoff = local_day_start_utc(period_start);
                 let mut seen = HashSet::new();
                 let mut handle_file = |path: &Path| {
                     for_each_claude_usage_record(path, &cutoff, &mut seen, None, |record| {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cli;
 pub mod core;
 pub mod cost_scanner;
 pub mod cursor_activity;
+mod codex_cost_speed;
 mod grok_costs;
 pub mod host;
 pub mod locale;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,10 +6,10 @@
 pub mod agent_sessions;
 pub mod browser;
 pub mod cli;
+mod codex_cost_speed;
 pub mod core;
 pub mod cost_scanner;
 pub mod cursor_activity;
-mod codex_cost_speed;
 mod grok_costs;
 pub mod host;
 pub mod locale;


### PR DESCRIPTION
## Summary

Local API-equivalent cost was losing Reddit/A-B compares against **ccusage** for two separate reasons:

1. **Codex dollars at ~half of default ccusage** when `service_tier = "priority"` in `~/.codex/config.toml`. ccusage `--speed auto` maps priority to **fast (2× list rates)**; Ceiling always priced standard.
2. **Claude `--days N`** used a rolling UTC duration (and labeled N+1 calendar days). Codex already used inclusive local calendar days. Windows did not match each other or ccusage.

### Changes

- Read Codex `service_tier` from config; `priority` / `fast` → 2× (ccusage parity).
- CLI: `codexbar cost --codex-speed auto|standard|fast` (default `auto`).
- JSON: `cost.codex_speed`, `cost.codex_service_tier` for fair A/B dumps.
- Charts / UI scanners use the same auto path via `CostScanner::new`.
- Claude inclusive local calendar window for `--days N` (same as Codex).

### Verified on this machine (7d)

| Compare | Ceiling | ccusage | Gap |
|---------|---------|---------|-----|
| Codex auto (priority/fast) | ~$933 | ~$935 | ~0.2% |
| Codex standard | ~$467 | ~$467 | ~0.2% |
| Claude day labels | 7 calendar days | — | was 8 |

### Residual (follow-up, not blocking)

Codex **30d** still sits ~8–9% under ccusage while **7d matches**. Likely older archive / fork-replay handling (Ceiling suppresses parent-history replay on subagents to avoid double-count). Prefer shipping parity on the headline gap; track long-window forensics separately.

### Fair compare (for reviewers / Reddit)

```powershell
# Same tier as default ccusage when service_tier=priority
npx ccusage@latest codex daily --speed auto
codexbar cost -p codex -d 7

# List rates only
npx ccusage@latest codex daily --speed standard
codexbar cost -p codex -d 7 --codex-speed standard
```

## Test plan

- [x] `cargo test -p codexbar --lib codex_cost_speed`
- [x] `cargo test -p codexbar --lib cost_scanner` / `codex_costs` / `cost_pricing`
- [x] Live `codexbar cost` vs `ccusage codex daily` at auto + standard (7d)
- [ ] CI green on this PR
- [ ] After merge: patch release (1.5.13) so installs pick up the fix

## Release note angle

> Local cost now matches ccusage speed tiers (priority/fast = 2×). Claude day windows match Codex. Compare with the same `--speed` / `service_tier` when auditing dollars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex cost speed options: automatic, standard, or fast.
  * Cost reports now show the selected Codex speed and service tier.
  * JSON output includes Codex speed metadata.

* **Bug Fixes**
  * Codex fast/priority pricing is now calculated correctly.
  * Claude `--days` cost calculations now use inclusive local calendar days, matching other providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->