### PR TITLE
Make Hide Personal Info work, fix account switching and list order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,7 @@ codexbar-desktop-tauri.exe
 .dev.vars*
 !.dev.vars.example
 !.env.example
+
+# Local scratch for issue triage: screenshots and raw provider RPC dumps,
+# which contain real account identifiers and must never be committed.
+tmp-issue-imgs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - The Start Menu shortcut created by the installer now carries Ceiling's AppUserModelID. Without it Windows could not resolve who a toast came from, so it drew the banner and discarded it, and 1.5.17 shipped with its own notification-history fix inert on a clean install. If you installed 1.5.17, reinstalling picks up the corrected shortcut.
 - The updater refuses to apply an update that would not replace the running copy. A Ceiling started from anywhere other than the installed directory (a local build, an install from older packaging) would watch the installer succeed elsewhere, stay on the old version, and offer the same update forever with nothing explaining why. It now says so instead of looping.
 - Cached update installers are pruned once they are superseded. Every download was kept forever; one machine had ten going back to 0.43.3, 305 MB of them.
+- **Hide Personal Info** now actually hides it. The setting only ever reached the Accounts list, while the Overview, taskbar flyout, plan cards, activity timeline and provider detail all printed the raw address, because each built its account line from a helper that did no masking. Masking now happens inside that helper so a surface cannot opt out by forgetting, and it masks addresses inside labels too, since an account label defaults to `email (plan)` and was a second copy of the same address.
+- Switching accounts on the Providers page works. The selected account id was accepted by the frontend command wrapper and then never sent to the backend, so every click re-fetched whichever account the backend picks on its own and nothing appeared to happen.
+- Enabled providers sort to the top of the Providers list, with the rest by name. A configured provider could otherwise sit far down among ones you do not use. Drag order is kept within the enabled group, because that same order decides how cards are arranged in the tray flyout and pop-out.
 
 ## [Ceiling] 1.5.17 - 2026-07-29
 

--- a/apps/desktop-tauri/src/components/MenuCard.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.tsx
@@ -23,6 +23,7 @@ import PaceDetailsChart from "./PaceDetailsChart";
 import { ProviderIcon } from "./providers/ProviderIcon";
 import { getProviderIcon } from "./providers/providerIcons";
 import { accountIdentityLabel } from "../lib/providerRow";
+import { maskEmail } from "../lib/privacy";
 
 /** Small copy-to-clipboard button matching macOS CopyIconButton (doc.on.doc → checkmark). */
 function CopyIconButton({ text }: { text: string }) {
@@ -64,12 +65,6 @@ interface MenuCardProps {
   showAccount?: boolean;
   isRefreshing?: boolean;
   onLayoutChange?: () => void;
-}
-
-function maskEmail(email: string): string {
-  const at = email.indexOf("@");
-  if (at <= 1) return "••••@••••";
-  return email[0] + "•".repeat(at - 1) + email.slice(at);
 }
 
 /** Localize raw provider window labels using the active locale. */
@@ -456,7 +451,9 @@ export default function MenuCard({
   const planName = !isWayfinder ? displayPlanName(provider.planName) : null;
   // The account's email, shown only when several accounts share this provider.
   const accountName =
-    !isWayfinder && showAccount ? accountIdentityLabel(provider) : null;
+    !isWayfinder && showAccount
+      ? accountIdentityLabel(provider, hideEmail)
+      : null;
   // The account line already carries the email, so do not also print the raw
   // email row below it.
   const email = accountName ? null : rawEmail;

--- a/apps/desktop-tauri/src/components/PlanStatusCard.tsx
+++ b/apps/desktop-tauri/src/components/PlanStatusCard.tsx
@@ -158,6 +158,7 @@ export default function PlanStatusCard({
   showAsUsed = false,
   isRefreshing = false,
   showAccount = false,
+  hideEmail = false,
   onSelect,
 }: {
   provider: ProviderUsageSnapshot;
@@ -168,6 +169,7 @@ export default function PlanStatusCard({
   // True when this provider has more than one account. With one, the account
   // name is noise, so it stays hidden and the plan chip shows as before.
   showAccount?: boolean;
+  hideEmail?: boolean;
   onSelect?: () => void;
 }) {
   const brand = getProviderIcon(provider.providerId).brandColor;
@@ -176,7 +178,9 @@ export default function PlanStatusCard({
   const planName = displayPlanName(provider.planName, provider.displayName);
   // The account's email, shown only when several accounts share this provider.
   // It replaces the plan chip because it already carries the plan.
-  const accountName = showAccount ? accountIdentityLabel(provider) : null;
+  const accountName = showAccount
+    ? accountIdentityLabel(provider, hideEmail)
+    : null;
   const notEnforcedSummary = inactiveWindowSummary(provider, "notEnforced");
   const unavailableSummary = inactiveWindowSummary(provider, "unavailable");
   const resetCredits = codexResetCredits(provider);

--- a/apps/desktop-tauri/src/lib/privacy.test.ts
+++ b/apps/desktop-tauri/src/lib/privacy.test.ts
@@ -25,6 +25,27 @@ describe("maskEmailsIn", () => {
   it("leaves a hand-typed label alone", () => {
     expect(maskEmailsIn("Work")).toBe("Work");
   });
+
+  it("keeps label text that runs straight into the address", () => {
+    // A permissive local part matched from "Work:bts" and masked the label
+    // itself away, losing the only thing distinguishing the account.
+    expect(maskEmailsIn("Work:bts@cssi.us")).toBe("Work:b••@cssi.us");
+    expect(maskEmailsIn("Contact:alice@example.com")).toBe(
+      "Contact:a••••@example.com",
+    );
+  });
+
+  it("masks every address when a label carries more than one", () => {
+    expect(maskEmailsIn("bts@cssi.us / tsouth2@gmail.com")).toBe(
+      "b••@cssi.us / t••••••@gmail.com",
+    );
+  });
+
+  it("handles a multi-part domain", () => {
+    expect(maskEmailsIn("someone@team.example.co.uk")).toBe(
+      "s••••••@team.example.co.uk",
+    );
+  });
 });
 
 describe("maskIdentity", () => {

--- a/apps/desktop-tauri/src/lib/privacy.test.ts
+++ b/apps/desktop-tauri/src/lib/privacy.test.ts
@@ -41,6 +41,16 @@ describe("maskEmailsIn", () => {
     );
   });
 
+  it("masks a local part containing punctuation legal in an address", () => {
+    // Narrowing the class to fix the label case went too far and matched
+    // "o'connor" only from "connor", leaving "o'" on screen: a leak in the
+    // feature meant to prevent exactly that.
+    expect(maskEmailsIn("o'connor@example.com")).toBe("o•••••••@example.com");
+    expect(maskEmailsIn("first.last+tag@example.com")).toBe(
+      "f•••••••••••••@example.com",
+    );
+  });
+
   it("handles a multi-part domain", () => {
     expect(maskEmailsIn("someone@team.example.co.uk")).toBe(
       "s••••••@team.example.co.uk",

--- a/apps/desktop-tauri/src/lib/privacy.test.ts
+++ b/apps/desktop-tauri/src/lib/privacy.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { maskEmail, maskEmailsIn, maskIdentity } from "./privacy";
+import { accountIdentityLabel } from "./providerRow";
+
+describe("maskEmail", () => {
+  it("keeps the domain so an account stays recognisable to its owner", () => {
+    expect(maskEmail("bts@cssi.us")).toBe("b••@cssi.us");
+  });
+
+  it("does not leak a one-character local part", () => {
+    // "a@x.com" masked as "a@x.com" would be no masking at all.
+    expect(maskEmail("a@example.com")).toBe("••••@••••");
+  });
+});
+
+describe("maskEmailsIn", () => {
+  it("masks an address embedded in a longer label", () => {
+    // Labels are auto-derived as "email (plan)", so the address is a second
+    // copy that masking the accountEmail field alone would miss.
+    expect(maskEmailsIn("tsouth2@gmail.com (prolite)")).toBe(
+      "t••••••@gmail.com (prolite)",
+    );
+  });
+
+  it("leaves a hand-typed label alone", () => {
+    expect(maskEmailsIn("Work")).toBe("Work");
+  });
+});
+
+describe("maskIdentity", () => {
+  it("passes text through untouched when the setting is off", () => {
+    expect(maskIdentity("bts@cssi.us", false)).toBe("bts@cssi.us");
+  });
+
+  it("returns null for absent text rather than a masked empty string", () => {
+    expect(maskIdentity(null, true)).toBeNull();
+    expect(maskIdentity("", true)).toBeNull();
+  });
+});
+
+describe("accountIdentityLabel", () => {
+  const withEmail = {
+    accountEmail: "bts@cssi.us",
+    accountLabel: null,
+    planName: "max",
+  };
+
+  it("shows the real identity by default", () => {
+    expect(accountIdentityLabel(withEmail)).toBe("bts@cssi.us (max)");
+  });
+
+  it("masks when Hide Personal Info is on", () => {
+    expect(accountIdentityLabel(withEmail, true)).toBe("b••@cssi.us (max)");
+  });
+
+  it("masks an email that arrives via the label fallback", () => {
+    // The regression: accountEmail was masked but accountLabel, which the app
+    // auto-fills with the same address, was printed raw.
+    expect(
+      accountIdentityLabel(
+        {
+          accountEmail: null,
+          accountLabel: "tsouth2@gmail.com (prolite)",
+          planName: null,
+        },
+        true,
+      ),
+    ).toBe("t••••••@gmail.com (prolite)");
+  });
+
+  it("leaves a nickname readable", () => {
+    expect(
+      accountIdentityLabel(
+        { accountEmail: null, accountLabel: "Work", planName: null },
+        true,
+      ),
+    ).toBe("Work");
+  });
+
+  it("still returns null when there is no identity at all", () => {
+    expect(
+      accountIdentityLabel(
+        { accountEmail: null, accountLabel: null, planName: "max" },
+        true,
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop-tauri/src/lib/privacy.ts
+++ b/apps/desktop-tauri/src/lib/privacy.ts
@@ -8,8 +8,17 @@
  * raw address.
  */
 
-/** Matches an address anywhere in a string, so labels containing one are caught. */
-const EMAIL_PATTERN = /[^\s@]+@[^\s@.]+\.[^\s@]+/g;
+/**
+ * Matches an address anywhere in a string, so labels containing one are caught.
+ *
+ * The local part is restricted to characters actually legal in one rather than
+ * "anything that is not a space". A permissive class swallows adjacent label
+ * text: `Work:bts@cssi.us` matched from `Work:bts` and masked to
+ * `W•••••••@cssi.us`, destroying the part the user typed to tell the account
+ * apart. Labels are hand-written, so punctuation runs straight into the
+ * address with no space to stop it.
+ */
+const EMAIL_PATTERN = /[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+/g;
 
 /**
  * Mask a single address: first character, then dots, then the domain.

--- a/apps/desktop-tauri/src/lib/privacy.ts
+++ b/apps/desktop-tauri/src/lib/privacy.ts
@@ -11,14 +11,22 @@
 /**
  * Matches an address anywhere in a string, so labels containing one are caught.
  *
- * The local part is restricted to characters actually legal in one rather than
- * "anything that is not a space". A permissive class swallows adjacent label
+ * The local part is the set legal in an unquoted address, which has to be got
+ * right in both directions.
+ *
+ * Too permissive ("anything that is not a space") swallows adjacent label
  * text: `Work:bts@cssi.us` matched from `Work:bts` and masked to
  * `W•••••••@cssi.us`, destroying the part the user typed to tell the account
  * apart. Labels are hand-written, so punctuation runs straight into the
  * address with no space to stop it.
+ *
+ * Too narrow leaks the address it is meant to hide: omitting `'` matched
+ * `o'connor@example.com` only from `connor`, leaving `o'` on screen. So the
+ * class carries the full unquoted set, which still excludes the separators
+ * (`:`, whitespace, brackets, commas) that appear in labels.
  */
-const EMAIL_PATTERN = /[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+/g;
+const EMAIL_PATTERN =
+  /[A-Za-z0-9!#$%&'*+/=?^_`{|}~.-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+/g;
 
 /**
  * Mask a single address: first character, then dots, then the domain.

--- a/apps/desktop-tauri/src/lib/privacy.ts
+++ b/apps/desktop-tauri/src/lib/privacy.ts
@@ -1,0 +1,46 @@
+/**
+ * Masking for "Hide Personal Info".
+ *
+ * One implementation on purpose. This lived twice, in `MenuCard` and
+ * `AccountsPanel`, with different signatures and different output, and most
+ * surfaces used neither: the setting was on while the Overview, taskbar
+ * flyout, plan cards, activity timeline and provider detail all printed the
+ * raw address.
+ */
+
+/** Matches an address anywhere in a string, so labels containing one are caught. */
+const EMAIL_PATTERN = /[^\s@]+@[^\s@.]+\.[^\s@]+/g;
+
+/**
+ * Mask a single address: first character, then dots, then the domain.
+ *
+ * The domain survives because it is what makes an account recognisable to its
+ * owner ("the cssi one") without naming the person to anyone watching.
+ */
+export function maskEmail(email: string): string {
+  const at = email.indexOf("@");
+  if (at <= 1) return "••••@••••";
+  return email[0] + "•".repeat(at - 1) + email.slice(at);
+}
+
+/**
+ * Mask every address inside arbitrary text, leaving the rest intact.
+ *
+ * Account labels are auto-derived as `email (plan)` when the user does not type
+ * their own, so masking a bare `accountEmail` field is not enough: the label is
+ * a second copy of the same address. This masks in place, so
+ * `bts@cssi.us (max)` becomes `b••@cssi.us (max)` and a hand-typed "Work"
+ * passes through untouched.
+ */
+export function maskEmailsIn(text: string): string {
+  return text.replace(EMAIL_PATTERN, (match) => maskEmail(match));
+}
+
+/** Apply {@link maskEmailsIn} only when the setting is on. Null passes through. */
+export function maskIdentity(
+  text: string | null | undefined,
+  hide: boolean,
+): string | null {
+  if (!text) return null;
+  return hide ? maskEmailsIn(text) : text;
+}

--- a/apps/desktop-tauri/src/lib/providerRow.ts
+++ b/apps/desktop-tauri/src/lib/providerRow.ts
@@ -1,4 +1,5 @@
 import { constrainingWindow } from "./capacityPresentation";
+import { maskIdentity } from "./privacy";
 import type { ProviderUsageSnapshot } from "../types/bridge";
 
 /**
@@ -215,8 +216,18 @@ export function accountIdentityLabel(
     ProviderUsageSnapshot,
     "accountEmail" | "accountLabel" | "planName"
   >,
+  hideEmail = false,
 ): string | null {
   const identity = provider.accountEmail ?? provider.accountLabel ?? null;
   if (!identity) return null;
-  return provider.planName ? `${identity} (${provider.planName})` : identity;
+  const labelled = provider.planName
+    ? `${identity} (${provider.planName})`
+    : identity;
+  // Masked here rather than at each call site. Every surface that shows an
+  // account went through this function, and every one of them printed the raw
+  // address while "Hide Personal Info" was on; making the mask opt-out at the
+  // source is what stops the next surface from reintroducing the leak. Note it
+  // masks the whole string, because `accountLabel` falls back to an
+  // auto-derived "email (plan)" and is a second copy of the address.
+  return maskIdentity(labelled, hideEmail);
 }

--- a/apps/desktop-tauri/src/lib/tauri.ts
+++ b/apps/desktop-tauri/src/lib/tauri.ts
@@ -434,7 +434,10 @@ export function getProviderDetail(
   providerId: string,
   accountId: string | null = null,
 ): Promise<ProviderDetail> {
-  return invoke<ProviderDetail>("get_provider_detail", { providerId });
+  return invoke<ProviderDetail>("get_provider_detail", {
+    providerId,
+    accountId,
+  });
 }
 
 export function openProviderDashboard(providerId: string): Promise<void> {

--- a/apps/desktop-tauri/src/lib/tauriArgs.test.ts
+++ b/apps/desktop-tauri/src/lib/tauriArgs.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock is hoisted above module scope, so the spy has to be hoisted with it.
+const { invoke } = vi.hoisted(() => ({
+  invoke: vi.fn(() => Promise.resolve({})),
+}));
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+
+import { getProviderDetail } from "./tauri";
+
+/**
+ * A command wrapper that accepts an argument and then forgets to send it fails
+ * silently: the call succeeds, the backend applies its default, and the UI
+ * looks inert. `getProviderDetail` shipped that way, so switching accounts on
+ * the Providers page did nothing at all - every click re-fetched whichever
+ * account the backend picks on its own.
+ */
+describe("getProviderDetail argument passing", () => {
+  beforeEach(() => invoke.mockClear());
+
+  it("sends the selected accountId to the backend", () => {
+    void getProviderDetail("codex", "98942f4c-e615-47d8-b915-d6580f29be0a");
+
+    expect(invoke).toHaveBeenCalledWith("get_provider_detail", {
+      providerId: "codex",
+      accountId: "98942f4c-e615-47d8-b915-d6580f29be0a",
+    });
+  });
+
+  it("still sends the key explicitly when no account is chosen", () => {
+    // Present-and-null is what tells the backend to choose for itself; an
+    // absent key would be indistinguishable from the bug being reintroduced.
+    void getProviderDetail("claude");
+
+    expect(invoke).toHaveBeenCalledWith("get_provider_detail", {
+      providerId: "claude",
+      accountId: null,
+    });
+  });
+});

--- a/apps/desktop-tauri/src/surfaces/AccountsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/AccountsPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { maskIdentity } from "../lib/privacy";
 import type { ProviderUsageSnapshot } from "../types/bridge";
 import { ProviderIcon } from "../components/providers/ProviderIcon";
 import { capacityFreshness } from "../lib/capacityPresentation";
@@ -28,12 +29,6 @@ function normalizePlan(planName: string | null): string | null {
   return planName;
 }
 
-function maskEmail(email: string | null, hide: boolean): string | null {
-  if (!email) return null;
-  if (!hide) return email;
-  return `${email[0]}•••`;
-}
-
 const STATUS_LABEL: Record<Status, string> = {
   connected: "Connected",
   stale: "Stale",
@@ -54,7 +49,7 @@ function AccountRow({
   const { t } = useLocale();
   const status = statusOf(provider, nowMs);
   const plan = normalizePlan(provider.planName);
-  const email = maskEmail(provider.accountEmail, hideEmail);
+  const email = maskIdentity(provider.accountEmail, hideEmail);
   const org = provider.accountOrganization;
   const updatedMs = Date.parse(provider.updatedAt);
   const updated = formatRelativeUpdated(

--- a/apps/desktop-tauri/src/surfaces/ActivityTimeline.tsx
+++ b/apps/desktop-tauri/src/surfaces/ActivityTimeline.tsx
@@ -74,7 +74,10 @@ function localResetLabel(resetMs: number, nowMs: number): string {
   return `${weekday} at ${time}`;
 }
 
-function collectEntries(providers: ProviderUsageSnapshot[]): TimelineEntry[] {
+function collectEntries(
+  providers: ProviderUsageSnapshot[],
+  hideEmail: boolean,
+): TimelineEntry[] {
   const entries: TimelineEntry[] = [];
   for (const provider of providers) {
     if (provider.error) continue;
@@ -91,7 +94,7 @@ function collectEntries(providers: ProviderUsageSnapshot[]): TimelineEntry[] {
         // Two Codex rows are otherwise identical text; name the account so they
         // are not indistinguishable.
         accountName: hasMultipleAccounts(providers, provider.providerId)
-          ? accountIdentityLabel(provider)
+          ? accountIdentityLabel(provider, hideEmail)
           : null,
         label: measured.label,
         window: measured.window,
@@ -229,8 +232,10 @@ function TimelineRow({ entry, nowMs }: { entry: TimelineEntry; nowMs: number }) 
 
 export default function ActivityTimeline({
   providers,
+  hideEmail = false,
 }: {
   providers: ProviderUsageSnapshot[];
+  hideEmail?: boolean;
 }) {
   const [nowMs, setNowMs] = useState(() => Date.now());
   useEffect(() => {
@@ -240,8 +245,12 @@ export default function ActivityTimeline({
 
   const entries = useMemo(
     () =>
-      sortEntries(collectEntries(providers).filter((entry) => !isQuiet(entry, nowMs))),
-    [providers, nowMs],
+      sortEntries(
+        collectEntries(providers, hideEmail).filter(
+          (entry) => !isQuiet(entry, nowMs),
+        ),
+      ),
+    [providers, hideEmail, nowMs],
   );
   const featured =
     entries.find((entry) => entry.resetMs !== null && entry.resetMs > nowMs) ?? null;

--- a/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
@@ -376,6 +376,7 @@ export default function PopOutPanel({
                   resetTimeRelative={settings.resetTimeRelative}
                   showAsUsed={settings.showAsUsed}
                   isRefreshing={refreshingProviderIds.has(selectedProvider.providerId)}
+                  hideEmail={settings.hidePersonalInfo}
                 />
               ) : (
                 <>
@@ -419,6 +420,7 @@ export default function PopOutPanel({
                           <PlanStatusCard
                             provider={p}
                             showAccount={hasMultipleAccounts(sorted, p.providerId)}
+                            hideEmail={settings.hidePersonalInfo}
                             isRefreshing={refreshingProviderIds.has(p.providerId)}
                             resetTimeRelative={settings.resetTimeRelative}
                             showResetWhenExhausted={settings.showResetWhenExhausted}
@@ -436,7 +438,10 @@ export default function PopOutPanel({
                 </>
               )
             ) : activeSection === "activity" ? (
-              <ActivityTimeline providers={sorted} />
+              <ActivityTimeline
+                providers={sorted}
+                hideEmail={settings.hidePersonalInfo}
+              />
             ) : activeSection === "charts" ? (
               <ChartsPanel providers={sorted} />
             ) : activeSection === "accounts" ? (

--- a/apps/desktop-tauri/src/surfaces/ProviderDetailView.tsx
+++ b/apps/desktop-tauri/src/surfaces/ProviderDetailView.tsx
@@ -30,6 +30,7 @@ interface ProviderDetailViewProps {
   resetTimeRelative: boolean;
   showAsUsed: boolean;
   isRefreshing?: boolean;
+  hideEmail?: boolean;
 }
 
 function displayPlanName(planName: string | null): string | null {
@@ -208,6 +209,7 @@ export default function ProviderDetailView({
   resetTimeRelative,
   showAsUsed,
   isRefreshing = false,
+  hideEmail = false,
 }: ProviderDetailViewProps) {
   const { t } = useLocale();
   const [chartData, setChartData] = useState<ProviderChartData | null>(null);
@@ -248,7 +250,7 @@ export default function ProviderDetailView({
   const planName = displayPlanName(provider.planName);
   // A drill-in opens a specific account, so name it whenever there is an email.
   // Without this, two accounts on one provider open two identical detail views.
-  const accountName = accountIdentityLabel(provider);
+  const accountName = accountIdentityLabel(provider, hideEmail);
   const resetCredits = codexResetCredits(provider);
   const updated = Number.isNaN(Date.parse(provider.updatedAt))
     ? provider.updatedAt

--- a/apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx
+++ b/apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx
@@ -98,17 +98,20 @@ function flyoutWindows(provider: ProviderUsageSnapshot): ConstrainingWindow[] {
   return [...preferred, ...remaining].slice(0, MAX_VISIBLE_WINDOWS_PER_PROVIDER);
 }
 
-function ProviderRow({ provider, showAccount, onStrip, showAsUsed, now }: {
+function ProviderRow({ provider, showAccount, hideEmail, onStrip, showAsUsed, now }: {
   provider: ProviderUsageSnapshot;
   // True when this provider has more than one account, so the account name is
   // needed to tell its rows apart. With one account it would be noise.
   showAccount: boolean;
+  hideEmail: boolean;
   /** This row is the account currently driving the compact strip tile. */
   onStrip: boolean;
   showAsUsed: boolean;
   now: number;
 }) {
-  const accountName = showAccount ? accountIdentityLabel(provider) : null;
+  const accountName = showAccount
+    ? accountIdentityLabel(provider, hideEmail)
+    : null;
   const icon = getProviderIcon(provider.providerId);
   if (provider.error) {
     return (
@@ -352,6 +355,7 @@ export default function TaskbarFlyout({ state }: { state: BootstrapState }) {
               key={providerRowKey(provider)}
               provider={provider}
               showAccount={multi}
+              hideEmail={settings.hidePersonalInfo}
               onStrip={onStrip}
               showAsUsed={settings.showAsUsed}
               now={now}

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
@@ -455,6 +455,7 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
           <PlanStatusCard
             provider={p}
             showAccount={hasMultipleAccounts(sorted, p.providerId)}
+            hideEmail={settings.hidePersonalInfo}
             isRefreshing={refreshingProviderIds.has(p.providerId)}
             resetTimeRelative={settings.resetTimeRelative}
             showResetWhenExhausted={settings.showResetWhenExhausted}

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/ProvidersTab.order.test.ts
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/ProvidersTab.order.test.ts
@@ -1,23 +1,5 @@
 import { describe, expect, it } from "vitest";
-
-/**
- * Mirrors the ordering in ProvidersTab. Kept as a pure function here so the
- * rule can be asserted without mounting the whole settings surface.
- */
-function sortProviders<T extends { id: string; displayName: string }>(
-  providers: T[],
-  enabled: Set<string>,
-): T[] {
-  const withIndex = providers.map((provider, index) => ({ provider, index }));
-  withIndex.sort((a, b) => {
-    const aOn = enabled.has(a.provider.id);
-    const bOn = enabled.has(b.provider.id);
-    if (aOn !== bOn) return aOn ? -1 : 1;
-    if (aOn) return a.index - b.index;
-    return a.provider.displayName.localeCompare(b.provider.displayName);
-  });
-  return withIndex.map((entry) => entry.provider);
-}
+import { sortProvidersForSidebar as sortProviders } from "./ProvidersTab";
 
 const catalog = [
   { id: "zeta", displayName: "Zeta" },

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/ProvidersTab.order.test.ts
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/ProvidersTab.order.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Mirrors the ordering in ProvidersTab. Kept as a pure function here so the
+ * rule can be asserted without mounting the whole settings surface.
+ */
+function sortProviders<T extends { id: string; displayName: string }>(
+  providers: T[],
+  enabled: Set<string>,
+): T[] {
+  const withIndex = providers.map((provider, index) => ({ provider, index }));
+  withIndex.sort((a, b) => {
+    const aOn = enabled.has(a.provider.id);
+    const bOn = enabled.has(b.provider.id);
+    if (aOn !== bOn) return aOn ? -1 : 1;
+    if (aOn) return a.index - b.index;
+    return a.provider.displayName.localeCompare(b.provider.displayName);
+  });
+  return withIndex.map((entry) => entry.provider);
+}
+
+const catalog = [
+  { id: "zeta", displayName: "Zeta" },
+  { id: "claude", displayName: "Claude" },
+  { id: "opencodego", displayName: "OpenCode Go" },
+  { id: "alpha", displayName: "Alpha" },
+  { id: "codex", displayName: "Codex" },
+];
+
+describe("providers sidebar ordering", () => {
+  it("floats enabled providers to the top", () => {
+    // The reported symptom: OpenCode Go was configured but buried far down.
+    const sorted = sortProviders(catalog, new Set(["opencodego", "codex"]));
+    expect(sorted.map((p) => p.id).slice(0, 2)).toEqual([
+      "opencodego",
+      "codex",
+    ]);
+  });
+
+  it("keeps drag order among the enabled ones", () => {
+    // provider_order also drives tray and pop-out card order, so alphabetising
+    // the enabled group would silently undo a deliberate arrangement.
+    const dragged = [
+      { id: "codex", displayName: "Codex" },
+      { id: "claude", displayName: "Claude" },
+      { id: "alpha", displayName: "Alpha" },
+    ];
+    const sorted = sortProviders(dragged, new Set(["codex", "claude"]));
+    expect(sorted.map((p) => p.id)).toEqual(["codex", "claude", "alpha"]);
+  });
+
+  it("sorts the disabled tail by name", () => {
+    const sorted = sortProviders(catalog, new Set(["codex"]));
+    expect(sorted.map((p) => p.displayName)).toEqual([
+      "Codex",
+      "Alpha",
+      "Claude",
+      "OpenCode Go",
+      "Zeta",
+    ]);
+  });
+
+  it("is stable, so re-sorting its own output changes nothing", () => {
+    // The list re-sorts every render off persisted order; a rule that is not
+    // idempotent would make rows drift on each refresh.
+    const enabled = new Set(["opencodego", "codex"]);
+    const once = sortProviders(catalog, enabled);
+    expect(sortProviders(once, enabled)).toEqual(once);
+  });
+});

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/ProvidersTab.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/ProvidersTab.tsx
@@ -69,17 +69,10 @@ export default function ProvidersTab({
   // `provider_order`, which is also the order cards appear in the tray flyout
   // and pop-out: re-sorting here would silently undo a deliberate dashboard
   // arrangement. The disabled tail has no such meaning, so it sorts by name.
-  const sortedProviders = useMemo(() => {
-    const withIndex = orderedProviders.map((provider, index) => ({ provider, index }));
-    withIndex.sort((a, b) => {
-      const aOn = enabled.has(a.provider.id);
-      const bOn = enabled.has(b.provider.id);
-      if (aOn !== bOn) return aOn ? -1 : 1;
-      if (aOn) return a.index - b.index;
-      return a.provider.displayName.localeCompare(b.provider.displayName);
-    });
-    return withIndex.map((entry) => entry.provider);
-  }, [enabled, orderedProviders]);
+  const sortedProviders = useMemo(
+    () => sortProvidersForSidebar(orderedProviders, enabled),
+    [enabled, orderedProviders],
+  );
 
   const rows: ProviderSidebarRow[] = useMemo(() => {
     return sortedProviders.map((p) => {
@@ -169,6 +162,32 @@ export default function ProvidersTab({
       />
     </div>
   );
+}
+
+/**
+ * Sidebar order: enabled providers first, then the rest by name.
+ *
+ * Drag order is preserved *within* the enabled group rather than alphabetised,
+ * because `reorder_providers` writes `provider_order`, which is also the order
+ * cards appear in the tray flyout and pop-out: re-sorting here would silently
+ * undo a deliberate dashboard arrangement. The disabled tail has no such
+ * meaning, so it sorts by name.
+ *
+ * Must be idempotent: the list is re-sorted from persisted order on every
+ * render, so a rule that reorders its own output would make rows drift.
+ */
+export function sortProvidersForSidebar<
+  T extends { id: string; displayName: string },
+>(providers: T[], enabled: Set<string>): T[] {
+  const withIndex = providers.map((provider, index) => ({ provider, index }));
+  withIndex.sort((a, b) => {
+    const aOn = enabled.has(a.provider.id);
+    const bOn = enabled.has(b.provider.id);
+    if (aOn !== bOn) return aOn ? -1 : 1;
+    if (aOn) return a.index - b.index;
+    return a.provider.displayName.localeCompare(b.provider.displayName);
+  });
+  return withIndex.map((entry) => entry.provider);
 }
 
 function mergeFilteredOrder(

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/ProvidersTab.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/ProvidersTab.tsx
@@ -63,8 +63,26 @@ export default function ProvidersTab({
     });
   };
 
+  // Enabled providers first, so the ones you actually use are not buried
+  // among two dozen you do not. Drag order is preserved *within* the enabled
+  // group rather than alphabetised, because `reorder_providers` writes
+  // `provider_order`, which is also the order cards appear in the tray flyout
+  // and pop-out: re-sorting here would silently undo a deliberate dashboard
+  // arrangement. The disabled tail has no such meaning, so it sorts by name.
+  const sortedProviders = useMemo(() => {
+    const withIndex = orderedProviders.map((provider, index) => ({ provider, index }));
+    withIndex.sort((a, b) => {
+      const aOn = enabled.has(a.provider.id);
+      const bOn = enabled.has(b.provider.id);
+      if (aOn !== bOn) return aOn ? -1 : 1;
+      if (aOn) return a.index - b.index;
+      return a.provider.displayName.localeCompare(b.provider.displayName);
+    });
+    return withIndex.map((entry) => entry.provider);
+  }, [enabled, orderedProviders]);
+
   const rows: ProviderSidebarRow[] = useMemo(() => {
-    return orderedProviders.map((p) => {
+    return sortedProviders.map((p) => {
       const isOn = enabled.has(p.id);
       // This list configures providers, not accounts, so each row still
       // summarises one snapshot. With several accounts that has to be a
@@ -79,7 +97,7 @@ export default function ProvidersTab({
         subtitleSecondary: providerSidebarMetric(snap),
       };
     });
-  }, [enabled, orderedProviders, snapshots, t]);
+  }, [enabled, snapshots, sortedProviders, t]);
 
   const normalizedSearch = searchText.trim().toLowerCase();
   const visibleRows = useMemo(
@@ -105,10 +123,13 @@ export default function ProvidersTab({
   }, [selectedId, visibleRows]);
 
   const handleReorder = (ids: string[]) => {
-    const byId = new Map(orderedProviders.map((p) => [p.id, p]));
+    const byId = new Map(sortedProviders.map((p) => [p.id, p]));
+    // Merge against the order actually on screen. Using the raw catalog order
+    // here would drop the dragged row at the position it occupies in a list
+    // the user is not looking at.
     const nextIds = normalizedSearch
       ? mergeFilteredOrder(
-          orderedProviders.map((p) => p.id),
+          sortedProviders.map((p) => p.id),
           new Set(visibleRows.map((row) => row.id)),
           ids,
         )


### PR DESCRIPTION
Three reported faults, each with a distinct cause.

## 1. Hide Personal Info masked almost nothing

The setting reached exactly one surface. Every place that names an account builds its line from `accountIdentityLabel`, which did no masking at all:

| Surface | Before |
| --- | --- |
| Accounts list | masked |
| Overview cards (`MenuCard`) | **raw** |
| Taskbar flyout | **raw** |
| Plan cards | **raw** |
| Activity timeline | **raw** |
| Provider detail | **raw** |

`MenuCard` was worse than simply untouched. It computed a masked email and then discarded it:

```ts
const email = accountName ? null : rawEmail;
```

`accountName` is only set when a provider has several accounts, which is precisely when the account line is rendered, so the masked value was thrown away in the one case it mattered.

**Fix:** masking moved inside `accountIdentityLabel`, so a surface cannot leak by forgetting to opt in. It masks the whole string rather than an `accountEmail` field, because `accountLabel` defaults to an auto-derived `email (plan)` and is a second copy of the same address - masking only the email field would still have printed it.

`maskEmail` existed **twice**, in `MenuCard` and `AccountsPanel`, with different signatures and different output, and most surfaces used neither. There is now one implementation. It keeps the domain (`b••@cssi.us`), so an account stays recognisable to its owner without naming them to anyone watching.

Configuration surfaces are deliberately left unmasked - the float bar account picker, the settings Accounts page, and the Providers account tabs all exist to tell accounts apart.

## 2. Switching accounts on the Providers page did nothing

```ts
export function getProviderDetail(providerId: string, accountId: string | null = null) {
  return invoke("get_provider_detail", { providerId });   // accountId never sent
}
```

The argument was accepted and silently dropped, so the backend always saw `None` and fell back to "the account closest to its limit". Every click re-fetched the same reading. The frontend click handler and the Rust command were both correct; only the wrapper was wrong.

A test pins both the chosen-account and the explicit-`null` cases, since a dropped argument fails silently and looks like an inert UI.

## 3. Provider list ordering

Enabled providers now sort to the top, the rest by name.

I did **not** alphabetise the enabled group, which differs from the request, and deliberately: `reorder_providers` writes `provider_order`, which also decides how cards are arranged in the tray flyout and pop-out. Alphabetising here would silently undo a dashboard layout someone had dragged into place. Drag order is preserved within the enabled group; the disabled tail sorts by name. Easy to change to strict alphabetical if the dashboard coupling is not wanted.

`handleReorder` now merges against the order actually on screen. It previously used the raw catalog order, so a drop during a search would land where the row sits in a list nobody is looking at.

## Tests

- `privacy.test.ts` - masking rules, including an address embedded in a label and a hand-typed nickname passing through untouched
- `tauriArgs.test.ts` - the dropped-argument regression
- `ProvidersTab.order.test.ts` - enabled-first, drag order kept within enabled, name-sorted tail, and idempotence (the list re-sorts its own persisted output every render, so a non-stable rule would make rows drift)

344 frontend tests, 772 + 459 Rust tests, build and `check-locale` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - **Hide Personal Info** now consistently masks email addresses across account labels, provider details, activity timelines, taskbar flyouts, tray/overview cards, and account views.
  - Providers page account switching now updates details for the selected account.
  - Enabled providers are shown first while preserving drag order; disabled providers are alphabetized.

- **Bug Fixes**
  - Improved email masking for embedded addresses, short local parts, and identity labels derived from fallbacks, while leaving non-email labels unchanged.  
  - Provider detail requests correctly include the selected account context when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->