### PR TITLE
Retry the R2 public download check while the edge catches up

### DIFF
--- a/.github/release-notes-1.5.17.md
+++ b/.github/release-notes-1.5.17.md
@@ -1,0 +1,41 @@
+## Highlights
+
+### Windows notifications actually stick around
+
+If a reset alert flashed past while you were looking elsewhere, it was gone for good. Ceiling's toasts appeared as a banner for a few seconds and never reached the Windows 11 notification center.
+
+They were published under an app identity Windows did not recognise, so it showed the banner and then discarded it. 1.5.17 publishes under the installed app's real identity, so alerts collect in the notification center like every other app, and repairs the setting on launch if Windows already marked Ceiling as banner-only.
+
+Toasts also carry the Ceiling name and logo now, instead of arriving as unattributed text.
+
+### Resets you were actually waiting for
+
+Two changes so the alerts that matter get through:
+
+- A confirmed reset is no longer dropped. Providers refresh at the same time, and only one alert was allowed per refresh, so an unrelated warning could silently swallow the only weekly reset notification you would get all week.
+- Scheduled 5-hour session resets no longer notify. They come round several times a day and are exactly what you already expect. Weekly and monthly resets always notify, and unexpected ones (early, partial, banked) still notify at any cadence.
+
+Portable builds are a deliberate exception. Windows only keeps notifications for an app claimed by a Start Menu shortcut, and Ceiling will not add one to a machine where you chose portable. Portable alerts appear as banners without notification-center history.
+
+### Simplified Chinese
+
+中文 is now a switchable interface language under Settings > General. Anything not yet translated falls back to English.
+
+### Sign in from inside Ceiling
+
+Claude and Codex now have in-app login flows next to the existing Copilot device flow, with progress shown as it happens. Providers without an in-app flow tell you what credentials they need instead of quietly opening a dashboard.
+
+## Also fixed
+
+- Estimated API value no longer under-reports when you have more than one Codex or Claude seat. Secondary accounts added under Accounts were never scanned.
+- The one-number strip could sit on a maxed-out Cursor API lane while Auto still had room. It now shows the hottest lane that still has capacity.
+
+## Installers
+
+- **Ceiling-1.5.17-Setup.exe** - standard installer
+- **Ceiling-1.5.17-portable.exe** - portable
+- **Ceiling-1.5.17-Store-Setup.exe** - Microsoft Store package (WebView2 bundled)
+
+---
+
+**Full Changelog**: https://github.com/tsouth89/ceiling/compare/v1.5.16...v1.5.17

--- a/scripts/publish-store-installer.ps1
+++ b/scripts/publish-store-installer.ps1
@@ -144,21 +144,39 @@ if ($SkipPublicVerification) {
 
 $downloadPath = Join-Path ([System.IO.Path]::GetTempPath()) "ceiling-store-$Version-$([guid]::NewGuid().ToString('N')).exe"
 try {
-    & curl.exe `
-        --fail `
-        --silent `
-        --show-error `
-        --location `
-        --max-redirs 0 `
-        --connect-timeout 10 `
-        --max-time 180 `
-        --retry 3 `
-        --retry-delay 5 `
-        --retry-connrefused `
-        --output $downloadPath `
-        $installerUrl
-    if ($LASTEXITCODE -ne 0) {
-        throw "Direct public download failed with curl exit code $LASTEXITCODE."
+    # R2's public edge serves a newly written object a moment after the upload
+    # API returns, so the first read can 404 on an object that is genuinely
+    # there. curl's own --retry does not cover this: 404 is a permanent client
+    # error, so it fails immediately. v1.5.17 died here 160 ms after a
+    # successful upload, on a URL that served fine seconds later.
+    #
+    # Retry the whole request on any failure, backing off, and only give up
+    # once the object has had a fair chance to propagate. A genuinely missing
+    # object still fails, just later.
+    $maxAttempts = 8
+    for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+        & curl.exe `
+            --fail `
+            --silent `
+            --show-error `
+            --location `
+            --max-redirs 0 `
+            --connect-timeout 10 `
+            --max-time 180 `
+            --retry 3 `
+            --retry-delay 5 `
+            --retry-connrefused `
+            --output $downloadPath `
+            $installerUrl
+        if ($LASTEXITCODE -eq 0) {
+            break
+        }
+        if ($attempt -eq $maxAttempts) {
+            throw "Direct public download failed with curl exit code $LASTEXITCODE after $maxAttempts attempts."
+        }
+        $backoff = [Math]::Min(5 * $attempt, 20)
+        Write-Host "Public download attempt $attempt/$maxAttempts failed (curl exit $LASTEXITCODE); retrying in ${backoff}s."
+        Start-Sleep -Seconds $backoff
     }
 
     $downloadHash = (Get-FileHash -LiteralPath $downloadPath -Algorithm SHA256).Hash.ToLowerInvariant()

--- a/scripts/publish-store-installer.ps1
+++ b/scripts/publish-store-installer.ps1
@@ -153,6 +153,9 @@ try {
     # Retry the whole request on any failure, backing off, and only give up
     # once the object has had a fair chance to propagate. A genuinely missing
     # object still fails, just later.
+    # The loop owns the retry policy, so curl gets none of its own: nesting the
+    # two multiplies the worst case (3 curl retries x 180s max-time, per outer
+    # attempt) into something far longer than the window intended here.
     $maxAttempts = 8
     for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
         & curl.exe `
@@ -163,9 +166,6 @@ try {
             --max-redirs 0 `
             --connect-timeout 10 `
             --max-time 180 `
-            --retry 3 `
-            --retry-delay 5 `
-            --retry-connrefused `
             --output $downloadPath `
             $installerUrl
         if ($LASTEXITCODE -eq 0) {


### PR DESCRIPTION
## What happened

The v1.5.17 release run [failed](https://github.com/tsouth89/ceiling/actions/runs/30499042007) on a healthy upload.

Both R2 objects uploaded successfully. The verification curl then hit the public URL **160 ms later** and got a 404:

```
23:30:58.99  Upload complete.
23:30:59.15  curl: (22) The requested URL returned error: 404
```

The same URL served the correct bytes seconds afterwards, and still does:

```
HTTP 200  size=237396184  redirects=0
sha256    12abcb9b5cccb755654db1ac601b575655fc2cfdbc5d286c6f9488472e7c6bc6
```

## Why the existing retry didn't cover it

R2's public edge starts serving a newly written object slightly after the upload API returns. The call already passed `--retry 3 --retry-delay 5 --retry-connrefused`, but **curl does not retry 404** - it is a permanent client error, so curl fails immediately. Those flags only ever covered transient network faults.

## Fix

Retry the whole request with backoff (5s, 10s, 15s, then 20s, 8 attempts, roughly a minute) and only then give up. A genuinely missing object still fails the release, just later.

Deliberately **not** applied to the immutability guard's `Get-PublicObject`, which reads a 404 as "not uploaded yet" and must keep failing fast.

## Impact on v1.5.17

The release itself is sound: binaries built and signed, smoke test passed, release doctor passed, and the draft GitHub release has all six assets. Only the Store submission steps were skipped, because they run after the step that failed.

Worth noting a plain re-run of the release workflow would **not** have recovered it. The immutability guard compares the existing R2 object against the freshly built installer, and a rebuild re-signs with new Authenticode timestamps, so the bytes differ and it throws `Refusing to overwrite immutable release object`. That guard is doing its job; it just means retries have to avoid rebuilding. The recovery path is `validate-store-submission.yml`, which takes a version already in R2 plus a `publish` flag.
