### PR TITLE
fix(charts): weekly window dollars after Codex priority/fast pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Invalidate persisted chart cache after Codex priority/fast pricing so the Weekly window card no longer keeps pre-2x standard dollars while the API-value ring shows the correct doubled amount.
+
 ## [Ceiling] 1.5.13 - 2026-07-26
 
 Patch for local cost accuracy vs ccusage (Codex priority/fast tiers and Claude day windows).

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -24,9 +24,10 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const LOCAL_USAGE_TTL: Duration = Duration::from_secs(30);
 const CHART_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
-// Version 6 restores the rolling comparison periods Compare needs; entries
-// cached at version 5 hold an empty list that would leave the tab stuck.
-const CHART_CACHE_VERSION: u8 = 6;
+// Version 7: Codex priority/fast (2x) pricing for local cost. Entries cached at
+// version 6 still hold pre-2x standard dollars for reset windows, so the
+// Weekly window card could show ~half of the API-value ring after 1.5.13.
+const CHART_CACHE_VERSION: u8 = 7;
 
 /// A single (date, value) point for cost or credits history charts.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -2277,6 +2277,80 @@ mod tests {
     }
 
     #[test]
+    fn codex_report_applies_cost_speed_to_reset_windows() {
+        // Weekly/reset windows must use the same speed tier as calendar totals.
+        // A post-pass that only multiplies today/7d/30d left Weekly at standard
+        // while the API-value ring (fresh scan) showed priority/fast 2x.
+        let tmp = tempfile::tempdir().unwrap();
+        let event_at = Utc::now() - Duration::minutes(10);
+        let local_day = event_at.with_timezone(&Local).date_naive();
+        let day_dir = tmp
+            .path()
+            .join("sessions")
+            .join(local_day.format("%Y").to_string())
+            .join(local_day.format("%m").to_string())
+            .join(local_day.format("%d").to_string());
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let ts = event_at.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
+        let line = format!(
+            r#"{{"timestamp":"{ts}","type":"event_msg","payload":{{"type":"token_count","info":{{"model":"gpt-5.6-sol","total_token_usage":{{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":100}}}}}}}}"#
+        );
+        std::fs::write(
+            day_dir.join(format!(
+                "rollout-{}-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jsonl",
+                local_day.format("%Y-%m-%d")
+            )),
+            line,
+        )
+        .unwrap();
+
+        let _guard = codex_home_lock().lock().expect("codex home lock");
+        let previous = std::env::var("CODEX_HOME").ok();
+        // SAFETY: serialized by `codex_home_lock`, and restored below.
+        unsafe { std::env::set_var("CODEX_HOME", tmp.path()) };
+
+        let starts_at = Utc::now() - Duration::hours(1);
+        let ends_at = Utc::now() + Duration::hours(1);
+        let windows = [CurrentUsageWindow {
+            id: "primary".into(),
+            starts_at,
+            ends_at,
+        }];
+
+        let standard = CostScanner::with_codex_speed(2, Some("standard"));
+        let fast = CostScanner::with_codex_speed(2, Some("fast"));
+        let std_report = scan_codex_report(&standard, 2, &windows);
+        let fast_report = scan_codex_report(&fast, 2, &windows);
+
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("CODEX_HOME", value),
+                None => std::env::remove_var("CODEX_HOME"),
+            }
+        }
+
+        let std_window = std_report
+            .current_windows
+            .get("primary")
+            .expect("primary window");
+        let fast_window = fast_report
+            .current_windows
+            .get("primary")
+            .expect("primary window");
+        assert!(
+            std_window.total_cost_usd > 0.0,
+            "window should price sol usage"
+        );
+        assert!(
+            (fast_window.total_cost_usd - std_window.total_cost_usd * 2.0).abs() < 1e-9,
+            "fast window must be 2x standard (got fast={} std={})",
+            fast_window.total_cost_usd,
+            std_window.total_cost_usd
+        );
+        assert_eq!(fast_window.codex_cost_speed.as_deref(), Some("fast"));
+    }
+
+    #[test]
     fn parses_current_codex_payload_token_count_events() {
         let path = std::env::temp_dir().join(format!(
             "codexbar-current-codex-token-count-{}.jsonl",


### PR DESCRIPTION
## Summary

After 1.5.13, the charts **API-value ring** (fresh scan) correctly shows Codex at priority/fast (2x), but the **Weekly window** card could keep ~half those dollars.

Root cause: `chart-data-cache.json` stayed at **version 6**, so on open Ceiling served **persisted pre-2x localUsage** for reset windows. The ring uses a different path and was never stuck on that cache.

## Fix

- Bump `CHART_CACHE_VERSION` 6 → 7 so upgrade drops stale standard-rate window costs
- Regression: `codex_report_applies_cost_speed_to_reset_windows` asserts fast = 2x standard on reset windows

## Repro (user)

Weekly ~$232.50 vs yesterday ring ~$477.97 on nearly the same tokens after a mid-day weekly reset. 232.5 × 2 ≈ 465 ≈ full-day fast with a small pre-reset slice.

## Workaround on 1.5.13

Quit Ceiling, delete `%APPDATA%\Ceiling\chart-data-cache.json` (or the parent of settings path), reopen Charts.

## Test plan

- [x] `cargo test -p codexbar --lib codex_report_applies_cost_speed_to_reset_windows`
- [ ] CI green
- [ ] After install: Weekly window ≈ 2x former standard for same tokens when service_tier=priority