### PR TITLE
Fix Estimated API value custom date range

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -873,21 +873,23 @@ fn load_local_api_value_totals(
                 .unwrap_or_default();
             let daily_series = daily_series_from_report(&report.daily_costs);
             let custom = custom_range.map(|(starts_at, ends_at)| {
+                let start_day = starts_at.with_timezone(&Local).date_naive();
+                // ends_at is exclusive midnight; convert to inclusive local day.
+                let end_day =
+                    ends_at.with_timezone(&Local).date_naive() - chrono::Duration::days(1);
                 let from_window = report
                     .current_windows
                     .get("custom")
                     .cloned()
                     .map(|summary| api_value_period(provider_id, &summary))
-                    .unwrap_or_else(|| empty_api_value_period());
+                    .unwrap_or_else(empty_api_value_period);
+                let from_daily = period_from_daily_series(&daily_series, start_day, end_day);
+                // Prefer the richer window (tokens + dollars). If the window is
+                // empty but daily dollars exist, use daily so Custom never lies.
                 if from_window.has_data {
                     from_window
                 } else {
-                    // Belt-and-suspenders: same dollars as the chart series.
-                    period_from_daily_series(
-                        &daily_series,
-                        starts_at.with_timezone(&Local).date_naive(),
-                        ends_at.with_timezone(&Local).date_naive() - chrono::Duration::days(1),
-                    )
+                    from_daily
                 }
             });
             // Oldest first so the trend reads left to right, ending today.
@@ -966,6 +968,7 @@ fn period_from_daily_series(
         return empty_api_value_period();
     }
     let mut api_value_usd = 0.0;
+    let mut tokens: u64 = 0;
     let mut has_data = false;
     for day in daily_series {
         let Ok(date) = NaiveDate::parse_from_str(&day.date, "%Y-%m-%d") else {
@@ -978,12 +981,13 @@ fn period_from_daily_series(
             has_data = true;
         }
         api_value_usd += day.api_value_usd;
+        tokens = tokens.saturating_add(day.tokens);
     }
     LocalApiValuePeriod {
         api_value_usd,
-        tokens: 0,
-        priced_tokens: 0,
-        total_tokens: 0,
+        tokens,
+        priced_tokens: tokens,
+        total_tokens: tokens,
         has_data: has_data || api_value_usd > 0.0,
     }
 }
@@ -1789,11 +1793,11 @@ mod tests {
     use super::{
         CostFetchFailure, LocalEffortCost, LocalModelCost, LocalPlanUsage, LocalProjectCost,
         LocalTokenBreakdown, LocalUsageWindowRequest, ProviderLocalUsageSummary, api_value_period,
-        comparison_period_specs, cost_fetch_failure_allows_early_retry, effort_breakdown,
-        format_cost_csv, local_midnight_in_tz, local_usage_summary_from_report,
+        comparison_period_specs, cost_fetch_failure_allows_early_retry, daily_series_from_report,
+        effort_breakdown, format_cost_csv, local_midnight_in_tz, local_usage_summary_from_report,
         local_yesterday_window_utc, localized_estimate_note, model_breakdown,
-        parse_api_value_custom_range, pricing_coverage_tokens, project_breakdown,
-        spend_budget_period_details, token_breakdown, token_cost_cache_is_fresh,
+        parse_api_value_custom_range, period_from_daily_series, pricing_coverage_tokens,
+        project_breakdown, spend_budget_period_details, token_breakdown, token_cost_cache_is_fresh,
     };
     use crate::commands::is_provider_cache_fresh;
     use chrono::{Local, LocalResult, NaiveDate, NaiveTime, TimeZone, Timelike, Utc};
@@ -2621,5 +2625,34 @@ mod tests {
         assert!(parse_api_value_custom_range("2026-07-10", "2026-07-01", today).is_err());
         assert!(parse_api_value_custom_range("2026-07-01", "2026-08-01", today).is_err());
         assert!(parse_api_value_custom_range("not-a-date", "2026-07-01", today).is_err());
+    }
+
+    #[test]
+    fn period_from_daily_series_sums_inclusive_range_only() {
+        let series = daily_series_from_report(&[
+            ("2026-07-01".into(), 10.0),
+            ("2026-07-02".into(), 5.0),
+            ("2026-07-15".into(), 1.0),
+            ("2026-07-28".into(), 99.0),
+        ]);
+        let period = period_from_daily_series(
+            &series,
+            NaiveDate::from_ymd_opt(2026, 7, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 7, 15).unwrap(),
+        );
+        assert!(period.has_data);
+        assert!((period.api_value_usd - 16.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn period_from_daily_series_empty_when_range_misses() {
+        let series = daily_series_from_report(&[("2026-06-01".into(), 10.0)]);
+        let period = period_from_daily_series(
+            &series,
+            NaiveDate::from_ymd_opt(2026, 7, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 7, 15).unwrap(),
+        );
+        assert!(!period.has_data);
+        assert_eq!(period.api_value_usd, 0.0);
     }
 }

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -314,6 +314,10 @@ pub struct LocalApiValueProvider {
     /// Last seven local calendar days, oldest first, today last.
     #[serde(default)]
     pub last_seven_days: Vec<LocalApiValueDay>,
+    /// Scanned local calendar days (oldest first). Used for custom ranges and
+    /// trends so the card never depends only on a single window key.
+    #[serde(default)]
+    pub daily_series: Vec<LocalApiValueDay>,
 }
 
 /// One local calendar day of estimated API value, for the card's trend.
@@ -727,11 +731,23 @@ pub(crate) async fn load_spend_budget_total(
 
 /// Inclusive local-calendar custom range for Estimated API value (YYYY-MM-DD).
 const API_VALUE_CUSTOM_MAX_DAYS: i64 = 366;
+/// Default scan horizon so custom ranges and daily series cover a full month+.
+const API_VALUE_DEFAULT_SCAN_DAYS: u32 = 90;
 #[tauri::command]
 pub async fn get_local_api_value_totals(
     since: Option<String>,
     until: Option<String>,
 ) -> Result<Vec<LocalApiValueProvider>, String> {
+    let since = since
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let until = until
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
     let custom = match (since.as_deref(), until.as_deref()) {
         (None, None) => None,
         (Some(since), Some(until)) => Some(parse_api_value_custom_range(
@@ -799,9 +815,10 @@ fn load_local_api_value_totals(
         .map(|(start, _)| {
             let start_date = start.with_timezone(&Local).date_naive();
             let days = (today - start_date).num_days().max(0) as u32 + 1;
-            days.clamp(60, API_VALUE_CUSTOM_MAX_DAYS as u32)
+            days.max(API_VALUE_DEFAULT_SCAN_DAYS)
+                .min(API_VALUE_CUSTOM_MAX_DAYS as u32)
         })
-        .unwrap_or(60);
+        .unwrap_or(API_VALUE_DEFAULT_SCAN_DAYS);
     API_VALUE_PROVIDERS
         .iter()
         .filter_map(|provider_id| {
@@ -854,13 +871,24 @@ fn load_local_api_value_totals(
                 .get("prior_thirty")
                 .cloned()
                 .unwrap_or_default();
-            let custom = custom_range.map(|_| {
-                let summary = report
+            let daily_series = daily_series_from_report(&report.daily_costs);
+            let custom = custom_range.map(|(starts_at, ends_at)| {
+                let from_window = report
                     .current_windows
                     .get("custom")
                     .cloned()
-                    .unwrap_or_default();
-                api_value_period(provider_id, &summary)
+                    .map(|summary| api_value_period(provider_id, &summary))
+                    .unwrap_or_else(|| empty_api_value_period());
+                if from_window.has_data {
+                    from_window
+                } else {
+                    // Belt-and-suspenders: same dollars as the chart series.
+                    period_from_daily_series(
+                        &daily_series,
+                        starts_at.with_timezone(&Local).date_naive(),
+                        ends_at.with_timezone(&Local).date_naive() - chrono::Duration::days(1),
+                    )
+                }
             });
             // Oldest first so the trend reads left to right, ending today.
             let last_seven_days = (0..7i64)
@@ -888,16 +916,76 @@ fn load_local_api_value_totals(
                 prior_thirty_days: api_value_period(provider_id, &prior_thirty_days),
                 custom,
                 last_seven_days,
+                daily_series,
             };
             // Omit providers with no source data in any period.
             (provider.today.has_data
                 || provider.yesterday.has_data
                 || provider.thirty_days.has_data
                 || provider.prior_thirty_days.has_data
-                || provider.custom.as_ref().is_some_and(|p| p.has_data))
+                || provider.custom.as_ref().is_some_and(|p| p.has_data)
+                || provider
+                    .daily_series
+                    .iter()
+                    .any(|day| day.api_value_usd > 0.0))
             .then_some(provider)
         })
         .collect()
+}
+
+fn empty_api_value_period() -> LocalApiValuePeriod {
+    LocalApiValuePeriod {
+        api_value_usd: 0.0,
+        tokens: 0,
+        priced_tokens: 0,
+        total_tokens: 0,
+        has_data: false,
+    }
+}
+
+fn daily_series_from_report(daily_costs: &[(String, f64)]) -> Vec<LocalApiValueDay> {
+    let mut days: Vec<LocalApiValueDay> = daily_costs
+        .iter()
+        .map(|(date, api_value_usd)| LocalApiValueDay {
+            date: date.clone(),
+            api_value_usd: *api_value_usd,
+            tokens: 0,
+        })
+        .collect();
+    days.sort_by(|left, right| left.date.cmp(&right.date));
+    days
+}
+
+/// Inclusive local-calendar sum from the daily dollar series.
+fn period_from_daily_series(
+    daily_series: &[LocalApiValueDay],
+    start: NaiveDate,
+    end_inclusive: NaiveDate,
+) -> LocalApiValuePeriod {
+    if start > end_inclusive {
+        return empty_api_value_period();
+    }
+    let mut api_value_usd = 0.0;
+    let mut has_data = false;
+    for day in daily_series {
+        let Ok(date) = NaiveDate::parse_from_str(&day.date, "%Y-%m-%d") else {
+            continue;
+        };
+        if date < start || date > end_inclusive {
+            continue;
+        }
+        if day.api_value_usd > 0.0 || day.tokens > 0 {
+            has_data = true;
+        }
+        api_value_usd += day.api_value_usd;
+    }
+    LocalApiValuePeriod {
+        api_value_usd,
+        tokens: 0,
+        priced_tokens: 0,
+        total_tokens: 0,
+        has_data: has_data || api_value_usd > 0.0,
+    }
 }
 
 /// One model's local Cursor activity. This is code-contribution activity from

--- a/apps/desktop-tauri/src/components/TotalApiValueCard.test.tsx
+++ b/apps/desktop-tauri/src/components/TotalApiValueCard.test.tsx
@@ -84,22 +84,48 @@ describe("TotalApiValueCard", () => {
   });
 
   it("loads a custom date range when Custom is selected", async () => {
-    tauriMocks.getLocalApiValueTotals.mockResolvedValue([
-      {
-        providerId: "codex",
-        today: period({ apiValueUsd: 1, tokens: 10, pricedTokens: 10, totalTokens: 10, hasData: true }),
-        yesterday: period({}),
-        thirtyDays: period({}),
-        priorThirtyDays: period({}),
-        custom: period({
-          apiValueUsd: 55,
-          tokens: 5000,
-          pricedTokens: 5000,
-          totalTokens: 5000,
-          hasData: true,
-        }),
-      },
-    ]);
+    tauriMocks.getLocalApiValueTotals
+      .mockResolvedValueOnce([
+        {
+          providerId: "codex",
+          today: period({
+            apiValueUsd: 1,
+            tokens: 10,
+            pricedTokens: 10,
+            totalTokens: 10,
+            hasData: true,
+          }),
+          yesterday: period({}),
+          thirtyDays: period({}),
+          priorThirtyDays: period({}),
+        },
+      ])
+      .mockResolvedValue([
+        {
+          providerId: "codex",
+          today: period({
+            apiValueUsd: 1,
+            tokens: 10,
+            pricedTokens: 10,
+            totalTokens: 10,
+            hasData: true,
+          }),
+          yesterday: period({}),
+          thirtyDays: period({}),
+          priorThirtyDays: period({}),
+          custom: period({
+            apiValueUsd: 55,
+            tokens: 5000,
+            pricedTokens: 5000,
+            totalTokens: 5000,
+            hasData: true,
+          }),
+          dailySeries: [
+            { date: "2026-07-01", apiValueUsd: 20, tokens: 100 },
+            { date: "2026-07-15", apiValueUsd: 35, tokens: 200 },
+          ],
+        },
+      ]);
     const { getByText, getAllByText, getByLabelText, findAllByText } = render(
       <TotalApiValueCard />,
     );
@@ -116,4 +142,5 @@ describe("TotalApiValueCard", () => {
     expect(getByLabelText("Custom date range")).toBeTruthy();
     expect((await findAllByText("$55.00")).length).toBeGreaterThan(0);
   });
+
 });

--- a/apps/desktop-tauri/src/components/TotalApiValueCard.tsx
+++ b/apps/desktop-tauri/src/components/TotalApiValueCard.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { getLocalApiValueTotals } from "../lib/tauri";
-import type { LocalApiValueProvider } from "../types/bridge";
+import type { LocalApiValueDay, LocalApiValueProvider } from "../types/bridge";
 import { getProviderIcon } from "./providers/providerIcons";
 import {
   buildApiValueCard,
   formatPeriodChange,
+  periodFromDailySeries,
   ringSegments,
   type ApiValueMetric,
   type ApiValuePeriodKey,
@@ -57,9 +58,9 @@ function defaultCustomRange(): { since: string; until: string } {
   return { since: formatLocalDate(since), until: formatLocalDate(until) };
 }
 
+/** Compact range label without fancy dashes (plain hyphen). */
 function shortRangeLabel(since: string, until: string): string {
   if (since === until) return since;
-  // Compact: "Jul 1 – Jul 7" when year matches; else keep ISO.
   const parse = (iso: string) => {
     const [y, m, d] = iso.split("-").map(Number);
     if (!y || !m || !d) return null;
@@ -67,13 +68,23 @@ function shortRangeLabel(since: string, until: string): string {
   };
   const a = parse(since);
   const b = parse(until);
-  if (!a || !b) return `${since} – ${until}`;
+  if (!a || !b) return `${since} - ${until}`;
   const fmt = (date: Date) =>
     date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
   if (a.getFullYear() === b.getFullYear()) {
-    return `${fmt(a)} – ${fmt(b)}`;
+    return `${fmt(a)} - ${fmt(b)}`;
   }
-  return `${since} – ${until}`;
+  return `${since} - ${until}`;
+}
+
+function tauriErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  if (err && typeof err === "object" && "message" in err) {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return String(err ?? "");
 }
 
 type TrendDay = {
@@ -85,11 +96,29 @@ type TrendDay = {
 
 const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
-/** Sum each provider's seven-day series into one per-day trend. */
-function buildTrend(providers: LocalApiValueProvider[]): TrendDay[] {
+function dayLabel(date: string): string {
+  const parsed = new Date(`${date}T12:00:00`);
+  if (Number.isNaN(parsed.getTime())) return date.slice(5);
+  return WEEKDAYS[parsed.getDay()];
+}
+
+/** Sum each provider's day series into one per-day trend. */
+function buildTrend(
+  providers: LocalApiValueProvider[],
+  period: ApiValuePeriodKey,
+  since: string,
+  until: string,
+): TrendDay[] {
   const totals = new Map<string, number>();
   for (const provider of providers) {
-    for (const day of provider.lastSevenDays ?? []) {
+    const series: LocalApiValueDay[] =
+      period === "custom"
+        ? (provider.dailySeries?.length
+            ? provider.dailySeries
+            : provider.lastSevenDays ?? [])
+        : (provider.lastSevenDays ?? []);
+    for (const day of series) {
+      if (period === "custom" && (day.date < since || day.date > until)) continue;
       totals.set(day.date, (totals.get(day.date) ?? 0) + day.apiValueUsd);
     }
   }
@@ -98,13 +127,9 @@ function buildTrend(providers: LocalApiValueProvider[]): TrendDay[] {
   const peak = Math.max(...dates.map((date) => totals.get(date) ?? 0));
   return dates.map((date) => {
     const value = totals.get(date) ?? 0;
-    // Parse as local noon so a date-only string cannot slip a day via UTC.
-    const parsed = new Date(`${date}T12:00:00`);
     return {
       date,
-      label: Number.isNaN(parsed.getTime())
-        ? date.slice(5)
-        : WEEKDAYS[parsed.getDay()],
+      label: dayLabel(date),
       value,
       height: peak > 0 ? Math.max(3, (value / peak) * 100) : 3,
     };
@@ -121,37 +146,67 @@ function buildTrend(providers: LocalApiValueProvider[]): TrendDay[] {
 export function TotalApiValueCard() {
   const [providers, setProviders] = useState<LocalApiValueProvider[] | null>(null);
   const [failed, setFailed] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [period, setPeriod] = useState<ApiValuePeriodKey>("today");
   const [metric, setMetric] = useState<ApiValueMetric>("apiValue");
   const [customSince, setCustomSince] = useState(() => defaultCustomRange().since);
   const [customUntil, setCustomUntil] = useState(() => defaultCustomRange().until);
   const [rangeError, setRangeError] = useState<string | null>(null);
 
+  const customRange = useMemo(
+    () =>
+      period === "custom" && customSince && customUntil
+        ? { since: customSince, until: customUntil }
+        : null,
+    [period, customSince, customUntil],
+  );
+
   useEffect(() => {
     let live = true;
     setFailed(false);
     setRangeError(null);
+    setLoading(true);
 
     const options =
-      period === "custom"
+      period === "custom" && customSince && customUntil
         ? { since: customSince, until: customUntil }
         : undefined;
 
     getLocalApiValueTotals(options)
       .then((rows) => {
         if (!live) return;
-        setProviders(rows);
+        // If the backend forgot custom but daily series covers the range, fill
+        // it here so the ring never sits empty after a successful scan.
+        if (period === "custom" && customSince && customUntil) {
+          setProviders(
+            rows.map((row) => {
+              if (row.custom?.hasData) return row;
+              const series = row.dailySeries?.length
+                ? row.dailySeries
+                : row.lastSevenDays;
+              const synthesized = periodFromDailySeries(
+                series,
+                customSince,
+                customUntil,
+              );
+              return synthesized.hasData ? { ...row, custom: synthesized } : row;
+            }),
+          );
+        } else {
+          setProviders(rows);
+        }
       })
       .catch((err: unknown) => {
         if (!live) return;
-        const message = err instanceof Error ? err.message : String(err ?? "");
-        // Backend validation (inverted range, future end, bad format) should
-        // stay on the custom pickers instead of blanking the whole card.
+        const message = tauriErrorMessage(err);
         if (period === "custom" && message) {
           setRangeError(message);
           return;
         }
         setFailed(true);
+      })
+      .finally(() => {
+        if (live) setLoading(false);
       });
     return () => {
       live = false;
@@ -159,8 +214,11 @@ export function TotalApiValueCard() {
   }, [period, customSince, customUntil]);
 
   const model = useMemo(
-    () => (providers ? buildApiValueCard(providers, period, metric) : null),
-    [providers, period, metric],
+    () =>
+      providers
+        ? buildApiValueCard(providers, period, metric, customRange)
+        : null,
+    [providers, period, metric, customRange],
   );
 
   const formatValue = (value: number) =>
@@ -172,6 +230,7 @@ export function TotalApiValueCard() {
       : (PERIODS.find((p) => p.key === period)?.label ?? "");
   const metricLabel = METRICS.find((m) => m.key === metric)?.label ?? "";
   const todayIso = formatLocalDate(new Date());
+  const ringCaption = period === "custom" ? "Custom" : periodLabel;
 
   if (failed) {
     return (
@@ -181,7 +240,7 @@ export function TotalApiValueCard() {
     );
   }
 
-  if (!model && !rangeError) {
+  if (!model && loading) {
     return (
       <section className="api-value-card" aria-label="Total API value">
         <p className="api-value-card__status">Reading local usage…</p>
@@ -189,27 +248,33 @@ export function TotalApiValueCard() {
     );
   }
 
-  const safeModel = model ?? buildApiValueCard([], period, metric);
+  const safeModel = model ?? buildApiValueCard([], period, metric, customRange);
   const segments = ringSegments(safeModel.slices, CIRCUMFERENCE);
   const coveragePercent =
     safeModel.coverage == null ? null : Math.round(safeModel.coverage * 100);
-  // Compare the raw ratio so 99.6% (rounds to 100) still shows the coverage
-  // note when any tokens are unpriced.
   const showCoverage = safeModel.coverage != null && safeModel.coverage < 1;
   const periodChangeLabel =
     safeModel.periodChange && metric === "apiValue"
       ? formatPeriodChange(safeModel.periodChange)
       : null;
 
-  // Seven-day trend, summed across providers per day. Heights are relative to
-  // the busiest day so a quiet day still renders a visible sliver.
-  const trend = buildTrend(providers ?? []);
+  const trend = buildTrend(
+    providers ?? [],
+    period,
+    customSince,
+    customUntil,
+  );
+  const trendTotal = trend.reduce((sum, day) => sum + day.value, 0);
+  const trendTitle =
+    period === "custom" ? shortRangeLabel(customSince, customUntil) : "Last 7 days";
 
-  const ariaSummary = safeModel.isEmpty
-    ? `No local ${metricLabel} data for ${periodLabel}.`
-    : `${metricLabel} for ${periodLabel}: ${formatValue(safeModel.total)} across ${safeModel.slices
-        .map((slice) => providerLabel(slice.providerId))
-        .join(", ")}.`;
+  const ariaSummary = loading
+    ? `Loading ${metricLabel} for ${periodLabel}.`
+    : safeModel.isEmpty
+      ? `No local ${metricLabel} data for ${periodLabel}.`
+      : `${metricLabel} for ${periodLabel}: ${formatValue(safeModel.total)} across ${safeModel.slices
+          .map((slice) => providerLabel(slice.providerId))
+          .join(", ")}.`;
 
   return (
     <section className="api-value-card" aria-label="Total API value">
@@ -217,7 +282,7 @@ export function TotalApiValueCard() {
         <div>
           <h3 className="api-value-card__title">Estimated API value</h3>
           <p className="api-value-card__subtitle">
-            API-equivalent estimate from local logs — not subscription spend.
+            API-equivalent estimate from local logs - not subscription spend.
           </p>
         </div>
         <div className="api-value-card__switchers">
@@ -263,6 +328,9 @@ export function TotalApiValueCard() {
               onChange={(event) => setCustomSince(event.target.value)}
             />
           </label>
+          <span className="api-value-card__date-sep" aria-hidden>
+            to
+          </span>
           <label className="api-value-card__date-field">
             <span>To</span>
             <input
@@ -273,6 +341,9 @@ export function TotalApiValueCard() {
               onChange={(event) => setCustomUntil(event.target.value)}
             />
           </label>
+          <span className="api-value-card__range-pill" title={periodLabel}>
+            {periodLabel}
+          </span>
           {rangeError && (
             <p className="api-value-card__range-error" role="alert">
               {rangeError}
@@ -281,79 +352,85 @@ export function TotalApiValueCard() {
         </div>
       )}
 
-      {safeModel.isEmpty || rangeError ? (
+      {loading ? (
         <p className="api-value-card__status" role="status">
-          {rangeError ? "Adjust the dates to load a range." : `No data for ${periodLabel}.`}
+          Reading local usage…
         </p>
       ) : (
         <div className="api-value-card__body">
           <div className="api-value-card__ring-wrap">
-          <div className="api-value-card__ring" role="img" aria-label={ariaSummary}>
-            <svg viewBox="0 0 120 120" className="api-value-card__ring-svg">
-              <circle
-                cx="60"
-                cy="60"
-                r={RING_RADIUS}
-                fill="none"
-                stroke="var(--ceiling-glass-border)"
-                strokeWidth={RING_THICKNESS}
-                opacity={0.35}
-              />
-              <g transform="rotate(-90 60 60)">
-                {segments.map((segment) => (
-                  <circle
-                    key={segment.providerId}
-                    cx="60"
-                    cy="60"
-                    r={RING_RADIUS}
-                    fill="none"
-                    stroke={providerColor(segment.providerId)}
-                    strokeWidth={RING_THICKNESS}
-                    strokeDasharray={`${segment.dash} ${CIRCUMFERENCE - segment.dash}`}
-                    strokeDashoffset={segment.offset}
-                    strokeLinecap="butt"
-                  />
-                ))}
-              </g>
-            </svg>
-            <div className="api-value-card__ring-center">
-              <strong>{formatValue(safeModel.total)}</strong>
-              <small>{periodLabel}</small>
-            </div>
-          </div>
-          {/* Below the ring, not inside it: the change label collided with the
-              stroke once the total needed the full centre. Rendered even when
-              empty so the card keeps one height across periods and metrics —
-              a shrinking card toggled the scrollbar and reflowed the header. */}
-          <span className="api-value-card__period-change">
-            {periodChangeLabel ?? ""}
-          </span>
-          </div>
-
-          <ul className="api-value-card__legend">
-            {safeModel.slices.map((slice) => (
-              <li className="api-value-card__legend-row" key={slice.providerId}>
-                <span
-                  className="api-value-card__legend-dot"
-                  style={{ background: providerColor(slice.providerId) }}
-                  aria-hidden="true"
+            <div className="api-value-card__ring" role="img" aria-label={ariaSummary}>
+              <svg viewBox="0 0 120 120" className="api-value-card__ring-svg">
+                <circle
+                  cx="60"
+                  cy="60"
+                  r={RING_RADIUS}
+                  fill="none"
+                  stroke="var(--ceiling-glass-border)"
+                  strokeWidth={RING_THICKNESS}
+                  opacity={0.35}
                 />
-                <span className="api-value-card__legend-name">
-                  {providerLabel(slice.providerId)}
-                </span>
-                <span className="api-value-card__legend-share">
-                  {Math.round(slice.share * 100)}%
-                </span>
-                <span className="api-value-card__legend-value">{formatValue(slice.value)}</span>
-              </li>
-            ))}
-          </ul>
+                <g transform="rotate(-90 60 60)">
+                  {segments.map((segment) => (
+                    <circle
+                      key={segment.providerId}
+                      cx="60"
+                      cy="60"
+                      r={RING_RADIUS}
+                      fill="none"
+                      stroke={providerColor(segment.providerId)}
+                      strokeWidth={RING_THICKNESS}
+                      strokeDasharray={`${segment.dash} ${CIRCUMFERENCE - segment.dash}`}
+                      strokeDashoffset={segment.offset}
+                      strokeLinecap="butt"
+                    />
+                  ))}
+                </g>
+              </svg>
+              <div className="api-value-card__ring-center">
+                <strong>
+                  {safeModel.isEmpty || rangeError ? formatValue(0) : formatValue(safeModel.total)}
+                </strong>
+                <small>{ringCaption}</small>
+              </div>
+            </div>
+            <span className="api-value-card__period-change">
+              {rangeError
+                ? "Adjust the dates to load a range."
+                : safeModel.isEmpty
+                  ? `No data for ${periodLabel}`
+                  : (periodChangeLabel ?? "")}
+            </span>
+          </div>
 
-          {trend.length > 0 && (
+          {!safeModel.isEmpty && !rangeError && (
+            <ul className="api-value-card__legend">
+              {safeModel.slices.map((slice) => (
+                <li className="api-value-card__legend-row" key={slice.providerId}>
+                  <span
+                    className="api-value-card__legend-dot"
+                    style={{ background: providerColor(slice.providerId) }}
+                    aria-hidden="true"
+                  />
+                  <span className="api-value-card__legend-name">
+                    {providerLabel(slice.providerId)}
+                  </span>
+                  <span className="api-value-card__legend-share">
+                    {Math.round(slice.share * 100)}%
+                  </span>
+                  <span className="api-value-card__legend-value">
+                    {formatValue(slice.value)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {trend.length > 0 && !rangeError && (
             <div className="api-value-card__trend">
               <div className="api-value-card__trend-head">
-                <span>Last 7 days</span>
-                <strong>{formatUsd(trend.reduce((sum, day) => sum + day.value, 0))}</strong>
+                <span>{trendTitle}</span>
+                <strong>{formatUsd(trendTotal)}</strong>
               </div>
               <div className="api-value-card__trend-bars">
                 {trend.map((day, index) => (
@@ -362,7 +439,7 @@ export function TotalApiValueCard() {
                     className="api-value-card__trend-bar"
                     data-today={index === trend.length - 1}
                     style={{ height: `${day.height}%` }}
-                    title={`${day.label}: ${formatUsd(day.value)}`}
+                    title={`${day.date}: ${formatUsd(day.value)}`}
                   />
                 ))}
               </div>
@@ -376,7 +453,7 @@ export function TotalApiValueCard() {
         </div>
       )}
 
-      {!safeModel.isEmpty && !rangeError && (
+      {!loading && !safeModel.isEmpty && !rangeError && (
         <p className="api-value-card__note">
           <span className="api-value-card__estimate-marker" aria-hidden="true">
             ~

--- a/apps/desktop-tauri/src/lib/apiValueCard.test.ts
+++ b/apps/desktop-tauri/src/lib/apiValueCard.test.ts
@@ -81,6 +81,31 @@ describe("buildApiValueCard", () => {
     expect(model.periodChange).toBeNull();
   });
 
+  it("falls back to dailySeries when custom window is empty", () => {
+    const model = buildApiValueCard(
+      [
+        {
+          providerId: "codex",
+          today: empty,
+          yesterday: empty,
+          thirtyDays: empty,
+          priorThirtyDays: empty,
+          custom: period({ hasData: false }),
+          dailySeries: [
+            { date: "2026-07-01", apiValueUsd: 10, tokens: 100 },
+            { date: "2026-07-15", apiValueUsd: 5, tokens: 50 },
+            { date: "2026-07-28", apiValueUsd: 99, tokens: 999 },
+          ],
+        },
+      ],
+      "custom",
+      "apiValue",
+      { since: "2026-07-01", until: "2026-07-15" },
+    );
+    expect(model.isEmpty).toBe(false);
+    expect(model.total).toBe(15);
+  });
+
   it("ranks multiple providers by value with shares summing to 1", () => {
     const model = buildApiValueCard(
       [

--- a/apps/desktop-tauri/src/lib/apiValueCard.ts
+++ b/apps/desktop-tauri/src/lib/apiValueCard.ts
@@ -1,10 +1,20 @@
-import type { LocalApiValuePeriod, LocalApiValueProvider } from "../types/bridge";
+import type {
+  LocalApiValueDay,
+  LocalApiValuePeriod,
+  LocalApiValueProvider,
+} from "../types/bridge";
 
 /** Metric the aggregate card is showing. */
 export type ApiValueMetric = "apiValue" | "tokens";
 
 /** Which period is selected on the Estimated API value card. */
 export type ApiValuePeriodKey = "today" | "yesterday" | "thirtyDays" | "custom";
+
+/** Inclusive YYYY-MM-DD bounds for the Custom period. */
+export type ApiValueCustomRange = {
+  since: string;
+  until: string;
+};
 
 export interface ApiValueSlice {
   providerId: string;
@@ -59,13 +69,52 @@ const EMPTY_PERIOD: LocalApiValuePeriod = {
   hasData: false,
 };
 
+/** Sum scanned daily dollars into a period for an inclusive local date range. */
+export function periodFromDailySeries(
+  days: LocalApiValueDay[] | undefined,
+  since: string,
+  until: string,
+): LocalApiValuePeriod {
+  if (!days?.length || !since || !until || since > until) {
+    return EMPTY_PERIOD;
+  }
+  let apiValueUsd = 0;
+  let tokens = 0;
+  let hasData = false;
+  for (const day of days) {
+    if (day.date < since || day.date > until) continue;
+    if (day.apiValueUsd > 0 || day.tokens > 0) hasData = true;
+    apiValueUsd += day.apiValueUsd;
+    tokens += day.tokens;
+  }
+  return {
+    apiValueUsd,
+    tokens,
+    pricedTokens: tokens,
+    totalTokens: tokens,
+    hasData: hasData || apiValueUsd > 0,
+  };
+}
+
 function periodOf(
   provider: LocalApiValueProvider,
   key: ApiValuePeriodKey,
+  customRange?: ApiValueCustomRange | null,
 ): LocalApiValuePeriod {
   if (key === "today") return provider.today;
   if (key === "yesterday") return provider.yesterday;
-  if (key === "custom") return provider.custom ?? EMPTY_PERIOD;
+  if (key === "custom") {
+    if (provider.custom?.hasData) return provider.custom;
+    // Fallback when the dedicated custom window is empty but daily series has
+    // dollars for the selected dates (the bug users hit on 1.5.15).
+    if (customRange) {
+      const series = provider.dailySeries?.length
+        ? provider.dailySeries
+        : provider.lastSevenDays;
+      return periodFromDailySeries(series, customRange.since, customRange.until);
+    }
+    return provider.custom ?? EMPTY_PERIOD;
+  }
   return provider.thirtyDays;
 }
 
@@ -81,6 +130,14 @@ function priorPeriodOf(
   }
   // Yesterday and custom ranges have no stable prior on this card.
   return null;
+}
+
+function pickPeriod(
+  provider: LocalApiValueProvider,
+  key: ApiValuePeriodKey,
+  customRange?: ApiValueCustomRange | null,
+): LocalApiValuePeriod {
+  return periodOf(provider, key, customRange);
 }
 
 function metricValue(period: LocalApiValuePeriod, metric: ApiValueMetric): number {
@@ -113,9 +170,13 @@ export function buildApiValueCard(
   providers: LocalApiValueProvider[],
   periodKey: ApiValuePeriodKey,
   metric: ApiValueMetric,
+  customRange?: ApiValueCustomRange | null,
 ): ApiValueCardModel {
   const rows = providers
-    .map((provider) => ({ provider, period: periodOf(provider, periodKey) }))
+    .map((provider) => ({
+      provider,
+      period: pickPeriod(provider, periodKey, customRange),
+    }))
     .filter(({ period }) => period.hasData);
 
   const total = rows.reduce((sum, { period }) => sum + metricValue(period, metric), 0);
@@ -127,7 +188,7 @@ export function buildApiValueCard(
       ? []
       : providers
           .map((provider) => {
-            const period = periodOf(provider, periodKey);
+            const period = pickPeriod(provider, periodKey, customRange);
             return {
               providerId: provider.providerId,
               value: period.hasData ? metricValue(period, metric) : 0,

--- a/apps/desktop-tauri/src/lib/tauri.ts
+++ b/apps/desktop-tauri/src/lib/tauri.ts
@@ -277,10 +277,17 @@ export function getLocalApiValueTotals(options?: {
   since?: string;
   until?: string;
 }): Promise<LocalApiValueProvider[]> {
-  return invoke<LocalApiValueProvider[]>("get_local_api_value_totals", {
-    since: options?.since ?? null,
-    until: options?.until ?? null,
-  });
+  const since = options?.since?.trim();
+  const until = options?.until?.trim();
+  // Only send the range when both sides are real dates. Passing null for both
+  // on every call made custom loads easy to mis-handle; omit args for presets.
+  if (since && until) {
+    return invoke<LocalApiValueProvider[]>("get_local_api_value_totals", {
+      since,
+      until,
+    });
+  }
+  return invoke<LocalApiValueProvider[]>("get_local_api_value_totals");
 }
 
 export function getCursorModelActivity(): Promise<CursorModelActivity[]> {

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -8307,8 +8307,12 @@ body:has(.dashboard-shell) #root {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-end;
-  gap: 10px 14px;
-  margin: 0 0 10px;
+  gap: 8px 10px;
+  margin: 0 0 12px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--ceiling-glass-border) 70%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--text-primary) 4%, transparent);
 }
 .api-value-card__date-field {
   display: flex;
@@ -8327,6 +8331,24 @@ body:has(.dashboard-shell) #root {
   color: var(--text-primary);
   font-size: 11.5px;
   font-weight: 500;
+}
+.api-value-card__date-sep {
+  align-self: center;
+  margin-bottom: 2px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.api-value-card__range-pill {
+  margin-left: auto;
+  align-self: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-primary) 10%, transparent);
+  color: var(--text-primary);
+  font-size: 10.5px;
+  font-weight: 700;
+  white-space: nowrap;
 }
 .api-value-card__range-error {
   flex: 1 1 100%;

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -732,6 +732,8 @@ export interface LocalApiValueProvider {
   custom?: LocalApiValuePeriod | null;
   /** Last seven local calendar days, oldest first, today last. */
   lastSevenDays?: LocalApiValueDay[];
+  /** Scanned local days (oldest first) for custom ranges and trends. */
+  dailySeries?: LocalApiValueDay[];
 }
 
 /** One local calendar day of estimated API value, for the card's trend. */

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -1442,12 +1442,9 @@ impl<'a> CodexReportRollups<'a> {
                 &self.range.until_key,
             )
         }) {
-            let Some(day_summary) = self.daily.get_mut(&record.day_key) else {
-                continue;
-            };
-            if let Some(cost) = add_codex_record_to_summary(day_summary, record) {
-                day_summary.total_cost_usd += cost;
-            }
+            // Always credit caller windows first. A missing daily bucket must not
+            // drop custom/reset-window totals (that is what broke Estimated API
+            // value custom ranges when a day key was absent from the map).
             if let Some(cost) = add_codex_record_to_summary(&mut file_summary, record) {
                 file_summary.total_cost_usd += cost;
             }
@@ -1461,6 +1458,12 @@ impl<'a> CodexReportRollups<'a> {
                     }
                 },
             );
+            let Some(day_summary) = self.daily.get_mut(&record.day_key) else {
+                continue;
+            };
+            if let Some(cost) = add_codex_record_to_summary(day_summary, record) {
+                day_summary.total_cost_usd += cost;
+            }
             if let Some(date) = CostUsageDayRange::parse_day_key(&record.day_key) {
                 contributed_today |= date == self.today;
                 contributed_seven_days |= date >= self.seven_day_start;


### PR DESCRIPTION
## Summary

Custom date range on Estimated API value was showing **No data** even when local logs had spend for that window (reproduced on a machine where the scanner returned thousands of dollars for the same dates).

### Fixes
- Attach a scanned `dailySeries` and fall back to summing those days when the custom window is empty
- Only pass `since`/`until` when both dates are set
- Keep ring layout while loading; cleaner custom date bar with range pill
- Codex: credit current windows before requiring a daily bucket key

### Test plan
- [x] Frontend unit tests
- [x] Rust custom-range + cost_scanner tests  
- [ ] Manual: Charts → Custom → month range → ring and legend show dollars; trend follows selected range

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added custom date-range support for Estimated API Value totals and trends.
  - Custom ranges now include daily activity and per-provider breakdowns, even when aggregated data is unavailable.
  - Added clearer date-range labeling and selection controls.

- **Bug Fixes**
  - Improved usage accounting when daily records are incomplete.
  - Fixed date-range handling and empty-result behavior.

- **Style**
  - Updated the custom-range layout with clearer spacing, separators, and range styling.
  - Added loading and error states for API value cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->