### PR TITLE
Give the installer's shortcut our AUMID, and stop the update loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+- The Start Menu shortcut created by the installer now carries Ceiling's AppUserModelID. Without it Windows could not resolve who a toast came from, so it drew the banner and discarded it, and 1.5.17 shipped with its own notification-history fix inert on a clean install. If you installed 1.5.17, reinstalling picks up the corrected shortcut.
+- The updater refuses to apply an update that would not replace the running copy. A Ceiling started from anywhere other than the installed directory (a local build, an install from older packaging) would watch the installer succeed elsewhere, stay on the old version, and offer the same update forever with nothing explaining why. It now says so instead of looping.
+- Cached update installers are pruned once they are superseded. Every download was kept forever; one machine had ten going back to 0.43.3, 305 MB of them.
+
 ## [Ceiling] 1.5.17 - 2026-07-29
 
 Windows notifications are the headline: they now carry the Ceiling name and logo, stay in the notification center instead of vanishing after a few seconds, and stop dropping the weekly and monthly resets worth interrupting for. Also adds Simplified Chinese and in-app provider login.

--- a/rust/installer/codexbar.iss
+++ b/rust/installer/codexbar.iss
@@ -1,4 +1,7 @@
 #define MyAppName "Ceiling"
+; Ceiling's AppUserModelID. Must match CEILING_AUMID in
+; rust/src/notifications.rs and the identifier in tauri.conf.json.
+#define AppUserModelId "io.github.tsouth89.ceiling"
 #ifndef AppVersion
   #define AppVersion "0.0.0-dev"
 #endif
@@ -22,7 +25,7 @@
 #endif
 
 [Setup]
-AppId=io.github.tsouth89.ceiling
+AppId={#AppUserModelId}
 AppName={#MyAppName}
 AppVersion={#AppVersion}
 AppVerName={#MyAppName} {#AppVersion}
@@ -57,9 +60,14 @@ Source: "..\icons\icon.ico"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#VCRedistPath}"; Flags: dontcopy
 Source: "{#WebView2InstallerPath}"; Flags: dontcopy
 
+; AppUserModelID must match CEILING_AUMID in rust/src/notifications.rs. Windows
+; resolves an app's notification identity from a Start Menu shortcut carrying
+; this property, and keeps toasts in the notification center only for an app it
+; can resolve. Without it here, every toast is treated as coming from an
+; unregistered app: the banner shows, then Windows discards it.
 [Icons]
-Name: "{autoprograms}\Ceiling"; Filename: "{app}\ceiling.exe"; Parameters: "menubar"; WorkingDir: "{app}"; IconFilename: "{app}\icon.ico"
-Name: "{autodesktop}\Ceiling"; Filename: "{app}\ceiling.exe"; Parameters: "menubar"; WorkingDir: "{app}"; Tasks: desktopicon; IconFilename: "{app}\icon.ico"
+Name: "{autoprograms}\Ceiling"; Filename: "{app}\ceiling.exe"; Parameters: "menubar"; WorkingDir: "{app}"; IconFilename: "{app}\icon.ico"; AppUserModelID: "{#AppUserModelId}"
+Name: "{autodesktop}\Ceiling"; Filename: "{app}\ceiling.exe"; Parameters: "menubar"; WorkingDir: "{app}"; Tasks: desktopicon; IconFilename: "{app}\icon.ico"; AppUserModelID: "{#AppUserModelId}"
 
 [Run]
 Filename: "{app}\ceiling.exe"; Parameters: "menubar"; Description: "Launch Ceiling"; Flags: nowait postinstall skipifsilent; Check: CanLaunchCeiling

--- a/rust/src/notifications.rs
+++ b/rust/src/notifications.rs
@@ -1444,18 +1444,6 @@ mod tests {
             let _ = std::fs::remove_file(&missing);
             assert_eq!(read_shortcut_aumid(&missing), None);
 
-            // If a shortcut is installed, whatever it claims must be readable
-            // as a real string rather than coming back empty.
-            if let Ok(installed) = start_menu_shortcut_path()
-                && installed.exists()
-            {
-                let claimed = read_shortcut_aumid(&installed);
-                assert!(
-                    claimed.as_deref().is_some_and(|id| !id.is_empty()),
-                    "installed shortcut read back no AUMID: {claimed:?}"
-                );
-            }
-
             if initialized {
                 CoUninitialize();
             }
@@ -1472,6 +1460,34 @@ mod tests {
         assert!(
             config.contains(&format!("\"identifier\": \"{CEILING_AUMID}\"")),
             "tauri.conf.json no longer declares {CEILING_AUMID} as its identifier"
+        );
+    }
+
+    /// The installer is the only thing that gives Ceiling a notification
+    /// identity, and it failing to do so is invisible until someone notices
+    /// alerts are not being kept. 1.5.17 shipped exactly that way: the
+    /// `[Icons]` entries had no `AppUserModelID`, so the shortcut claimed
+    /// nothing and Windows discarded every toast it rendered.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn the_installer_stamps_our_aumid_onto_the_start_menu_shortcut() {
+        let script = include_str!("../installer/codexbar.iss");
+
+        assert!(
+            script.contains(&format!(r#"#define AppUserModelId "{CEILING_AUMID}""#)),
+            "installer no longer defines {CEILING_AUMID} as its AppUserModelId"
+        );
+
+        let start_menu_icon = script
+            .lines()
+            .find(|line| {
+                line.trim_start()
+                    .starts_with(r#"Name: "{autoprograms}\Ceiling""#)
+            })
+            .expect("installer no longer creates a Start Menu shortcut");
+        assert!(
+            start_menu_icon.contains(r#"AppUserModelID: "{#AppUserModelId}""#),
+            "Start Menu shortcut does not claim our AUMID, so toasts will not be kept: {start_menu_icon}"
         );
     }
 

--- a/rust/src/updater.rs
+++ b/rust/src/updater.rs
@@ -525,7 +525,25 @@ fn registered_install_dir() -> Option<PathBuf> {
         .ok()?
         .get_value::<String, _>("InstallLocation")
         .ok()
-        .map(|location| PathBuf::from(location.trim_end_matches(['\\', '/'])))
+        .and_then(|location| parse_install_location(&location))
+}
+
+/// Turn a raw `InstallLocation` value into a directory worth comparing against.
+///
+/// Only an absolute path means anything here. A blank or relative value would
+/// be resolved against the *current working directory*, which for a shortcut
+/// launch is nothing to do with where Ceiling is installed, and could make the
+/// "this copy is not the installed one" refusal fire on a perfectly good
+/// install. Anything unusable is treated as "no registration", which lets the
+/// update proceed rather than blocking it on a malformed registry value.
+#[cfg(target_os = "windows")]
+fn parse_install_location(raw: &str) -> Option<PathBuf> {
+    let trimmed = raw.trim().trim_end_matches(['\\', '/']);
+    if trimmed.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(trimmed);
+    path.is_absolute().then_some(path)
 }
 
 /// Refuse to auto-apply an update that would leave *this* copy untouched.
@@ -827,6 +845,31 @@ mod tests {
             assert!(
                 !path_is_within(Path::new(outside), installed),
                 "{outside} should not count as installed"
+            );
+        }
+    }
+
+    /// A malformed registry value must not be mistaken for a real install
+    /// directory: a blank or relative one resolves against the working
+    /// directory, which could refuse a legitimate update.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn only_an_absolute_install_location_counts_as_a_registration() {
+        assert_eq!(
+            parse_install_location(r"C:\Users\me\AppData\Local\Programs\Ceiling\"),
+            Some(PathBuf::from(r"C:\Users\me\AppData\Local\Programs\Ceiling"))
+        );
+        // Surrounding whitespace is stripped, not treated as part of the path.
+        assert_eq!(
+            parse_install_location("  C:\\Programs\\Ceiling  "),
+            Some(PathBuf::from(r"C:\Programs\Ceiling"))
+        );
+
+        for unusable in ["", "   ", "\\", "/", "Ceiling", r".\Ceiling"] {
+            assert_eq!(
+                parse_install_location(unusable),
+                None,
+                "{unusable:?} should not read as an install directory"
             );
         }
     }

--- a/rust/src/updater.rs
+++ b/rust/src/updater.rs
@@ -258,6 +258,10 @@ pub async fn download_update(
 ) -> Result<PathBuf, String> {
     validate_auto_download(update_info)?;
 
+    // Clear out installers this build has already outgrown before adding
+    // another one, so the cache cannot grow without bound.
+    prune_superseded_downloads();
+
     let file_path = prepare_download_path(update_info)?;
     let response = start_download(&update_info.download_url).await?;
     write_download_response(response, &file_path, &progress_tx).await?;
@@ -479,6 +483,13 @@ pub fn apply_update(installer_path: &PathBuf) -> Result<(), String> {
     }
 
     #[cfg(target_os = "windows")]
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(reason) = update_would_not_replace_this_copy(&current_exe)
+    {
+        return Err(reason);
+    }
+
+    #[cfg(target_os = "windows")]
     spawn_windows_installer(
         installer_path,
         &windows_update_relaunch_path(
@@ -498,6 +509,62 @@ pub fn apply_update(installer_path: &PathBuf) -> Result<(), String> {
 
     // Exit the application to allow the installer to proceed
     std::process::exit(0);
+}
+
+/// Where the official installer puts Ceiling, as recorded by its own
+/// Add/Remove Programs registration.
+#[cfg(target_os = "windows")]
+fn registered_install_dir() -> Option<PathBuf> {
+    use winreg::RegKey;
+    use winreg::enums::HKEY_CURRENT_USER;
+
+    RegKey::predef(HKEY_CURRENT_USER)
+        .open_subkey(
+            r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\io.github.tsouth89.ceiling_is1",
+        )
+        .ok()?
+        .get_value::<String, _>("InstallLocation")
+        .ok()
+        .map(|location| PathBuf::from(location.trim_end_matches(['\\', '/'])))
+}
+
+/// Refuse to auto-apply an update that would leave *this* copy untouched.
+///
+/// The installer writes to a fixed directory. A copy of Ceiling running from
+/// anywhere else (a local `tauri build`, an old install from different
+/// packaging, a copy on a stick) is not the one it upgrades, so the update
+/// silently succeeds, this binary stays on the old version, the next check sees
+/// the same release, and it loops forever with nothing to show the user why.
+///
+/// Returns the reason to refuse, or `None` when applying is safe.
+#[cfg(target_os = "windows")]
+fn update_would_not_replace_this_copy(current_exe: &Path) -> Option<String> {
+    let install_dir = registered_install_dir()?;
+    if !install_dir.exists() {
+        // Nothing registered on disk to contradict; let the update proceed.
+        return None;
+    }
+    if path_is_within(current_exe, &install_dir) {
+        return None;
+    }
+    Some(format!(
+        "This copy of Ceiling is running from {} but the installer updates {}. \
+         Applying the update here would leave this copy on the old version and keep \
+         prompting you. Close this copy and run the installed Ceiling, or download the \
+         installer from the releases page.",
+        current_exe.parent().unwrap_or(current_exe).display(),
+        install_dir.display()
+    ))
+}
+
+#[cfg(target_os = "windows")]
+fn path_is_within(path: &Path, dir: &Path) -> bool {
+    // Compare case-insensitively: Windows paths differing only in case are the
+    // same directory, and refusing a valid update over that is worse than the
+    // rare false accept.
+    let normalize = |value: &Path| value.to_string_lossy().to_lowercase().replace('/', "\\");
+    let dir = normalize(dir);
+    normalize(path).starts_with(&format!("{}\\", dir.trim_end_matches('\\')))
 }
 
 #[cfg(target_os = "windows")]
@@ -675,9 +742,115 @@ pub fn cleanup_downloads() {
     }
 }
 
+/// Delete cached installers at or below the running version.
+///
+/// Every downloaded installer was kept forever: a real machine had ten of them
+/// going back to 0.43.3, 305 MB, none of them useful once installed. Only an
+/// installer newer than the running version can still be applied, which is
+/// exactly what [`find_pending_installer_in_dir`] looks for, so anything else
+/// is dead weight.
+///
+/// Best-effort by design. A file that will not delete (open, locked, denied) is
+/// skipped rather than failing the update it is housekeeping for.
+pub fn prune_superseded_downloads() {
+    let Some(download_dir) = get_download_dir() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(&download_dir) else {
+        return;
+    };
+    let current_version = parse_version_triplet(CURRENT_VERSION);
+    let mut removed = 0usize;
+    let mut freed = 0u64;
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        let Some(version) = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(installer_version_from_name)
+        else {
+            continue;
+        };
+        if version > current_version {
+            continue;
+        }
+        let size = entry.metadata().map(|meta| meta.len()).unwrap_or(0);
+        if std::fs::remove_file(&path).is_ok() {
+            removed += 1;
+            freed += size;
+        }
+    }
+    if removed > 0 {
+        tracing::info!(
+            removed,
+            freed_mb = freed / (1024 * 1024),
+            "pruned superseded update installers"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A copy running outside the installed directory is never the one the
+    /// installer upgrades, and applying anyway is what produced a silent
+    /// forever-loop: install succeeds elsewhere, this binary stays old, the
+    /// next check offers the same release again.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn an_update_that_would_not_replace_this_copy_is_refused() {
+        let installed = Path::new(r"C:\Users\me\AppData\Local\Programs\Ceiling");
+
+        // The installed copy applies normally.
+        assert!(path_is_within(
+            Path::new(r"C:\Users\me\AppData\Local\Programs\Ceiling\ceiling.exe"),
+            installed
+        ));
+        // Windows path case must not decide whether an update is allowed.
+        assert!(path_is_within(
+            Path::new(r"c:\users\me\appdata\local\programs\CEILING\ceiling.exe"),
+            installed
+        ));
+        assert!(path_is_within(
+            Path::new(r"C:\Users\me\AppData\Local\Programs\Ceiling\bin\ceiling.exe"),
+            installed
+        ));
+
+        // A local `tauri build`, an old install from different packaging, and a
+        // sibling directory that merely shares a prefix are all not it.
+        for outside in [
+            r"C:\Users\me\AppData\Local\Ceiling\codexbar-desktop-tauri.exe",
+            r"C:\projects\ceiling\target\debug\ceiling.exe",
+            r"C:\Users\me\AppData\Local\Programs\Ceiling-old\ceiling.exe",
+        ] {
+            assert!(
+                !path_is_within(Path::new(outside), installed),
+                "{outside} should not count as installed"
+            );
+        }
+    }
+
+    #[test]
+    fn only_installers_newer_than_this_build_are_worth_keeping() {
+        // prune_superseded_downloads and find_pending_installer_in_dir must
+        // agree, or pruning would delete the very update about to be applied.
+        let current = parse_version_triplet(CURRENT_VERSION);
+        for name in [
+            "Ceiling-0.43.3-Setup.exe",
+            "Ceiling-1.2.0-Setup.exe",
+            "Ceiling-1.5.12-Setup.exe",
+        ] {
+            let version = installer_version_from_name(name).expect(name);
+            assert!(version <= current, "{name} should be prunable");
+        }
+
+        let far_future = installer_version_from_name("Ceiling-99.0.0-Setup.exe").unwrap();
+        assert!(
+            far_future > current,
+            "a genuinely newer installer must survive pruning"
+        );
+    }
 
     #[test]
     fn test_version_comparison() {


### PR DESCRIPTION
Chasing a real update loop on a live machine turned up three faults, one of which means **1.5.17's headline fix does not work on a clean install**.

## 1. The installer never claimed our notification identity

Windows resolves a desktop app's notification identity from a Start Menu shortcut carrying `AppUserModelID`. The installer's `[Icons]` entries set no such property:

```
Name: "{autoprograms}\Ceiling"; Filename: "{app}\ceiling.exe"; ... IconFilename: "{app}\icon.ico"
```

So the shortcut claimed nothing, and Windows went back to discarding toasts after drawing the banner - exactly the bug #180 set out to fix.

It looked correct during that work only by accident: the machine had an older Tauri NSIS install, and *Tauri's* NSIS installer does stamp the AUMID. Once 1.5.17's Inno installer replaced that shortcut, the property read back as an empty string:

```
before: ''
after : 'io.github.tsouth89.ceiling'
```

Fixed by setting `AppUserModelID` on both `[Icons]` entries from a shared `#define`, so the `AppId` directive and the shortcuts cannot drift.

**Anyone who installed 1.5.17 has no notification history until they reinstall.**

## 2. The updater looped forever with nothing to explain it

The installer writes to `{localappdata}\Programs\Ceiling`. A copy of Ceiling running anywhere else is not the one it upgrades, so the install succeeds, the running binary stays on the old version, the next check offers the same release, and round it goes. Silently, with no diagnostic.

Reproduced exactly: a local `tauri build` at `%LOCALAPPDATA%\Ceiling` kept re-applying 1.5.17 into `Programs\Ceiling` and relaunching itself, still on 1.5.16.

`apply_update` now compares the running exe against the installer's registered `InstallLocation` and refuses with a message naming both paths, rather than looping.

## 3. Cached installers were never pruned

`cleanup_downloads()` existed but was **dead code**, never called from anywhere. Every downloaded installer was kept forever. The machine had ten, going back to 0.43.3 - **305 MB**.

`prune_superseded_downloads()` now runs before each download and drops anything at or below the running version, which is precisely the set `find_pending_installer_in_dir` already refuses to apply.

## Tests

- `the_installer_stamps_our_aumid_onto_the_start_menu_shortcut` - asserts the `.iss` defines our AUMID and puts it on the Start Menu icon. This failure mode is invisible until someone notices alerts are not being kept, so it needs a guard.
- `an_update_that_would_not_replace_this_copy_is_refused` - covers the installed copy, case-differing paths, and the three not-it cases including a sibling directory that merely shares a prefix.
- `only_installers_newer_than_this_build_are_worth_keeping` - pins pruning to the same comparison the pending-installer search uses, so pruning cannot delete the update about to be applied.

I also removed an assertion that read the machine's own installed shortcut. It is what caught fault 1, but a test depending on local install state fails for the wrong reasons on other machines; the `.iss` guard covers the same invariant deterministically.

775 + 459 Rust tests pass, both clippy gates clean.
