### PR TITLE
Clarify Claude missing-sign-in errors for charts vs capacity

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
@@ -459,6 +459,11 @@ fn normalize_reset_description(desc: &str, lang: codexbar::settings::Language) -
     )
 }
 
+/// Charts read local `~/.claude` session logs; live capacity needs CLI OAuth.
+/// Call this out when capacity auth fails so Accounts/Charts do not look broken.
+const CLAUDE_CHARTS_WITHOUT_CAPACITY_NOTE: &str =
+    "Charts can still show local session spend without live capacity.";
+
 pub(crate) fn friendly_provider_error(id: ProviderId, error: &str) -> String {
     if id == ProviderId::Grok {
         let trimmed = error.trim();
@@ -489,32 +494,50 @@ pub(crate) fn friendly_provider_error(id: ProviderId, error: &str) -> String {
         return "Claude usage fetch was cancelled before usage data was returned. Refresh Claude, or re-authenticate with Claude Code and try again.".to_string();
     }
 
-    if lower.contains("claude oauth credentials not found") {
-        return "Claude sign-in was not found. Run `claude` once to authenticate, then refresh Claude in Ceiling.".to_string();
-    }
-
-    if lower.contains("oauth token expired") || lower.contains("token invalid or expired") {
-        return "Claude sign-in expired. Run `claude` to refresh your Claude Code login, then refresh Claude in Ceiling.".to_string();
-    }
-
-    if trimmed == "Authentication required" {
-        return "Claude needs sign-in before Ceiling can read usage. Run `claude` once, or add Claude cookies in Provider settings.".to_string();
-    }
-
+    // Multi-source Auto failures must be handled before the single-source OAuth
+    // rewrite: the composite string also contains "credentials not found" and
+    // used to collapse into an OAuth-only line that hid Web/CLI outcomes.
     if lower.starts_with("claude usage failed from all configured sources.") {
-        return trimmed
+        let detail = trimmed
+            .strip_prefix("Claude usage failed from all configured sources.")
+            .unwrap_or(trimmed)
+            .trim()
+            .trim_start_matches('.')
+            .trim()
             .replace(
                 "OAuth: OAuth error: Claude OAuth credentials not found. Run `claude` to authenticate.",
                 "OAuth: sign-in not found",
             )
             .replace(
-                "Web: No cookies available for web API",
-                "Web: no Claude cookies available",
+                "OAuth: OAuth error: Claude OAuth credentials not found",
+                "OAuth: sign-in not found",
             )
             .replace(
-                "CLI: Provider not installed:",
-                "CLI: not installed:",
-            );
+                "Web: No cookies available for web API",
+                "Web: no session available",
+            )
+            .replace("CLI: Provider not installed:", "CLI: not installed:");
+        return format!(
+            "Claude capacity could not be loaded ({detail}). Run `claude` once in a terminal, then refresh Claude in Ceiling. {CLAUDE_CHARTS_WITHOUT_CAPACITY_NOTE}"
+        );
+    }
+
+    if lower.contains("claude oauth credentials not found") {
+        return format!(
+            "Claude CLI sign-in was not found. Run `claude` once in a terminal, then refresh Claude in Ceiling. {CLAUDE_CHARTS_WITHOUT_CAPACITY_NOTE}"
+        );
+    }
+
+    if lower.contains("oauth token expired") || lower.contains("token invalid or expired") {
+        return format!(
+            "Claude sign-in expired. Run `claude` to refresh your Claude Code login, then refresh Claude in Ceiling. {CLAUDE_CHARTS_WITHOUT_CAPACITY_NOTE}"
+        );
+    }
+
+    if trimmed == "Authentication required" {
+        return format!(
+            "Claude needs a CLI sign-in before Ceiling can read capacity. Run `claude` once, then refresh Claude in Ceiling. {CLAUDE_CHARTS_WITHOUT_CAPACITY_NOTE}"
+        );
     }
 
     trimmed.to_string()

--- a/apps/desktop-tauri/src-tauri/src/commands/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/tests.rs
@@ -1169,8 +1169,57 @@ fn claude_error_message_explains_missing_sign_in() {
 
     assert_eq!(
         message,
-        "Claude sign-in was not found. Run `claude` once to authenticate, then refresh Claude in Ceiling."
+        "Claude CLI sign-in was not found. Run `claude` once in a terminal, then refresh Claude in Ceiling. Charts can still show local session spend without live capacity."
     );
+}
+
+#[test]
+fn claude_multi_source_failure_keeps_all_sources_not_oauth_only() {
+    let message = super::friendly_provider_error(
+        ProviderId::Claude,
+        "Claude usage failed from all configured sources. OAuth: OAuth error: Claude OAuth credentials not found. Run `claude` to authenticate.; Web: No cookies available for web API; CLI: Provider not installed: claude not found",
+    );
+
+    assert!(
+        message.contains("Claude capacity could not be loaded"),
+        "expected capacity framing, got: {message}"
+    );
+    assert!(
+        message.contains("OAuth: sign-in not found"),
+        "expected shortened OAuth detail, got: {message}"
+    );
+    assert!(
+        message.contains("Web: no session available"),
+        "expected shortened Web detail, got: {message}"
+    );
+    assert!(
+        message.contains("CLI: not installed:"),
+        "expected shortened CLI detail, got: {message}"
+    );
+    assert!(
+        message.contains("Run `claude` once in a terminal"),
+        "expected CLI fix hint, got: {message}"
+    );
+    assert!(
+        message.contains("Charts can still show local session spend without live capacity."),
+        "expected charts note, got: {message}"
+    );
+    assert!(
+        !message.starts_with("Claude CLI sign-in was not found."),
+        "multi-source must not collapse to the OAuth-only line: {message}"
+    );
+}
+
+#[test]
+fn claude_auth_required_does_not_suggest_cookies() {
+    let message = super::friendly_provider_error(ProviderId::Claude, "Authentication required");
+
+    assert!(message.contains("CLI sign-in") || message.contains("Run `claude`"));
+    assert!(
+        !message.to_lowercase().contains("cookie"),
+        "must not recommend browser cookies: {message}"
+    );
+    assert!(message.contains("Charts can still show local session spend without live capacity."));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Stop collapsing Auto multi-source Claude failures into an OAuth-only error line
- Point users at CLI `claude` login for live capacity
- Note that Charts can still show local session spend without live capacity
- Do not recommend browser cookies for Claude capacity

Fixes #165

## Test plan

- [x] `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` filters for Claude friendly-error tests
- [ ] Manual: enable Claude without CLI login; Accounts error mentions charts vs capacity
- [ ] Manual: multi-source Auto failure still shows shortened OAuth/Web/CLI details

## Notes for CodeRabbit

Core change is `friendly_provider_error` ordering in `bridge.rs`: multi-source prefix must run before the OAuth credentials rewrite.