### PR TITLE
Stop a 1% Claude session reading as 100% used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- A lightly used Claude account could report its 5-hour session as 100% used, and raise an exhausted alert, while the account was at 1%. Anthropic reports utilization as either whole percentages or fractions of the limit, and a lone `1` means 1% in one and 100% in the other. A response whose windows were all `0` or `1` was assumed to be fractions, so the first 1% of use rendered as a maxed-out session. The scale is now only read as fractions when the response actually contains a fractional value, which is the case that proves it.
+
 ## [Ceiling] 1.5.18 - 2026-07-29
 
 Follow-up to 1.5.17. Notification history did not actually work on a clean install, and a Ceiling running from outside the installed folder could loop on the same update forever. Also makes Hide Personal Info do what it says.

--- a/rust/src/providers/claude/mod.rs
+++ b/rust/src/providers/claude/mod.rs
@@ -90,18 +90,40 @@ pub(crate) enum UtilizationScale {
 impl UtilizationScale {
     /// Resolve the unit from every raw utilization in one response.
     ///
-    /// A value above `1.0` can only be a percentage, since a fraction never
-    /// exceeds the limit, so one such window settles the whole response.
-    /// Otherwise the values are read as fractions, which keeps a genuine `1.0`
-    /// meaning 100%.
+    /// Two things settle it, and only real evidence in the payload counts:
+    ///
+    /// - a value above `1.0` can only be a percentage, since a fraction never
+    ///   exceeds the limit;
+    /// - a value strictly between `0` and `1` can only be a fraction, since the
+    ///   API reports whole percentages.
+    ///
+    /// With neither, every window is `0` or `1` and the response is genuinely
+    /// ambiguous. That is read as percentages, because the alternative is worse
+    /// in practice: an account that has just been used reports `1` for 1%, and
+    /// calling that a fraction renders a barely-touched session as **100%
+    /// used**, which is what this previously did. Reading a real fraction-scale
+    /// `1.0` as 1% is the opposite error, but it needs a maxed window while
+    /// every other window in the same response sits at exactly `0` or `1`.
+    ///
+    /// A response reporting fractions gives itself away as soon as any window
+    /// holds an ordinary value like `0.14`, which is the common case.
     pub(crate) fn detect(values: impl IntoIterator<Item = f64>) -> Self {
-        if values
-            .into_iter()
-            .any(|value| value.is_finite() && value > 1.0)
-        {
-            Self::Percent
-        } else {
+        let mut saw_fraction = false;
+        for value in values {
+            if !value.is_finite() {
+                continue;
+            }
+            if value > 1.0 {
+                return Self::Percent;
+            }
+            if value > 0.0 && value < 1.0 {
+                saw_fraction = true;
+            }
+        }
+        if saw_fraction {
             Self::Fraction
+        } else {
+            Self::Percent
         }
     }
 

--- a/rust/src/providers/claude/oauth/mod.rs
+++ b/rust/src/providers/claude/oauth/mod.rs
@@ -645,6 +645,34 @@ mod tests {
         );
     }
 
+    /// The reported case end to end: an account whose only activity is 1% of
+    /// its session, with every other window still at zero.
+    ///
+    /// The existing one-percent test above passes only because `five_hour: 28`
+    /// settles the scale for the whole response. Nothing settles this one, and
+    /// that is exactly the payload a lightly used account sends: it rendered a
+    /// 1% session as 100% used and raised an exhausted alert for it.
+    #[test]
+    fn a_lone_one_percent_window_is_not_read_as_exhausted() {
+        let response: OAuthUsageResponse = serde_json::from_str(
+            r#"{
+                "five_hour": {"utilization": 1, "resets_at": "2026-07-30T07:00:00Z"},
+                "seven_day": {"utilization": 0, "resets_at": "2026-08-05T08:00:00Z"}
+            }"#,
+        )
+        .expect("percentage OAuth response should parse");
+
+        let usage = ClaudeOAuthFetcher::new().build_usage_snapshot(&response, &test_credentials());
+
+        assert_eq!(response.utilization_scale(), UtilizationScale::Percent);
+        assert!(
+            (usage.primary.used_percent - 1.0).abs() < 0.001,
+            "a 1% session read as {}%",
+            usage.primary.used_percent
+        );
+        assert!((usage.secondary.expect("weekly").used_percent - 0.0).abs() < 0.001);
+    }
+
     /// The same `1` still means 100% when the response is genuinely fractional.
     #[test]
     fn fractional_response_keeps_a_full_window_at_one_hundred() {
@@ -672,14 +700,38 @@ mod tests {
         );
         assert_eq!(
             UtilizationScale::detect([0.0, 0.14, 1.0]),
-            UtilizationScale::Fraction
+            UtilizationScale::Fraction,
+            "a value between 0 and 1 can only be a fraction"
         );
-        // Nothing disambiguates an all zero/one response, so 1.0 stays 100%.
+    }
+
+    /// The reported bug: a session at 1% rendered as 100% used, and alerted as
+    /// exhausted, on an account whose other windows were all still at zero.
+    ///
+    /// The recorded history showed the session jump 0 -> 100 between two reads
+    /// with nothing in between, while a second account on the same build and
+    /// the same API climbed 91, 92, 93 - values only a percentage scale
+    /// produces. The response was percentages; `1` meant 1%.
+    #[test]
+    fn a_barely_used_session_is_not_read_as_exhausted() {
         assert_eq!(
-            UtilizationScale::detect([0.0, 1.0]),
-            UtilizationScale::Fraction
+            UtilizationScale::detect([1.0, 0.0]),
+            UtilizationScale::Percent,
+            "1 alongside only zeros is 1%, not a maxed-out fraction"
         );
-        assert_eq!(UtilizationScale::detect([]), UtilizationScale::Fraction);
+        assert_eq!(
+            UtilizationScale::detect([1.0, 0.0]).to_percent(1.0),
+            1.0,
+            "a freshly used session must not render as exhausted"
+        );
+
+        // An empty response has no evidence either way and must not invent a
+        // fraction scale that would multiply later readings by 100.
+        assert_eq!(UtilizationScale::detect([]), UtilizationScale::Percent);
+        assert_eq!(
+            UtilizationScale::detect([0.0, 0.0]),
+            UtilizationScale::Percent
+        );
     }
 
     #[test]


### PR DESCRIPTION
A Claude account sitting at **1%** reported its 5-hour session as **100% used** and raised an exhausted alert for it.

## Cause

Anthropic reports `utilization` as either whole percentages (`23` = 23%) or fractions of the limit (`0.23` = 23%). A lone `1` is ambiguous: 1% in one scale, 100% in the other.

The scale was already resolved once per response, which handles the case where some other window is above `1.0` and settles it. But when **every** window is `0` or `1`, nothing settles it, and the code assumed fractions:

```rust
if values.any(|value| value > 1.0) { Percent } else { Fraction }
```

That is exactly the payload a lightly used account sends. The first 1% of use turned into `1 × 100 = 100%`.

## Evidence

The recorded history removed the guesswork. Two Claude accounts, same build, same API:

| Account | Recent session values |
| --- | --- |
| working | 91, 92, 93, 0, **6**, **7** |
| affected | 0, 0, 0, 0, **100**, **100** |

The working account reports values above `1`, so its scale resolves to `Percent` and it renders correctly. The affected account jumped `0 -> 100` between consecutive reads with nothing in between - impossible for real usage, and precisely what `1 × 100` produces. The reporter independently confirmed Claude itself showed 1%.

## Fix

Read fractions only when the response contains a value **strictly between 0 and 1**, which is the thing that actually proves a fraction scale. A genuinely fractional payload gives itself away as soon as any window holds an ordinary value like `0.14`.

The residual error is the mirror case: a real fraction `1.0` while every other window sits at exactly `0` or `1`. That needs a maxed window on an otherwise untouched account, where the current bug fires for any account that has just started being used. The tradeoff is documented at the function.

## Why the existing test missed it

There was already a `freshly_reset_window_reporting_one_percent_is_not_full`. It passes because its payload includes `"five_hour": {"utilization": 28}`, which settles the scale for the whole response - so it never exercised a payload where nothing does.

The new test uses the reported payload (`five_hour: 1`, `seven_day: 0`) and I verified it **fails against the old logic** and passes against the new, rather than assuming it covers the bug.

## Validation

778 shared + 459 desktop Rust tests, both per-manifest `clippy -D warnings` gates clean. All 65 existing Claude tests still pass, including the fractional cases that must keep reading `1.0` as 100%.
