### PR TITLE
Automate Microsoft Store submissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,6 +303,84 @@ jobs:
             -AssetsDir $env:RELEASE_ASSETS_DIR `
             -BucketName $env:CLOUDFLARE_R2_BUCKET
 
+      - name: Set up Microsoft Store Developer CLI
+        if: vars.MICROSOFT_STORE_SUBMISSION_ENABLED == 'true'
+        uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0 # v1.4
+
+      - name: Configure Partner Center credentials
+        if: vars.MICROSOFT_STORE_SUBMISSION_ENABLED == 'true'
+        shell: pwsh
+        env:
+          PARTNER_CENTER_TENANT_ID: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
+          PARTNER_CENTER_SELLER_ID: ${{ secrets.PARTNER_CENTER_SELLER_ID }}
+          PARTNER_CENTER_CLIENT_ID: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
+          PARTNER_CENTER_CLIENT_SECRET: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
+        run: |
+          foreach ($name in @(
+            "PARTNER_CENTER_TENANT_ID",
+            "PARTNER_CENTER_SELLER_ID",
+            "PARTNER_CENTER_CLIENT_ID",
+            "PARTNER_CENTER_CLIENT_SECRET"
+          )) {
+            if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
+              throw "The release environment is missing secret $name."
+            }
+          }
+          msstore settings --enableTelemetry false
+          msstore reconfigure `
+            --tenantId $env:PARTNER_CENTER_TENANT_ID `
+            --sellerId $env:PARTNER_CENTER_SELLER_ID `
+            --clientId $env:PARTNER_CENTER_CLIENT_ID `
+            --clientSecret $env:PARTNER_CENTER_CLIENT_SECRET
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store CLI authentication failed."
+          }
+
+      - name: Prepare Microsoft Store package update
+        if: vars.MICROSOFT_STORE_SUBMISSION_ENABLED == 'true'
+        shell: pwsh
+        env:
+          PARTNER_CENTER_PRODUCT_ID: ${{ vars.PARTNER_CENTER_PRODUCT_ID }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:PARTNER_CENTER_PRODUCT_ID)) {
+            throw "The release environment is missing variable PARTNER_CENTER_PRODUCT_ID."
+          }
+          $installerUrl = "https://downloads.ceiling.win/releases/v$env:RELEASE_VERSION/Ceiling-$env:RELEASE_VERSION-Store-Setup.exe"
+          $currentPath = Join-Path $env:RUNNER_TEMP "store-package-current.json"
+          $preparedPath = Join-Path $env:RUNNER_TEMP "store-package-prepared.json"
+          msstore submission get $env:PARTNER_CENTER_PRODUCT_ID > $currentPath
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not retrieve Ceiling's current Microsoft Store package."
+          }
+          & .\scripts\prepare-store-submission.ps1 `
+            -CurrentPackagePath $currentPath `
+            -InstallerUrl $installerUrl `
+            -OutputPath $preparedPath
+          "STORE_INSTALLER_URL=$installerUrl" |
+            Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "STORE_PACKAGE_PATH=$preparedPath" |
+            Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Submit update to Microsoft Store
+        if: vars.MICROSOFT_STORE_SUBMISSION_ENABLED == 'true'
+        shell: pwsh
+        env:
+          PARTNER_CENTER_PRODUCT_ID: ${{ vars.PARTNER_CENTER_PRODUCT_ID }}
+        run: |
+          $package = Get-Content -LiteralPath $env:STORE_PACKAGE_PATH -Raw
+          msstore submission update $env:PARTNER_CENTER_PRODUCT_ID $package
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store package update failed."
+          }
+          msstore submission publish $env:PARTNER_CENTER_PRODUCT_ID
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store submission failed."
+          }
+          "### Submitted Ceiling to Microsoft Store" |
+            Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "Installer: $env:STORE_INSTALLER_URL" |
+            Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
       - name: Sign out of Azure
         if: always()
         shell: pwsh

--- a/.github/workflows/validate-store-submission.yml
+++ b/.github/workflows/validate-store-submission.yml
@@ -1,0 +1,153 @@
+name: Validate Microsoft Store submission
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing Ceiling version already published to R2 (for example, 1.5.16)
+        required: true
+        type: string
+      publish:
+        description: Submit this version to Microsoft Store after validation
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: microsoft-store-submission
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate Store access and package
+    runs-on: windows-latest
+    timeout-minutes: 30
+    environment: release
+
+    steps:
+      - name: Check out main
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Validate version
+        shell: pwsh
+        env:
+          STORE_VERSION: ${{ inputs.version }}
+        run: |
+          if ($env:STORE_VERSION -notmatch '^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$') {
+            throw "Version must look like 1.5.16 (without the v prefix)."
+          }
+          "STORE_INSTALLER_URL=https://downloads.ceiling.win/releases/v$env:STORE_VERSION/Ceiling-$env:STORE_VERSION-Store-Setup.exe" |
+            Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Verify immutable R2 installer and checksum
+        shell: pwsh
+        run: |
+          $installerPath = Join-Path $env:RUNNER_TEMP "Ceiling-Store-Setup.exe"
+          $hashPath = "$installerPath.sha256"
+          & curl.exe --fail --silent --show-error --location --max-redirs 0 `
+            --retry 3 --output $installerPath $env:STORE_INSTALLER_URL
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not download $env:STORE_INSTALLER_URL"
+          }
+          & curl.exe --fail --silent --show-error --location --max-redirs 0 `
+            --retry 3 --output $hashPath "$env:STORE_INSTALLER_URL.sha256"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not download $env:STORE_INSTALLER_URL.sha256"
+          }
+          $expectedText = Get-Content -LiteralPath $hashPath -Raw
+          if ($expectedText -notmatch '(?i)\b([0-9a-f]{64})\b') {
+            throw "The published checksum sidecar does not contain a SHA-256 value."
+          }
+          $expected = $Matches[1].ToLowerInvariant()
+          $actual = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -ne $expected) {
+            throw "R2 installer SHA-256 mismatch. Expected $expected, got $actual."
+          }
+          Write-Host "Verified immutable R2 installer: $env:STORE_INSTALLER_URL"
+
+      - name: Set up Microsoft Store Developer CLI
+        uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0 # v1.4
+
+      - name: Configure Partner Center credentials
+        shell: pwsh
+        env:
+          PARTNER_CENTER_TENANT_ID: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
+          PARTNER_CENTER_SELLER_ID: ${{ secrets.PARTNER_CENTER_SELLER_ID }}
+          PARTNER_CENTER_CLIENT_ID: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
+          PARTNER_CENTER_CLIENT_SECRET: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
+        run: |
+          foreach ($name in @(
+            "PARTNER_CENTER_TENANT_ID",
+            "PARTNER_CENTER_SELLER_ID",
+            "PARTNER_CENTER_CLIENT_ID",
+            "PARTNER_CENTER_CLIENT_SECRET"
+          )) {
+            if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
+              throw "The release environment is missing secret $name."
+            }
+          }
+          msstore settings --enableTelemetry false
+          msstore reconfigure `
+            --tenantId $env:PARTNER_CENTER_TENANT_ID `
+            --sellerId $env:PARTNER_CENTER_SELLER_ID `
+            --clientId $env:PARTNER_CENTER_CLIENT_ID `
+            --clientSecret $env:PARTNER_CENTER_CLIENT_SECRET
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store CLI authentication failed."
+          }
+
+      - name: Read and prepare current Store package
+        shell: pwsh
+        env:
+          PARTNER_CENTER_PRODUCT_ID: ${{ vars.PARTNER_CENTER_PRODUCT_ID }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:PARTNER_CENTER_PRODUCT_ID)) {
+            throw "The release environment is missing variable PARTNER_CENTER_PRODUCT_ID."
+          }
+          $currentPath = Join-Path $env:RUNNER_TEMP "store-package-current.json"
+          $preparedPath = Join-Path $env:RUNNER_TEMP "store-package-prepared.json"
+          msstore submission get $env:PARTNER_CENTER_PRODUCT_ID > $currentPath
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not retrieve Ceiling's current Microsoft Store package."
+          }
+          & .\scripts\prepare-store-submission.ps1 `
+            -CurrentPackagePath $currentPath `
+            -InstallerUrl $env:STORE_INSTALLER_URL `
+            -OutputPath $preparedPath
+          "STORE_PACKAGE_PATH=$preparedPath" |
+            Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Publish Microsoft Store submission
+        if: inputs.publish
+        shell: pwsh
+        env:
+          PARTNER_CENTER_PRODUCT_ID: ${{ vars.PARTNER_CENTER_PRODUCT_ID }}
+        run: |
+          $package = Get-Content -LiteralPath $env:STORE_PACKAGE_PATH -Raw
+          msstore submission update $env:PARTNER_CENTER_PRODUCT_ID $package
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store package update failed."
+          }
+          msstore submission publish $env:PARTNER_CENTER_PRODUCT_ID
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store submission failed."
+          }
+          "### Submitted Ceiling to Microsoft Store" |
+            Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "Installer: $env:STORE_INSTALLER_URL" |
+            Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+      - name: Report validation-only result
+        if: ${{ !inputs.publish }}
+        shell: pwsh
+        run: |
+          "### Microsoft Store validation passed" |
+            Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "Credentials, product access, package shape, and installer URL were validated. No submission was changed." |
+            Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -49,7 +49,41 @@ must define these Cloudflare values:
 The release workflow runs `scripts/publish-store-installer.ps1`, which validates
 the signed installer's checksum before upload and downloads it again from the
 custom domain with redirects disabled. This keeps the Microsoft Store package
-URL versioned, immutable, and directly downloadable.
+URL versioned, immutable, and directly downloadable. A retry skips an existing
+object only when its installer and checksum bytes match; it refuses to overwrite
+a version URL with different bytes.
+
+## Microsoft Store submission automation
+
+Microsoft Store submission is disabled until Partner Center onboarding has
+been validated. The GitHub `release` environment must define:
+
+- variable `PARTNER_CENTER_PRODUCT_ID`;
+- variable `MICROSOFT_STORE_SUBMISSION_ENABLED` (`false` during onboarding);
+- secrets `PARTNER_CENTER_TENANT_ID`, `PARTNER_CENTER_SELLER_ID`,
+  `PARTNER_CENTER_CLIENT_ID`, and `PARTNER_CENTER_CLIENT_SECRET`.
+
+The Entra application represented by those credentials must be associated with
+the Partner Center account and assigned the **Manager** role. Ceiling must
+already have a published MSI/EXE submission, and its Store product must be free;
+Microsoft Store Developer CLI does not currently support updates for paid
+MSI/EXE products.
+
+After adding the credentials, run **Validate Microsoft Store submission** from
+GitHub Actions with an existing R2 version and leave `publish` unchecked. This
+verifies the installer and checksum, authenticates to Partner Center, reads the
+current package configuration, and prepares the new package JSON without
+changing the Store submission. If it passes:
+
+1. rerun it once with `publish` checked to submit that version;
+2. wait for certification to complete in Partner Center; and
+3. set `MICROSOFT_STORE_SUBMISSION_ENABLED` to `true`.
+
+Future tagged releases then retrieve the current Store package configuration,
+change only its package URL to the newly verified immutable R2 installer, and
+submit it for certification. Leave the enable variable `false` if Store
+submission should temporarily remain manual. Never reuse or overwrite a
+versioned R2 URL after Microsoft has certified it.
 
 For a local unsigned packaging rehearsal, use the managed Windows checkout:
 

--- a/scripts/prepare-store-submission.ps1
+++ b/scripts/prepare-store-submission.ps1
@@ -1,0 +1,66 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$CurrentPackagePath,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^https://')]
+    [string]$InstallerUrl,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $CurrentPackagePath -PathType Leaf)) {
+    throw "Current Microsoft Store package JSON not found: $CurrentPackagePath"
+}
+
+try {
+    $current = Get-Content -LiteralPath $CurrentPackagePath -Raw | ConvertFrom-Json
+} catch {
+    throw "Microsoft Store CLI did not return valid package JSON: $($_.Exception.Message)"
+}
+
+$packagesProperty = $current.PSObject.Properties |
+    Where-Object { $_.Name -ieq "packages" } |
+    Select-Object -First 1
+if (-not $packagesProperty) {
+    throw "Microsoft Store package JSON does not contain a Packages array."
+}
+
+$packages = @($packagesProperty.Value)
+if ($packages.Count -ne 1) {
+    throw "Expected exactly one Microsoft Store package for Ceiling, but found $($packages.Count)."
+}
+
+$packageUrlProperty = $packages[0].PSObject.Properties |
+    Where-Object { $_.Name -ieq "packageUrl" } |
+    Select-Object -First 1
+if (-not $packageUrlProperty) {
+    throw "The Microsoft Store package does not contain a PackageUrl field."
+}
+
+$packageUrlProperty.Value = $InstallerUrl
+
+$outputDirectory = Split-Path -Parent $OutputPath
+if ($outputDirectory -and -not (Test-Path -LiteralPath $outputDirectory)) {
+    New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+}
+
+$current | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath $OutputPath -Encoding utf8
+
+$prepared = Get-Content -LiteralPath $OutputPath -Raw | ConvertFrom-Json
+$preparedPackagesProperty = $prepared.PSObject.Properties |
+    Where-Object { $_.Name -ieq "packages" } |
+    Select-Object -First 1
+$preparedPackageUrlProperty = @($preparedPackagesProperty.Value)[0].PSObject.Properties |
+    Where-Object { $_.Name -ieq "packageUrl" } |
+    Select-Object -First 1
+if ($preparedPackageUrlProperty.Value -ne $InstallerUrl) {
+    throw "Prepared Microsoft Store submission does not contain the expected installer URL."
+}
+
+Write-Host "Prepared Microsoft Store package update for $InstallerUrl"

--- a/scripts/publish-store-installer.ps1
+++ b/scripts/publish-store-installer.ps1
@@ -39,6 +39,67 @@ if ($localHash -ne $expectedHash) {
 }
 
 $objectPrefix = "releases/v$Version"
+$installerUrl = "$($DownloadOrigin.TrimEnd('/'))/$objectPrefix/$installerName"
+$hashUrl = "$installerUrl.sha256"
+
+function Get-PublicObject {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Url,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Destination
+    )
+
+    $status = & curl.exe `
+        --silent `
+        --show-error `
+        --location `
+        --max-redirs 0 `
+        --connect-timeout 10 `
+        --max-time 180 `
+        --retry 3 `
+        --retry-delay 5 `
+        --retry-connrefused `
+        --output $Destination `
+        --write-out "%{http_code}" `
+        $Url
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not check existing immutable object $Url (curl exit $LASTEXITCODE)."
+    }
+
+    return [int]$status
+}
+
+$existingInstallerPath = Join-Path ([System.IO.Path]::GetTempPath()) "ceiling-store-existing-$Version-$([guid]::NewGuid().ToString('N')).exe"
+$existingHashPath = "$existingInstallerPath.sha256"
+$skipUpload = $false
+try {
+    $installerStatus = Get-PublicObject -Url $installerUrl -Destination $existingInstallerPath
+    if ($installerStatus -eq 200) {
+        $existingHash = (Get-FileHash -LiteralPath $existingInstallerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($existingHash -ne $expectedHash) {
+            throw "Refusing to overwrite immutable release object $installerUrl. Existing SHA-256 is $existingHash; expected $expectedHash."
+        }
+
+        $hashStatus = Get-PublicObject -Url $hashUrl -Destination $existingHashPath
+        if ($hashStatus -ne 200) {
+            throw "Installer already exists, but its immutable checksum sidecar returned HTTP ${hashStatus}: $hashUrl"
+        }
+        $existingHashText = Get-Content -LiteralPath $existingHashPath -Raw
+        if ($existingHashText -notmatch '(?i)\b([0-9a-f]{64})\b' -or
+            $Matches[1].ToLowerInvariant() -ne $expectedHash) {
+            throw "Installer already exists, but its immutable checksum sidecar does not match: $hashUrl"
+        }
+
+        Write-Host "Immutable release objects already have the expected bytes; skipping upload."
+        $skipUpload = $true
+    } elseif ($installerStatus -ne 404) {
+        throw "Unexpected HTTP $installerStatus while checking immutable release object $installerUrl"
+    }
+} finally {
+    Remove-Item -LiteralPath $existingInstallerPath, $existingHashPath -Force -ErrorAction SilentlyContinue
+}
 
 function Publish-R2Object {
     param(
@@ -65,18 +126,19 @@ function Publish-R2Object {
     }
 }
 
-Publish-R2Object `
-    -Path $installerPath `
-    -ContentType "application/vnd.microsoft.portable-executable" `
-    -CacheControl "public, max-age=31536000, immutable"
-Publish-R2Object `
-    -Path $hashPath `
-    -ContentType "text/plain; charset=utf-8" `
-    -CacheControl "public, max-age=31536000, immutable"
+if (-not $skipUpload) {
+    Publish-R2Object `
+        -Path $installerPath `
+        -ContentType "application/vnd.microsoft.portable-executable" `
+        -CacheControl "public, max-age=31536000, immutable"
+    Publish-R2Object `
+        -Path $hashPath `
+        -ContentType "text/plain; charset=utf-8" `
+        -CacheControl "public, max-age=31536000, immutable"
+}
 
-$installerUrl = "$($DownloadOrigin.TrimEnd('/'))/$objectPrefix/$installerName"
 if ($SkipPublicVerification) {
-    Write-Output "Uploaded Microsoft Store installer: $installerUrl"
+    Write-Output "Microsoft Store installer is available at: $installerUrl"
     return
 }
 


### PR DESCRIPTION
## Summary

- submit each verified, versioned R2 Store installer through Microsoft Store Developer CLI after tagged releases
- add a manual validation workflow for credential and package-shape testing before automation is enabled
- preserve the existing Partner Center package settings and change only the installer URL
- prevent release retries from overwriting immutable R2 objects with different bytes
- document the Partner Center and GitHub environment onboarding sequence

## Why

Ceiling already builds, signs, uploads, and verifies a standalone Store installer. Partner Center submission was the remaining manual step. This connects that final step while keeping it disabled until a validation-only run succeeds.

## Safety

- Store automation is gated by `MICROSOFT_STORE_SUBMISSION_ENABLED == true`
- onboarding defaults to validation only and does not mutate a Store submission
- the Microsoft publisher action is pinned to the exact v1.4 commit
- an existing versioned R2 object is skipped only if both installer and checksum match; differing bytes fail instead of overwriting
- exactly one existing Ceiling package must be returned by Partner Center

## Validation

- `actionlint` 1.7.12
- PowerShell parser checks for both changed scripts
- sample package transformation preserving existing fields
- `git diff --check`
