### PR TITLE
Prefer Cursor Auto/API remaining capacity on the strip

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -119,13 +119,23 @@ fn cursor_actionable_windows(
 ) -> Vec<(Option<&str>, &crate::commands::RateWindowSnapshot)> {
     let mut out = Vec::new();
     if let Some(window) = snapshot.secondary.as_ref() {
-        out.push((snapshot.secondary_label.as_deref().or(Some("Auto")), window));
+        let label = snapshot
+            .secondary_label
+            .as_deref()
+            .map(str::trim)
+            .filter(|label| !label.is_empty())
+            .unwrap_or("Auto");
+        out.push((Some(label), window));
     }
     for extra in &snapshot.extra_rate_windows {
         if extra.id != "cursor-api" {
             continue;
         }
-        out.push((Some(extra.title.as_str()), &extra.window));
+        let label = match extra.title.trim() {
+            "" => "API",
+            label => label,
+        };
+        out.push((Some(label), &extra.window));
     }
     out
 }
@@ -2215,6 +2225,31 @@ mod tests {
         let readout = constraining_readout(&snapshot);
         assert_eq!(readout.label, Some("API"));
         assert_eq!(readout.window.used_percent, 40.0);
+    }
+
+    #[test]
+    fn cursor_strip_trims_labels_and_falls_back_when_blank() {
+        let mut snapshot = snap("cursor", None, 40.0);
+        snapshot.secondary = Some(rate_window(60.0, Some(10_080)));
+        snapshot.secondary_label = Some("  Auto Custom  ".into());
+        snapshot
+            .extra_rate_windows
+            .push(crate::commands::NamedRateWindowSnapshot {
+                id: "cursor-api".into(),
+                title: "   ".into(),
+                window: rate_window(70.0, Some(10_080)),
+            });
+
+        let readout = constraining_readout(&snapshot);
+        assert_eq!(readout.label, Some("API"));
+
+        snapshot.extra_rate_windows.clear();
+        let readout = constraining_readout(&snapshot);
+        assert_eq!(readout.label, Some("Auto Custom"));
+
+        snapshot.secondary_label = Some("   ".into());
+        let readout = constraining_readout(&snapshot);
+        assert_eq!(readout.label, Some("Auto"));
     }
 
     #[test]

--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -72,10 +72,11 @@ fn native_mode_has_configured_provider(settings: &codexbar::settings::Settings) 
 
 /// The rate window that actually constrains a provider right now.
 ///
-/// Mirrors `constrainingWindow` in `capacityPresentation.ts` (SOU-288): an
-/// exhausted/maxed lane outranks everything else, then highest used percent,
-/// then soonest reset. The native taskbar is a one-number surface, so showing
-/// a freshly-reset 5h session while weekly is at 100% is actively misleading.
+/// Mirrors `constrainingWindow` in `capacityPresentation.ts` (SOU-288):
+/// - Default: exhausted/maxed outranks everything, then highest used %, then
+///   soonest reset (Claude session vs weekly).
+/// - Cursor: Auto/API are parallel pools. Prefer the hottest lane that still
+///   has room so a maxed API bar does not hide Auto capacity on the strip.
 #[derive(Debug, Clone, Copy)]
 struct ConstrainingReadout<'a> {
     label: Option<&'a str>,
@@ -112,9 +113,92 @@ fn outranks_window(
     }
 }
 
+/// Cursor Auto + API only (not Plan/Monthly blend).
+fn cursor_actionable_windows(
+    snapshot: &crate::commands::ProviderUsageSnapshot,
+) -> Vec<(Option<&str>, &crate::commands::RateWindowSnapshot)> {
+    let mut out = Vec::new();
+    if let Some(window) = snapshot.secondary.as_ref() {
+        out.push((snapshot.secondary_label.as_deref().or(Some("Auto")), window));
+    }
+    for extra in &snapshot.extra_rate_windows {
+        if extra.id != "cursor-api" {
+            continue;
+        }
+        out.push((Some(extra.title.as_str()), &extra.window));
+    }
+    out
+}
+
+fn cursor_strip_readout(
+    snapshot: &crate::commands::ProviderUsageSnapshot,
+) -> ConstrainingReadout<'_> {
+    let actionable = cursor_actionable_windows(snapshot);
+    if !actionable.is_empty() {
+        // Hottest non-exhausted Auto/API lane.
+        let mut with_room: Option<ConstrainingReadout<'_>> = None;
+        for (label, window) in &actionable {
+            if is_blocking_window(window) {
+                continue;
+            }
+            let candidate = ConstrainingReadout {
+                label: *label,
+                window,
+            };
+            let replace = match with_room {
+                None => true,
+                Some(best) => {
+                    candidate.window.used_percent > best.window.used_percent
+                        || (candidate.window.used_percent == best.window.used_percent
+                            && reset_at_rank(candidate.window) < reset_at_rank(best.window))
+                }
+            };
+            if replace {
+                with_room = Some(candidate);
+            }
+        }
+        if let Some(best) = with_room {
+            return best;
+        }
+        // All actionable lanes exhausted: soonest reset.
+        let mut exhausted: Option<ConstrainingReadout<'_>> = None;
+        for (label, window) in &actionable {
+            if !is_blocking_window(window) {
+                continue;
+            }
+            let candidate = ConstrainingReadout {
+                label: *label,
+                window,
+            };
+            let replace = match exhausted {
+                None => true,
+                Some(best) => {
+                    reset_at_rank(candidate.window) < reset_at_rank(best.window)
+                        || (reset_at_rank(candidate.window) == reset_at_rank(best.window)
+                            && candidate.window.used_percent > best.window.used_percent)
+                }
+            };
+            if replace {
+                exhausted = Some(candidate);
+            }
+        }
+        if let Some(best) = exhausted {
+            return best;
+        }
+    }
+    ConstrainingReadout {
+        label: snapshot.primary_label.as_deref(),
+        window: &snapshot.primary,
+    }
+}
+
 fn constraining_readout(
     snapshot: &crate::commands::ProviderUsageSnapshot,
 ) -> ConstrainingReadout<'_> {
+    if snapshot.provider_id == "cursor" {
+        return cursor_strip_readout(snapshot);
+    }
+
     let mut best = ConstrainingReadout {
         label: snapshot.primary_label.as_deref(),
         window: &snapshot.primary,
@@ -2092,6 +2176,88 @@ mod tests {
         let readout = constraining_readout(&snapshot);
         assert_eq!(readout.label, Some("Session (5h)"));
         assert_eq!(readout.window.used_percent, 92.0);
+    }
+
+    #[test]
+    fn cursor_strip_prefers_auto_when_api_is_maxed() {
+        // Parallel pools: maxed API must not hide Auto that still has room.
+        let mut snapshot = snap("cursor", None, 40.0);
+        snapshot.primary_label = Some("Monthly".into());
+        snapshot.secondary = Some(rate_window(60.0, Some(10_080)));
+        snapshot.secondary_label = Some("Auto".into());
+        snapshot
+            .extra_rate_windows
+            .push(crate::commands::NamedRateWindowSnapshot {
+                id: "cursor-api".into(),
+                title: "API".into(),
+                window: rate_window(100.0, Some(10_080)),
+            });
+
+        let readout = constraining_readout(&snapshot);
+        assert_eq!(readout.label, Some("Auto"));
+        assert_eq!(readout.window.used_percent, 60.0);
+    }
+
+    #[test]
+    fn cursor_strip_prefers_api_when_auto_is_maxed() {
+        let mut snapshot = snap("cursor", None, 40.0);
+        snapshot.primary_label = Some("Monthly".into());
+        snapshot.secondary = Some(rate_window(100.0, Some(10_080)));
+        snapshot.secondary_label = Some("Auto".into());
+        snapshot
+            .extra_rate_windows
+            .push(crate::commands::NamedRateWindowSnapshot {
+                id: "cursor-api".into(),
+                title: "API".into(),
+                window: rate_window(40.0, Some(10_080)),
+            });
+
+        let readout = constraining_readout(&snapshot);
+        assert_eq!(readout.label, Some("API"));
+        assert_eq!(readout.window.used_percent, 40.0);
+    }
+
+    #[test]
+    fn cursor_strip_ignores_hotter_plan_when_auto_api_exist() {
+        let mut snapshot = snap("cursor", None, 95.0);
+        snapshot.primary_label = Some("Monthly".into());
+        snapshot.secondary = Some(rate_window(55.0, Some(10_080)));
+        snapshot.secondary_label = Some("Auto".into());
+        snapshot
+            .extra_rate_windows
+            .push(crate::commands::NamedRateWindowSnapshot {
+                id: "cursor-api".into(),
+                title: "API".into(),
+                window: rate_window(30.0, Some(10_080)),
+            });
+
+        let readout = constraining_readout(&snapshot);
+        assert_eq!(readout.label, Some("Auto"));
+        assert_eq!(readout.window.used_percent, 55.0);
+    }
+
+    #[test]
+    fn cursor_strip_picks_soonest_reset_when_both_exhausted() {
+        let mut soon = rate_window(100.0, Some(10_080));
+        soon.resets_at = Some("2026-07-21T04:00:00Z".into());
+        let mut later = rate_window(100.0, Some(10_080));
+        later.resets_at = Some("2026-07-28T04:00:00Z".into());
+
+        let mut snapshot = snap("cursor", None, 50.0);
+        snapshot.primary_label = Some("Monthly".into());
+        snapshot.secondary = Some(later);
+        snapshot.secondary_label = Some("Auto".into());
+        snapshot
+            .extra_rate_windows
+            .push(crate::commands::NamedRateWindowSnapshot {
+                id: "cursor-api".into(),
+                title: "API".into(),
+                window: soon,
+            });
+
+        let readout = constraining_readout(&snapshot);
+        assert_eq!(readout.label, Some("API"));
+        assert_eq!(readout.window.used_percent, 100.0);
     }
 
     #[test]

--- a/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
@@ -335,17 +335,17 @@ describe("FloatBar", () => {
     });
   });
 
-  it("headlines Cursor total usage instead of the Auto lane", async () => {
+  it("headlines Cursor Auto/API remaining capacity, not Plan total", async () => {
     const live = snapshot("cursor", "Cursor", 20);
     live.updatedAt = new Date().toISOString();
     live.primaryLabel = "Monthly";
     live.secondary = rateWindow(70);
     live.secondaryLabel = "Auto";
-    live.inactiveRateWindows = [
+    live.extraRateWindows = [
       {
         id: "cursor-api",
         title: "API",
-        description: "Not currently enforced by Cursor",
+        window: rateWindow(100),
       },
     ];
     tauriMocks.getCachedProviders.mockResolvedValue([live]);
@@ -361,16 +361,15 @@ describe("FloatBar", () => {
     );
 
     await waitFor(() => {
-      // Cursor's account-wide total remains the headline even when Auto is
-      // more constrained. The tray detail still exposes both lanes.
-      expect(container.querySelector(".floatbar__window")?.textContent).toBe("Total");
-      expect(container.querySelector(".floatbar__pct")?.textContent).toBe("20%");
+      // API is maxed; Auto still has room → strip shows Auto, not Plan 20%.
+      expect(container.querySelector(".floatbar__window")?.textContent).toBe(
+        "Auto",
+      );
+      expect(container.querySelector(".floatbar__pct")?.textContent).toBe("70%");
       expect(container.querySelector(".floatbar__pill--crit")).toBeNull();
       // No tiny companion chip anymore.
       expect(container.querySelector(".floatbar__companion")).toBeNull();
-      // Inactive windows no longer paint the whole provider "lifted" (SOU-152).
-      // The provider timestamp is fresh (set above), so the pill is live with
-      // no state chip at all; the inactive lane surfaces in the tray detail.
+      // Fresh timestamp → live pill, no state chip.
       expect(container.querySelector(".floatbar__chip")).toBeNull();
       expect(container.querySelector(".floatbar__pill--lifted")).toBeNull();
     });

--- a/apps/desktop-tauri/src/floatbar/FloatBar.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.tsx
@@ -108,18 +108,11 @@ export function isFloatBarEligible(
 }
 
 /**
- * Cursor exposes a total plan meter alongside Auto/API lanes. The compact
- * strip should headline that account-wide total; the tray detail remains the
- * place to compare the individual lanes.
+ * One-number strip meter. Cursor uses actionable Auto/API selection inside
+ * `constrainingWindow` (a maxed API bar must not hide Auto that still has room).
+ * Overview still shows Plan as the hero via `glanceMeters`.
  */
 function floatBarWindow(provider: ProviderUsageSnapshot): ConstrainingWindow {
-  if (provider.providerId === "cursor") {
-    return {
-      id: "primary",
-      label: "Total",
-      window: provider.primary,
-    };
-  }
   return constrainingWindow(provider);
 }
 

--- a/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
@@ -93,7 +93,10 @@ describe("capacityPresentation", () => {
 
   it("prefers a blocking window over a merely higher-pressure one", () => {
     const exhausted = window(100);
+    // Claude uses the blocking-wins path (Cursor uses actionable remaining).
     const snap = provider({
+      providerId: "claude",
+      displayName: "Claude",
       primary: window(100),
       primaryLabel: "Session",
       secondary: { ...window(97), isExhausted: false },
@@ -106,6 +109,8 @@ describe("capacityPresentation", () => {
 
     // And a blocking non-primary wins even when primary reads higher.
     const blockedExtra = provider({
+      providerId: "claude",
+      displayName: "Claude",
       primary: window(80),
       primaryLabel: "Session",
       extraRateWindows: [
@@ -123,6 +128,8 @@ describe("capacityPresentation", () => {
     const soon = { ...window(60), resetsAt: "2026-07-21T04:00:00Z" };
     const later = { ...window(60), resetsAt: "2026-07-28T04:00:00Z" };
     const snap = provider({
+      providerId: "claude",
+      displayName: "Claude",
       primary: later,
       primaryLabel: "Weekly",
       secondary: soon,
@@ -130,6 +137,75 @@ describe("capacityPresentation", () => {
     });
 
     expect(constrainingWindow(snap).label).toBe("Session");
+  });
+
+  it("Cursor strip prefers hottest Auto/API that still has room (not Plan)", () => {
+    // Reporter case: API 100% while Auto ~60% still has room → show Auto.
+    const apiMaxed = provider({
+      primary: window(40),
+      primaryLabel: "Monthly",
+      secondary: window(60),
+      secondaryLabel: "Auto",
+      extraRateWindows: [
+        { id: "cursor-api", title: "API", window: window(100) },
+      ],
+    });
+    expect(constrainingWindow(apiMaxed).label).toBe("Auto");
+    expect(constrainingWindow(apiMaxed).window.usedPercent).toBe(60);
+
+    // Symmetric: Auto maxed, API still useful → show API.
+    const autoMaxed = provider({
+      primary: window(40),
+      primaryLabel: "Monthly",
+      secondary: window(100),
+      secondaryLabel: "Auto",
+      extraRateWindows: [
+        { id: "cursor-api", title: "API", window: window(40) },
+      ],
+    });
+    expect(constrainingWindow(autoMaxed).label).toBe("API");
+    expect(constrainingWindow(autoMaxed).window.usedPercent).toBe(40);
+
+    // Both open: hottest wins (not Plan even if Plan is hotter).
+    const bothOpen = provider({
+      primary: window(90),
+      primaryLabel: "Monthly",
+      secondary: window(55),
+      secondaryLabel: "Auto",
+      extraRateWindows: [
+        { id: "cursor-api", title: "API", window: window(70) },
+      ],
+    });
+    expect(constrainingWindow(bothOpen).label).toBe("API");
+    expect(constrainingWindow(bothOpen).window.usedPercent).toBe(70);
+  });
+
+  it("Cursor strip falls back to soonest-reset exhausted lane when both are maxed", () => {
+    const soon = { ...window(100), resetsAt: "2026-07-21T04:00:00Z" };
+    const later = { ...window(100), resetsAt: "2026-07-28T04:00:00Z" };
+    const snap = provider({
+      primary: window(50),
+      primaryLabel: "Monthly",
+      secondary: later,
+      secondaryLabel: "Auto",
+      extraRateWindows: [
+        { id: "cursor-api", title: "API", window: soon },
+      ],
+    });
+    expect(constrainingWindow(snap).label).toBe("API");
+    expect(constrainingWindow(snap).window.usedPercent).toBe(100);
+  });
+
+  it("Cursor strip falls back to Plan when Auto/API lanes are absent", () => {
+    const snap = provider({
+      primary: window(42),
+      primaryLabel: "Monthly",
+      secondary: null,
+      extraRateWindows: [],
+    });
+    expect(constrainingWindow(snap).id).toBe("primary");
+    expect(constrainingWindow(snap).label).toBe("Monthly");
+    expect(constrainingWindow(snap).window.usedPercent).toBe(42);
   });
 
   it("keeps Cursor plan as hero and shows reported Auto and API companions", () => {

--- a/apps/desktop-tauri/src/lib/capacityPresentation.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.ts
@@ -50,6 +50,9 @@ function resetAtMs(window: RateWindowSnapshot): number {
  *     you even when another lane reads higher pressure.
  *  2. Then the highest used percent, i.e. closest to its ceiling.
  *  3. Then the soonest reset, so a tie resolves toward the one that bites first.
+ *
+ * Cursor does **not** use this path (see `cursorStripWindow`): Auto and API are
+ * parallel pools, so a maxed API bar must not hide Auto capacity on the strip.
  */
 function outranks(
   candidate: ConstrainingWindow,
@@ -64,10 +67,103 @@ function outranks(
   return resetAtMs(candidate.window) < resetAtMs(best.window);
 }
 
+/**
+ * Cursor Auto + API lanes only. Plan/Monthly is a blend and is not used for the
+ * one-number strip when these actionable pools exist.
+ */
+function cursorActionableWindows(
+  provider: ProviderUsageSnapshot,
+): ConstrainingWindow[] {
+  const out: ConstrainingWindow[] = [];
+  if (provider.secondary) {
+    out.push({
+      id: "secondary",
+      label: provider.secondaryLabel?.trim() || "Auto",
+      window: provider.secondary,
+    });
+  }
+  for (const extra of provider.extraRateWindows ?? []) {
+    if (extra.id !== "cursor-api") continue;
+    out.push({
+      id: `extra-${extra.id}`,
+      label: extra.title?.trim() || "API",
+      window: extra.window,
+    });
+  }
+  return out;
+}
+
+/** Hottest non-exhausted window, then soonest reset on a used-% tie. */
+function hottestWithRoom(
+  windows: ConstrainingWindow[],
+): ConstrainingWindow | null {
+  let best: ConstrainingWindow | null = null;
+  for (const candidate of windows) {
+    if (isBlocking(candidate.window)) continue;
+    if (
+      !best ||
+      candidate.window.usedPercent > best.window.usedPercent ||
+      (candidate.window.usedPercent === best.window.usedPercent &&
+        resetAtMs(candidate.window) < resetAtMs(best.window))
+    ) {
+      best = candidate;
+    }
+  }
+  return best;
+}
+
+/** Among exhausted windows, prefer the one that resets soonest. */
+function soonestExhausted(
+  windows: ConstrainingWindow[],
+): ConstrainingWindow | null {
+  let best: ConstrainingWindow | null = null;
+  for (const candidate of windows) {
+    if (!isBlocking(candidate.window)) continue;
+    if (
+      !best ||
+      resetAtMs(candidate.window) < resetAtMs(best.window) ||
+      (resetAtMs(candidate.window) === resetAtMs(best.window) &&
+        candidate.window.usedPercent > best.window.usedPercent)
+    ) {
+      best = candidate;
+    }
+  }
+  return best;
+}
+
+/**
+ * Cursor strip / taskbar readout: show **actionable remaining** capacity.
+ *
+ * Auto and API are parallel product pools. A maxed API lane does not stop Auto,
+ * so the strip prefers the hottest lane that still has room. Only when every
+ * actionable lane is exhausted do we surface an exhausted bar (soonest reset).
+ * Plan/Monthly never wins the strip when Auto or API is present.
+ */
+function cursorStripWindow(
+  provider: ProviderUsageSnapshot,
+): ConstrainingWindow {
+  const actionable = cursorActionableWindows(provider);
+  if (actionable.length > 0) {
+    const withRoom = hottestWithRoom(actionable);
+    if (withRoom) return withRoom;
+    const exhausted = soonestExhausted(actionable);
+    if (exhausted) return exhausted;
+  }
+  return {
+    id: "primary",
+    label: provider.primaryLabel?.trim() || "Plan",
+    window: provider.primary,
+  };
+}
+
 /** Pick the window actually constraining this provider (see `outranks`). */
 export function constrainingWindow(
   provider: ProviderUsageSnapshot,
 ): ConstrainingWindow {
+  if (provider.providerId === "cursor") {
+    return cursorStripWindow(provider);
+  }
+
   let best: ConstrainingWindow = {
     id: "primary",
     label: provider.primaryLabel?.trim() || "Plan",


### PR DESCRIPTION
## Summary
Cursor Auto and API are parallel product pools. The one-number strip (native taskbar + float bar) was treating them like Claude session/weekly and could stick on a maxed API lane while Auto still had room.

- Cursor strip now prefers the **hottest non-exhausted** Auto/API window
- When both are exhausted, show the one that **resets soonest**
- Plan/Monthly is not used for the strip when Auto or API is present (overview still uses Plan as the hero via glance meters)
- Claude and other providers keep the existing blocking-wins path
- Float bar no longer forces Cursor `Total`/primary; it uses the same `constrainingWindow` selection

## Test plan
- [x] `vitest` capacityPresentation + FloatBar tests
- [x] `cargo test` cursor_strip_* + constraining_readout_*
- [ ] Manual: taskbar/float bar with API at 100% and Auto ~60% shows Auto, not API