### PR TITLE
Isolate Store validation credentials

### DIFF
--- a/.github/workflows/validate-store-submission.yml
+++ b/.github/workflows/validate-store-submission.yml
@@ -91,7 +91,7 @@ jobs:
             "PARTNER_CENTER_CLIENT_SECRET"
           )) {
             if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
-              throw "The release environment is missing secret $name."
+              throw "The store-validation environment is missing secret $name."
             }
           }
           msstore settings --enableTelemetry false
@@ -110,7 +110,7 @@ jobs:
           PARTNER_CENTER_PRODUCT_ID: ${{ vars.PARTNER_CENTER_PRODUCT_ID }}
         run: |
           if ([string]::IsNullOrWhiteSpace($env:PARTNER_CENTER_PRODUCT_ID)) {
-            throw "The release environment is missing variable PARTNER_CENTER_PRODUCT_ID."
+            throw "The store-validation environment is missing variable PARTNER_CENTER_PRODUCT_ID."
           }
           $currentPath = Join-Path $env:RUNNER_TEMP "store-package-current.json"
           $preparedPath = Join-Path $env:RUNNER_TEMP "store-package-prepared.json"

--- a/.github/workflows/validate-store-submission.yml
+++ b/.github/workflows/validate-store-submission.yml
@@ -25,7 +25,9 @@ jobs:
     name: Validate Store access and package
     runs-on: windows-latest
     timeout-minutes: 30
-    environment: release
+    # Keep manual validation separate from the tag-only release environment,
+    # which also contains signing and R2 credentials.
+    environment: store-validation
 
     steps:
       - name: Check out main

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -73,7 +73,10 @@ After adding the credentials, run **Validate Microsoft Store submission** from
 GitHub Actions with an existing R2 version and leave `publish` unchecked. This
 verifies the installer and checksum, authenticates to Partner Center, reads the
 current package configuration, and prepares the new package JSON without
-changing the Store submission. If it passes:
+changing the Store submission. The manual workflow uses a separate
+`store-validation` environment containing the same five Partner Center values,
+so it cannot access the tag-only environment's signing or R2 credentials. If it
+passes:
 
 1. rerun it once with `publish` checked to submit that version;
 2. wait for certification to complete in Partner Center; and


### PR DESCRIPTION
## Summary

- run manual Microsoft Store validation in a dedicated `store-validation` environment
- keep the tag-only `release` environment and its signing/R2 credentials inaccessible to manual main-branch runs
- document the duplicated Partner Center-only configuration

## Validation

- actionlint 1.7.12
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that Microsoft Store validation runs in a separate environment from tagged releases.
  - Documented that manual validation cannot access release signing or storage credentials.
  - Updated the release process steps to reflect the revised validation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->