### PR TITLE
Add custom date range to Estimated API value charts

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -308,6 +308,9 @@ pub struct LocalApiValueProvider {
     pub thirty_days: LocalApiValuePeriod,
     /// Calendar days [today-60, today-30) for dollar period-over-period on 30d.
     pub prior_thirty_days: LocalApiValuePeriod,
+    /// Optional inclusive local-calendar range from `get_local_api_value_totals`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom: Option<LocalApiValuePeriod>,
     /// Last seven local calendar days, oldest first, today last.
     #[serde(default)]
     pub last_seven_days: Vec<LocalApiValueDay>,
@@ -722,19 +725,72 @@ pub(crate) async fn load_spend_budget_total(
     .flatten()
 }
 
+/// Inclusive local-calendar custom range for Estimated API value (YYYY-MM-DD).
+const API_VALUE_CUSTOM_MAX_DAYS: i64 = 366;
 #[tauri::command]
-pub async fn get_local_api_value_totals() -> Result<Vec<LocalApiValueProvider>, String> {
+pub async fn get_local_api_value_totals(
+    since: Option<String>,
+    until: Option<String>,
+) -> Result<Vec<LocalApiValueProvider>, String> {
+    let custom = match (since.as_deref(), until.as_deref()) {
+        (None, None) => None,
+        (Some(since), Some(until)) => {
+            Some(parse_api_value_custom_range(since, until, Local::now().date_naive())?)
+        }
+        _ => {
+            return Err(
+                "Custom range needs both a start and end date (YYYY-MM-DD).".to_string(),
+            );
+        }
+    };
     // A worker panic/cancel must surface as an error, not an empty result —
     // "unavailable" and "genuinely no data" are distinct on this card.
-    tauri::async_runtime::spawn_blocking(|| load_local_api_value_totals(Local::now()))
-        .await
-        .map_err(|err| {
-            tracing::warn!("Local API-value totals worker failed: {}", err);
-            "Unable to load local API-value totals.".to_string()
-        })
+    tauri::async_runtime::spawn_blocking(move || {
+        load_local_api_value_totals(Local::now(), custom)
+    })
+    .await
+    .map_err(|err| {
+        tracing::warn!("Local API-value totals worker failed: {}", err);
+        "Unable to load local API-value totals.".to_string()
+    })
 }
 
-fn load_local_api_value_totals(now: DateTime<Local>) -> Vec<LocalApiValueProvider> {
+/// Parse and validate an inclusive local-calendar custom range.
+/// Returns `(start, end_exclusive)` as UTC midnights for the cost scanner.
+fn parse_api_value_custom_range(
+    since: &str,
+    until: &str,
+    today: NaiveDate,
+) -> Result<(DateTime<Utc>, DateTime<Utc>), String> {
+    let start = NaiveDate::parse_from_str(since.trim(), "%Y-%m-%d").map_err(|_| {
+        format!("Start date must be YYYY-MM-DD (got {since:?}).")
+    })?;
+    let end_inclusive = NaiveDate::parse_from_str(until.trim(), "%Y-%m-%d").map_err(|_| {
+        format!("End date must be YYYY-MM-DD (got {until:?}).")
+    })?;
+    if start > end_inclusive {
+        return Err("Start date must be on or before the end date.".to_string());
+    }
+    if end_inclusive > today {
+        return Err("End date cannot be in the future.".to_string());
+    }
+    let span_days = (end_inclusive - start).num_days() + 1;
+    if span_days > API_VALUE_CUSTOM_MAX_DAYS {
+        return Err(format!(
+            "Custom range can span at most {API_VALUE_CUSTOM_MAX_DAYS} days."
+        ));
+    }
+    // Inclusive end day → [start midnight, day-after-end midnight).
+    Ok((
+        local_midnight_utc(start),
+        local_midnight_utc(end_inclusive + chrono::Duration::days(1)),
+    ))
+}
+
+fn load_local_api_value_totals(
+    now: DateTime<Local>,
+    custom_range: Option<(DateTime<Utc>, DateTime<Utc>)>,
+) -> Vec<LocalApiValueProvider> {
     let today = now.date_naive();
     let (yesterday_start, yesterday_end) = local_yesterday_window_utc(now);
     // Exact [start, end) windows so thirty-day and prior-thirty stay adjacent
@@ -743,6 +799,13 @@ fn load_local_api_value_totals(now: DateTime<Local>) -> Vec<LocalApiValueProvide
     let thirty_start = local_midnight_utc(today - chrono::Duration::days(29));
     let thirty_end = local_midnight_utc(today + chrono::Duration::days(1));
     let prior_start = local_midnight_utc(today - chrono::Duration::days(59));
+    let scan_days = custom_range
+        .map(|(start, _)| {
+            let start_date = start.with_timezone(&Local).date_naive();
+            let days = (today - start_date).num_days().max(0) as u32 + 1;
+            days.clamp(60, API_VALUE_CUSTOM_MAX_DAYS as u32)
+        })
+        .unwrap_or(60);
     API_VALUE_PROVIDERS
         .iter()
         .filter_map(|provider_id| {
@@ -763,6 +826,13 @@ fn load_local_api_value_totals(now: DateTime<Local>) -> Vec<LocalApiValueProvide
                     ends_at: thirty_start,
                 },
             ];
+            if let Some((starts_at, ends_at)) = custom_range {
+                windows.push(CurrentUsageWindow {
+                    id: "custom".to_string(),
+                    starts_at,
+                    ends_at,
+                });
+            }
             // One window per local calendar day for the seven-day trend.
             for offset in 0..7i64 {
                 let date = today - chrono::Duration::days(offset);
@@ -772,7 +842,7 @@ fn load_local_api_value_totals(now: DateTime<Local>) -> Vec<LocalApiValueProvide
                     ends_at: local_midnight_utc(date + chrono::Duration::days(1)),
                 });
             }
-            let report = get_cost_usage_report_with_windows(provider_id, 60, &windows)?;
+            let report = get_cost_usage_report_with_windows(provider_id, scan_days, &windows)?;
             let yesterday = report
                 .current_windows
                 .get("yesterday")
@@ -788,6 +858,14 @@ fn load_local_api_value_totals(now: DateTime<Local>) -> Vec<LocalApiValueProvide
                 .get("prior_thirty")
                 .cloned()
                 .unwrap_or_default();
+            let custom = custom_range.map(|_| {
+                let summary = report
+                    .current_windows
+                    .get("custom")
+                    .cloned()
+                    .unwrap_or_default();
+                api_value_period(provider_id, &summary)
+            });
             // Oldest first so the trend reads left to right, ending today.
             let last_seven_days = (0..7i64)
                 .rev()
@@ -812,13 +890,15 @@ fn load_local_api_value_totals(now: DateTime<Local>) -> Vec<LocalApiValueProvide
                 yesterday: api_value_period(provider_id, &yesterday),
                 thirty_days: api_value_period(provider_id, &thirty_days),
                 prior_thirty_days: api_value_period(provider_id, &prior_thirty_days),
+                custom,
                 last_seven_days,
             };
             // Omit providers with no source data in any period.
             (provider.today.has_data
                 || provider.yesterday.has_data
                 || provider.thirty_days.has_data
-                || provider.prior_thirty_days.has_data)
+                || provider.prior_thirty_days.has_data
+                || provider.custom.as_ref().is_some_and(|p| p.has_data))
                 .then_some(provider)
         })
         .collect()
@@ -1628,8 +1708,8 @@ mod tests {
         comparison_period_specs, cost_fetch_failure_allows_early_retry, effort_breakdown,
         format_cost_csv, local_midnight_in_tz, local_usage_summary_from_report,
         local_yesterday_window_utc, localized_estimate_note, model_breakdown,
-        pricing_coverage_tokens, project_breakdown, spend_budget_period_details, token_breakdown,
-        token_cost_cache_is_fresh,
+        parse_api_value_custom_range, pricing_coverage_tokens, project_breakdown,
+        spend_budget_period_details, token_breakdown,        token_cost_cache_is_fresh,
     };
     use crate::commands::is_provider_cache_fresh;
     use chrono::{Local, LocalResult, NaiveDate, NaiveTime, TimeZone, Timelike, Utc};
@@ -2434,5 +2514,28 @@ mod tests {
             localized_estimate_note("claude", Language::English),
             "API-equivalent estimate from local Claude logs; not subscription spend"
         );
+    }
+    #[test]
+    fn parse_api_value_custom_range_accepts_inclusive_local_days() {
+        let today = NaiveDate::from_ymd_opt(2026, 7, 28).unwrap();
+        let (start, end) =
+            parse_api_value_custom_range("2026-07-01", "2026-07-07", today).expect("range");
+        assert_eq!(
+            start.with_timezone(&Local).date_naive(),
+            NaiveDate::from_ymd_opt(2026, 7, 1).unwrap()
+        );
+        // Exclusive end is the day after the inclusive until date.
+        assert_eq!(
+            end.with_timezone(&Local).date_naive(),
+            NaiveDate::from_ymd_opt(2026, 7, 8).unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_api_value_custom_range_rejects_inverted_and_future() {
+        let today = NaiveDate::from_ymd_opt(2026, 7, 28).unwrap();
+        assert!(parse_api_value_custom_range("2026-07-10", "2026-07-01", today).is_err());
+        assert!(parse_api_value_custom_range("2026-07-01", "2026-08-01", today).is_err());
+        assert!(parse_api_value_custom_range("not-a-date", "2026-07-01", today).is_err());
     }
 }

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -734,25 +734,23 @@ pub async fn get_local_api_value_totals(
 ) -> Result<Vec<LocalApiValueProvider>, String> {
     let custom = match (since.as_deref(), until.as_deref()) {
         (None, None) => None,
-        (Some(since), Some(until)) => {
-            Some(parse_api_value_custom_range(since, until, Local::now().date_naive())?)
-        }
+        (Some(since), Some(until)) => Some(parse_api_value_custom_range(
+            since,
+            until,
+            Local::now().date_naive(),
+        )?),
         _ => {
-            return Err(
-                "Custom range needs both a start and end date (YYYY-MM-DD).".to_string(),
-            );
+            return Err("Custom range needs both a start and end date (YYYY-MM-DD).".to_string());
         }
     };
     // A worker panic/cancel must surface as an error, not an empty result —
     // "unavailable" and "genuinely no data" are distinct on this card.
-    tauri::async_runtime::spawn_blocking(move || {
-        load_local_api_value_totals(Local::now(), custom)
-    })
-    .await
-    .map_err(|err| {
-        tracing::warn!("Local API-value totals worker failed: {}", err);
-        "Unable to load local API-value totals.".to_string()
-    })
+    tauri::async_runtime::spawn_blocking(move || load_local_api_value_totals(Local::now(), custom))
+        .await
+        .map_err(|err| {
+            tracing::warn!("Local API-value totals worker failed: {}", err);
+            "Unable to load local API-value totals.".to_string()
+        })
 }
 
 /// Parse and validate an inclusive local-calendar custom range.
@@ -762,12 +760,10 @@ fn parse_api_value_custom_range(
     until: &str,
     today: NaiveDate,
 ) -> Result<(DateTime<Utc>, DateTime<Utc>), String> {
-    let start = NaiveDate::parse_from_str(since.trim(), "%Y-%m-%d").map_err(|_| {
-        format!("Start date must be YYYY-MM-DD (got {since:?}).")
-    })?;
-    let end_inclusive = NaiveDate::parse_from_str(until.trim(), "%Y-%m-%d").map_err(|_| {
-        format!("End date must be YYYY-MM-DD (got {until:?}).")
-    })?;
+    let start = NaiveDate::parse_from_str(since.trim(), "%Y-%m-%d")
+        .map_err(|_| format!("Start date must be YYYY-MM-DD (got {since:?})."))?;
+    let end_inclusive = NaiveDate::parse_from_str(until.trim(), "%Y-%m-%d")
+        .map_err(|_| format!("End date must be YYYY-MM-DD (got {until:?})."))?;
     if start > end_inclusive {
         return Err("Start date must be on or before the end date.".to_string());
     }
@@ -899,7 +895,7 @@ fn load_local_api_value_totals(
                 || provider.thirty_days.has_data
                 || provider.prior_thirty_days.has_data
                 || provider.custom.as_ref().is_some_and(|p| p.has_data))
-                .then_some(provider)
+            .then_some(provider)
         })
         .collect()
 }
@@ -1709,7 +1705,7 @@ mod tests {
         format_cost_csv, local_midnight_in_tz, local_usage_summary_from_report,
         local_yesterday_window_utc, localized_estimate_note, model_breakdown,
         parse_api_value_custom_range, pricing_coverage_tokens, project_breakdown,
-        spend_budget_period_details, token_breakdown,        token_cost_cache_is_fresh,
+        spend_budget_period_details, token_breakdown, token_cost_cache_is_fresh,
     };
     use crate::commands::is_provider_cache_fresh;
     use chrono::{Local, LocalResult, NaiveDate, NaiveTime, TimeZone, Timelike, Utc};

--- a/apps/desktop-tauri/src/components/TotalApiValueCard.test.tsx
+++ b/apps/desktop-tauri/src/components/TotalApiValueCard.test.tsx
@@ -82,4 +82,38 @@ describe("TotalApiValueCard", () => {
     const { findByText } = render(<TotalApiValueCard />);
     expect(await findByText(/unavailable right now/)).toBeTruthy();
   });
+
+  it("loads a custom date range when Custom is selected", async () => {
+    tauriMocks.getLocalApiValueTotals.mockResolvedValue([
+      {
+        providerId: "codex",
+        today: period({ apiValueUsd: 1, tokens: 10, pricedTokens: 10, totalTokens: 10, hasData: true }),
+        yesterday: period({}),
+        thirtyDays: period({}),
+        priorThirtyDays: period({}),
+        custom: period({
+          apiValueUsd: 55,
+          tokens: 5000,
+          pricedTokens: 5000,
+          totalTokens: 5000,
+          hasData: true,
+        }),
+      },
+    ]);
+    const { getByText, getAllByText, getByLabelText, findAllByText } = render(
+      <TotalApiValueCard />,
+    );
+    await waitFor(() => expect(getAllByText("$1.00").length).toBeGreaterThan(0));
+    getByText("Custom").click();
+    await waitFor(() =>
+      expect(tauriMocks.getLocalApiValueTotals).toHaveBeenCalledWith(
+        expect.objectContaining({
+          since: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          until: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        }),
+      ),
+    );
+    expect(getByLabelText("Custom date range")).toBeTruthy();
+    expect((await findAllByText("$55.00")).length).toBeGreaterThan(0);
+  });
 });

--- a/apps/desktop-tauri/src/components/TotalApiValueCard.tsx
+++ b/apps/desktop-tauri/src/components/TotalApiValueCard.tsx
@@ -14,6 +14,7 @@ const PERIODS: { key: ApiValuePeriodKey; label: string }[] = [
   { key: "today", label: "Today" },
   { key: "yesterday", label: "Yesterday" },
   { key: "thirtyDays", label: "30 days" },
+  { key: "custom", label: "Custom" },
 ];
 
 const METRICS: { key: ApiValueMetric; label: string }[] = [
@@ -39,6 +40,40 @@ function providerLabel(providerId: string): string {
 
 function providerColor(providerId: string): string {
   return getProviderIcon(providerId).brandColor;
+}
+
+/** Local calendar date as YYYY-MM-DD. */
+function formatLocalDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function defaultCustomRange(): { since: string; until: string } {
+  const until = new Date();
+  const since = new Date();
+  since.setDate(since.getDate() - 6); // inclusive 7 local days ending today
+  return { since: formatLocalDate(since), until: formatLocalDate(until) };
+}
+
+function shortRangeLabel(since: string, until: string): string {
+  if (since === until) return since;
+  // Compact: "Jul 1 – Jul 7" when year matches; else keep ISO.
+  const parse = (iso: string) => {
+    const [y, m, d] = iso.split("-").map(Number);
+    if (!y || !m || !d) return null;
+    return new Date(y, m - 1, d);
+  };
+  const a = parse(since);
+  const b = parse(until);
+  if (!a || !b) return `${since} – ${until}`;
+  const fmt = (date: Date) =>
+    date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  if (a.getFullYear() === b.getFullYear()) {
+    return `${fmt(a)} – ${fmt(b)}`;
+  }
+  return `${since} – ${until}`;
 }
 
 type TrendDay = {
@@ -88,16 +123,40 @@ export function TotalApiValueCard() {
   const [failed, setFailed] = useState(false);
   const [period, setPeriod] = useState<ApiValuePeriodKey>("today");
   const [metric, setMetric] = useState<ApiValueMetric>("apiValue");
+  const [customSince, setCustomSince] = useState(() => defaultCustomRange().since);
+  const [customUntil, setCustomUntil] = useState(() => defaultCustomRange().until);
+  const [rangeError, setRangeError] = useState<string | null>(null);
 
   useEffect(() => {
     let live = true;
-    getLocalApiValueTotals()
-      .then((rows) => live && setProviders(rows))
-      .catch(() => live && setFailed(true));
+    setFailed(false);
+    setRangeError(null);
+
+    const options =
+      period === "custom"
+        ? { since: customSince, until: customUntil }
+        : undefined;
+
+    getLocalApiValueTotals(options)
+      .then((rows) => {
+        if (!live) return;
+        setProviders(rows);
+      })
+      .catch((err: unknown) => {
+        if (!live) return;
+        const message = err instanceof Error ? err.message : String(err ?? "");
+        // Backend validation (inverted range, future end, bad format) should
+        // stay on the custom pickers instead of blanking the whole card.
+        if (period === "custom" && message) {
+          setRangeError(message);
+          return;
+        }
+        setFailed(true);
+      });
     return () => {
       live = false;
     };
-  }, []);
+  }, [period, customSince, customUntil]);
 
   const model = useMemo(
     () => (providers ? buildApiValueCard(providers, period, metric) : null),
@@ -107,8 +166,12 @@ export function TotalApiValueCard() {
   const formatValue = (value: number) =>
     metric === "apiValue" ? formatUsd(value) : formatTokens(value);
 
-  const periodLabel = PERIODS.find((p) => p.key === period)?.label ?? "";
+  const periodLabel =
+    period === "custom"
+      ? shortRangeLabel(customSince, customUntil)
+      : (PERIODS.find((p) => p.key === period)?.label ?? "");
   const metricLabel = METRICS.find((m) => m.key === metric)?.label ?? "";
+  const todayIso = formatLocalDate(new Date());
 
   if (failed) {
     return (
@@ -118,7 +181,7 @@ export function TotalApiValueCard() {
     );
   }
 
-  if (!model) {
+  if (!model && !rangeError) {
     return (
       <section className="api-value-card" aria-label="Total API value">
         <p className="api-value-card__status">Reading local usage…</p>
@@ -126,24 +189,25 @@ export function TotalApiValueCard() {
     );
   }
 
-  const segments = ringSegments(model.slices, CIRCUMFERENCE);
+  const safeModel = model ?? buildApiValueCard([], period, metric);
+  const segments = ringSegments(safeModel.slices, CIRCUMFERENCE);
   const coveragePercent =
-    model.coverage == null ? null : Math.round(model.coverage * 100);
+    safeModel.coverage == null ? null : Math.round(safeModel.coverage * 100);
   // Compare the raw ratio so 99.6% (rounds to 100) still shows the coverage
   // note when any tokens are unpriced.
-  const showCoverage = model.coverage != null && model.coverage < 1;
+  const showCoverage = safeModel.coverage != null && safeModel.coverage < 1;
   const periodChangeLabel =
-    model.periodChange && metric === "apiValue"
-      ? formatPeriodChange(model.periodChange)
+    safeModel.periodChange && metric === "apiValue"
+      ? formatPeriodChange(safeModel.periodChange)
       : null;
 
   // Seven-day trend, summed across providers per day. Heights are relative to
   // the busiest day so a quiet day still renders a visible sliver.
   const trend = buildTrend(providers ?? []);
 
-  const ariaSummary = model.isEmpty
+  const ariaSummary = safeModel.isEmpty
     ? `No local ${metricLabel} data for ${periodLabel}.`
-    : `${metricLabel} for ${periodLabel}: ${formatValue(model.total)} across ${model.slices
+    : `${metricLabel} for ${periodLabel}: ${formatValue(safeModel.total)} across ${safeModel.slices
         .map((slice) => providerLabel(slice.providerId))
         .join(", ")}.`;
 
@@ -188,9 +252,38 @@ export function TotalApiValueCard() {
         </div>
       </header>
 
-      {model.isEmpty ? (
+      {period === "custom" && (
+        <div className="api-value-card__custom-range" role="group" aria-label="Custom date range">
+          <label className="api-value-card__date-field">
+            <span>From</span>
+            <input
+              type="date"
+              value={customSince}
+              max={customUntil || todayIso}
+              onChange={(event) => setCustomSince(event.target.value)}
+            />
+          </label>
+          <label className="api-value-card__date-field">
+            <span>To</span>
+            <input
+              type="date"
+              value={customUntil}
+              min={customSince || undefined}
+              max={todayIso}
+              onChange={(event) => setCustomUntil(event.target.value)}
+            />
+          </label>
+          {rangeError && (
+            <p className="api-value-card__range-error" role="alert">
+              {rangeError}
+            </p>
+          )}
+        </div>
+      )}
+
+      {safeModel.isEmpty || rangeError ? (
         <p className="api-value-card__status" role="status">
-          No data for {periodLabel}.
+          {rangeError ? "Adjust the dates to load a range." : `No data for ${periodLabel}.`}
         </p>
       ) : (
         <div className="api-value-card__body">
@@ -224,7 +317,7 @@ export function TotalApiValueCard() {
               </g>
             </svg>
             <div className="api-value-card__ring-center">
-              <strong>{formatValue(model.total)}</strong>
+              <strong>{formatValue(safeModel.total)}</strong>
               <small>{periodLabel}</small>
             </div>
           </div>
@@ -238,7 +331,7 @@ export function TotalApiValueCard() {
           </div>
 
           <ul className="api-value-card__legend">
-            {model.slices.map((slice) => (
+            {safeModel.slices.map((slice) => (
               <li className="api-value-card__legend-row" key={slice.providerId}>
                 <span
                   className="api-value-card__legend-dot"
@@ -283,7 +376,7 @@ export function TotalApiValueCard() {
         </div>
       )}
 
-      {!model.isEmpty && (
+      {!safeModel.isEmpty && !rangeError && (
         <p className="api-value-card__note">
           <span className="api-value-card__estimate-marker" aria-hidden="true">
             ~
@@ -293,8 +386,8 @@ export function TotalApiValueCard() {
             <>
               {" "}
               {coveragePercent}% of tokens priced
-              {model.unpricedProviderIds.length > 0 &&
-                ` (unpriced models in ${model.unpricedProviderIds
+              {safeModel.unpricedProviderIds.length > 0 &&
+                ` (unpriced models in ${safeModel.unpricedProviderIds
                   .map(providerLabel)
                   .join(", ")})`}
               .

--- a/apps/desktop-tauri/src/lib/apiValueCard.test.ts
+++ b/apps/desktop-tauri/src/lib/apiValueCard.test.ts
@@ -18,7 +18,10 @@ const empty = period({});
 function provider(
   providerId: string,
   periods: Partial<
-    Record<"today" | "yesterday" | "thirtyDays" | "priorThirtyDays", LocalApiValuePeriod>
+    Record<
+      "today" | "yesterday" | "thirtyDays" | "priorThirtyDays" | "custom",
+      LocalApiValuePeriod
+    >
   >,
 ): LocalApiValueProvider {
   return {
@@ -27,6 +30,7 @@ function provider(
     yesterday: periods.yesterday ?? empty,
     thirtyDays: periods.thirtyDays ?? empty,
     priorThirtyDays: periods.priorThirtyDays ?? empty,
+    custom: periods.custom,
   };
 }
 
@@ -54,6 +58,27 @@ describe("buildApiValueCard", () => {
     expect(model.total).toBe(12);
     expect(model.coverage).toBe(1);
     expect(model.unpricedProviderIds).toHaveLength(0);
+  });
+
+  it("reads the custom period and skips period-over-period", () => {
+    const model = buildApiValueCard(
+      [
+        provider("codex", {
+          custom: period({
+            apiValueUsd: 42,
+            tokens: 4000,
+            pricedTokens: 4000,
+            totalTokens: 4000,
+            hasData: true,
+          }),
+        }),
+      ],
+      "custom",
+      "apiValue",
+    );
+    expect(model.isEmpty).toBe(false);
+    expect(model.total).toBe(42);
+    expect(model.periodChange).toBeNull();
   });
 
   it("ranks multiple providers by value with shares summing to 1", () => {

--- a/apps/desktop-tauri/src/lib/apiValueCard.ts
+++ b/apps/desktop-tauri/src/lib/apiValueCard.ts
@@ -3,8 +3,8 @@ import type { LocalApiValuePeriod, LocalApiValueProvider } from "../types/bridge
 /** Metric the aggregate card is showing. */
 export type ApiValueMetric = "apiValue" | "tokens";
 
-/** Which of the three periods is selected. */
-export type ApiValuePeriodKey = "today" | "yesterday" | "thirtyDays";
+/** Which period is selected on the Estimated API value card. */
+export type ApiValuePeriodKey = "today" | "yesterday" | "thirtyDays" | "custom";
 
 export interface ApiValueSlice {
   providerId: string;
@@ -51,12 +51,21 @@ export interface ApiValueCardModel {
   periodChange: ApiValuePeriodChange | null;
 }
 
+const EMPTY_PERIOD: LocalApiValuePeriod = {
+  apiValueUsd: 0,
+  tokens: 0,
+  pricedTokens: 0,
+  totalTokens: 0,
+  hasData: false,
+};
+
 function periodOf(
   provider: LocalApiValueProvider,
   key: ApiValuePeriodKey,
 ): LocalApiValuePeriod {
   if (key === "today") return provider.today;
   if (key === "yesterday") return provider.yesterday;
+  if (key === "custom") return provider.custom ?? EMPTY_PERIOD;
   return provider.thirtyDays;
 }
 
@@ -70,7 +79,7 @@ function priorPeriodOf(
   if (key === "thirtyDays") {
     return { period: provider.priorThirtyDays, versusLabel: "vs prior 30d" };
   }
-  // Yesterday has no stable prior on this card.
+  // Yesterday and custom ranges have no stable prior on this card.
   return null;
 }
 

--- a/apps/desktop-tauri/src/lib/tauri.ts
+++ b/apps/desktop-tauri/src/lib/tauri.ts
@@ -272,8 +272,15 @@ export function getProviderLocalUsageSummary(
   return invoke<ProviderLocalUsageSummary | null>("get_provider_local_usage_summary", { providerId });
 }
 
-export function getLocalApiValueTotals(): Promise<LocalApiValueProvider[]> {
-  return invoke<LocalApiValueProvider[]>("get_local_api_value_totals");
+/** Local API-value totals. Optional inclusive YYYY-MM-DD custom range fills `custom`. */
+export function getLocalApiValueTotals(options?: {
+  since?: string;
+  until?: string;
+}): Promise<LocalApiValueProvider[]> {
+  return invoke<LocalApiValueProvider[]>("get_local_api_value_totals", {
+    since: options?.since ?? null,
+    until: options?.until ?? null,
+  });
 }
 
 export function getCursorModelActivity(): Promise<CursorModelActivity[]> {

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -8303,6 +8303,37 @@ body:has(.dashboard-shell) #root {
   background: color-mix(in srgb, var(--text-primary) 12%, transparent);
   color: var(--text-primary);
 }
+.api-value-card__custom-range {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 10px 14px;
+  margin: 0 0 10px;
+}
+.api-value-card__date-field {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.api-value-card__date-field input[type="date"] {
+  min-width: 9.5rem;
+  padding: 4px 8px;
+  border: 1px solid color-mix(in srgb, var(--ceiling-glass-border) 70%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--surface-elevated, var(--bg-primary)) 88%, transparent);
+  color: var(--text-primary);
+  font-size: 11.5px;
+  font-weight: 500;
+}
+.api-value-card__range-error {
+  flex: 1 1 100%;
+  margin: 0;
+  font-size: 11px;
+  color: var(--danger, #e35d6a);
+}
 .api-value-card__body {
   display: flex;
   flex-wrap: wrap;

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -728,6 +728,8 @@ export interface LocalApiValueProvider {
   thirtyDays: LocalApiValuePeriod;
   /** Calendar days [today-60, today-30) for 30d dollar period-over-period. */
   priorThirtyDays: LocalApiValuePeriod;
+  /** Inclusive local-calendar custom range when since/until were requested. */
+  custom?: LocalApiValuePeriod | null;
   /** Last seven local calendar days, oldest first, today last. */
   lastSevenDays?: LocalApiValueDay[];
 }


### PR DESCRIPTION
## Summary

- Add Custom period with From/To date pickers on Estimated API value
- Backend `get_local_api_value_totals(since?, until?)` fills optional `custom` inclusive local-calendar window (max 366 days)
- Keep Today / Yesterday / 30 days; custom has no period-over-period delta

Implements #164

## Test plan

- [x] `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml parse_api_value_custom`
- [x] `npm test -- --run src/lib/apiValueCard.test.ts src/components/TotalApiValueCard.test.tsx`
- [ ] Manual: Charts → Custom → change range → totals update

## Notes for CodeRabbit

Cherry-picked onto `origin/main` without the unpushed spend-anomaly commit; conflict resolution intentionally omitted that unrelated code.