### PR TITLE
Tweak 1.5.15 release notes wording

### DIFF
--- a/.github/release-notes-1.5.15.md
+++ b/.github/release-notes-1.5.15.md
@@ -18,7 +18,7 @@ If Claude was Error with "sign-in was not found" while Charts still showed dolla
 
 ### Custom range on Estimated API value
 
-Charts → Estimated API value adds **Custom** next to Today / Yesterday / 30 days. Pick inclusive local From/To dates (up to 366 days) for every-other-week use or a single month.
+On Charts, Estimated API value adds **Custom** next to Today / Yesterday / 30 days. Pick inclusive local From/To dates (up to 366 days) for every-other-week use or a single month.
 
 ## Installers
 


### PR DESCRIPTION
Match the draft GitHub release body (no special arrows).