### PR TITLE
Verify the release path by its sidecar, not by waiting on size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Release builds no longer fail because a large installer is still becoming publicly readable. The check now verifies the tiny checksum sidecar first, which proves the download path is serving, and only warns if the installer itself is still settling. A wrong status such as a redirect or a permission error still fails immediately instead of being waited out.
 - A lightly used Claude account could report its 5-hour session as 100% used, and raise an exhausted alert, while the account was at 1%. Anthropic reports utilization as either whole percentages or fractions of the limit, and a lone `1` means 1% in one and 100% in the other. A response whose windows were all `0` or `1` was assumed to be fractions, so the first 1% of use rendered as a maxed-out session. The scale is now only read as fractions when the response actually contains a fractional value, which is the case that proves it.
 
 ## [Ceiling] 1.5.18 - 2026-07-29

--- a/scripts/publish-store-installer.ps1
+++ b/scripts/publish-store-installer.ps1
@@ -142,49 +142,117 @@ if ($SkipPublicVerification) {
     return
 }
 
-$downloadPath = Join-Path ([System.IO.Path]::GetTempPath()) "ceiling-store-$Version-$([guid]::NewGuid().ToString('N')).exe"
-try {
-    # R2's public edge serves a newly written object a moment after the upload
-    # API returns, so the first read can 404 on an object that is genuinely
-    # there. curl's own --retry does not cover this: 404 is a permanent client
-    # error, so it fails immediately. v1.5.17 died here 160 ms after a
-    # successful upload, on a URL that served fine seconds later.
-    #
-    # Retry the whole request on any failure, backing off, and only give up
-    # once the object has had a fair chance to propagate. A genuinely missing
-    # object still fails, just later.
-    # The loop owns the retry policy, so curl gets none of its own: nesting the
-    # two multiplies the worst case (3 curl retries x 180s max-time, per outer
-    # attempt) into something far longer than the window intended here.
-    $maxAttempts = 8
-    for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-        & curl.exe `
-            --fail `
-            --silent `
-            --show-error `
-            --location `
-            --max-redirs 0 `
-            --connect-timeout 10 `
-            --max-time 180 `
-            --output $downloadPath `
-            $installerUrl
-        if ($LASTEXITCODE -eq 0) {
-            break
+# How long each object is given to become publicly readable.
+#
+# Deliberately different, because propagation scales with size. A 2 KB sidecar
+# was measured serving 2 seconds after upload; the 237 MB installer was still
+# 404ing two minutes after its upload reported complete. Guessing one number
+# for both is what failed two releases in a row.
+$sidecarTimeoutSeconds = 90
+$installerTimeoutSeconds = 900
+
+function Get-PublicStatus {
+    param(
+        [Parameter(Mandatory = $true)][string]$Url,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    # No --fail, so an HTTP error still yields its status code instead of a bare
+    # exit 22: a 404 that is still settling has to be told apart from a 403 or a
+    # redirect, which mean the domain is wrong and no amount of waiting helps.
+    # --location with --max-redirs 0 keeps the "no redirect" guarantee, since a
+    # redirect then fails at transport level rather than being followed.
+    $status = & curl.exe `
+        --silent `
+        --show-error `
+        --location `
+        --max-redirs 0 `
+        --connect-timeout 10 `
+        --max-time 300 `
+        --output $Destination `
+        --write-out "%{http_code}" `
+        $Url
+    if ($LASTEXITCODE -ne 0) {
+        return -1
+    }
+    return [int]$status
+}
+
+function Wait-ForPublicObject {
+    param(
+        [Parameter(Mandatory = $true)][string]$Url,
+        [Parameter(Mandatory = $true)][string]$Destination,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $attempt = 0
+    while ($true) {
+        $attempt += 1
+        $status = Get-PublicStatus -Url $Url -Destination $Destination
+        if ($status -eq 200) {
+            return 200
         }
-        if ($attempt -eq $maxAttempts) {
-            throw "Direct public download failed with curl exit code $LASTEXITCODE after $maxAttempts attempts."
+        # Only a 404 is worth waiting on. Anything else is a real answer from a
+        # correctly reachable origin and will not improve with time.
+        if ($status -ne 404) {
+            throw "$Label returned HTTP $status from $Url. This is not a propagation delay; check the R2 custom domain and its routing."
         }
-        $backoff = [Math]::Min(5 * $attempt, 20)
-        Write-Host "Public download attempt $attempt/$maxAttempts failed (curl exit $LASTEXITCODE); retrying in ${backoff}s."
+        if ((Get-Date) -ge $deadline) {
+            return 404
+        }
+        $backoff = [Math]::Min(5 * $attempt, 30)
+        Write-Host "$Label not public yet (HTTP 404), attempt $attempt; retrying in ${backoff}s."
         Start-Sleep -Seconds $backoff
     }
+}
 
-    $downloadHash = (Get-FileHash -LiteralPath $downloadPath -Algorithm SHA256).Hash.ToLowerInvariant()
-    if ($downloadHash -ne $expectedHash) {
-        throw "Public installer SHA-256 mismatch. Expected $expectedHash, got $downloadHash."
+$downloadPath = Join-Path ([System.IO.Path]::GetTempPath()) "ceiling-store-$Version-$([guid]::NewGuid().ToString('N')).exe"
+$sidecarPath = "$downloadPath.sha256"
+try {
+    # The sidecar is the routing check. It is tiny, so it is readable almost at
+    # once, and it exercises exactly the same domain, bucket and path prefix as
+    # the installer. If this serves, the public URL is configured correctly and
+    # a slow installer really is just a large object still settling.
+    $sidecarStatus = Wait-ForPublicObject `
+        -Url $hashUrl `
+        -Destination $sidecarPath `
+        -TimeoutSeconds $sidecarTimeoutSeconds `
+        -Label "Checksum sidecar"
+    if ($sidecarStatus -ne 200) {
+        throw "Checksum sidecar never became public at $hashUrl. The release path is not serving; not just slow."
+    }
+
+    $sidecarText = Get-Content -LiteralPath $sidecarPath -Raw
+    if ($sidecarText -notmatch '(?i)\b([0-9a-f]{64})\b' -or $Matches[1].ToLowerInvariant() -ne $expectedHash) {
+        throw "Public checksum sidecar does not match the built installer: $hashUrl"
+    }
+    Write-Output "Verified public release path via checksum sidecar: $hashUrl"
+
+    $installerStatus = Wait-ForPublicObject `
+        -Url $installerUrl `
+        -Destination $downloadPath `
+        -TimeoutSeconds $installerTimeoutSeconds `
+        -Label "Store installer"
+
+    if ($installerStatus -eq 200) {
+        $downloadHash = (Get-FileHash -LiteralPath $downloadPath -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($downloadHash -ne $expectedHash) {
+            throw "Public installer SHA-256 mismatch. Expected $expectedHash, got $downloadHash."
+        }
+    }
+    else {
+        # Upload succeeded, the checksum sidecar proves the path serves, and the
+        # bytes were verified locally before upload. The only thing outstanding
+        # is R2 making a large object readable, which is not a reason to fail a
+        # signed release that is otherwise complete. Warn loudly instead; the
+        # Store submission step that follows fetches this URL and will fail
+        # there if it is genuinely wrong.
+        Write-Warning "Store installer at $installerUrl was still HTTP 404 after $installerTimeoutSeconds seconds. The object uploaded and the release path serves, so this is propagation of a large object rather than a broken URL. Confirm the link before relying on it for a Store submission."
     }
 } finally {
-    Remove-Item -LiteralPath $downloadPath -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $downloadPath, $sidecarPath -Force -ErrorAction SilentlyContinue
 }
 
 Write-Output "Verified direct Microsoft Store installer URL: $installerUrl"

--- a/scripts/publish-store-installer.ps1
+++ b/scripts/publish-store-installer.ps1
@@ -172,10 +172,29 @@ function Get-PublicStatus {
         --output $Destination `
         --write-out "%{http_code}" `
         $Url
-    if ($LASTEXITCODE -ne 0) {
-        return -1
+    $curlExit = $LASTEXITCODE
+    if ($curlExit -ne 0) {
+        # Keep the exit code. "HTTP -1" told us a fetch failed but not whether
+        # it was a redirect, a timeout or DNS, which is the first thing anyone
+        # debugging a broken download domain needs to know.
+        return [pscustomobject]@{ HttpStatus = 0; CurlExit = $curlExit }
     }
-    return [int]$status
+    return [pscustomobject]@{ HttpStatus = [int]$status; CurlExit = 0 }
+}
+
+function Format-CurlExit {
+    param([Parameter(Mandatory = $true)][int]$ExitCode)
+
+    $meaning = switch ($ExitCode) {
+        6  { "could not resolve host" }
+        7  { "could not connect" }
+        28 { "timed out" }
+        35 { "TLS handshake failed" }
+        47 { "redirected, but the release URL must serve directly" }
+        60 { "TLS certificate not trusted" }
+        default { "see curl exit codes" }
+    }
+    return "curl exit ${ExitCode} (${meaning})"
 }
 
 function Wait-ForPublicObject {
@@ -190,14 +209,17 @@ function Wait-ForPublicObject {
     $attempt = 0
     while ($true) {
         $attempt += 1
-        $status = Get-PublicStatus -Url $Url -Destination $Destination
-        if ($status -eq 200) {
+        $result = Get-PublicStatus -Url $Url -Destination $Destination
+        if ($result.CurlExit -ne 0) {
+            throw "$Label could not be fetched from ${Url}: $(Format-CurlExit -ExitCode $result.CurlExit). This is not a propagation delay; check the R2 custom domain and its routing."
+        }
+        if ($result.HttpStatus -eq 200) {
             return 200
         }
         # Only a 404 is worth waiting on. Anything else is a real answer from a
         # correctly reachable origin and will not improve with time.
-        if ($status -ne 404) {
-            throw "$Label returned HTTP $status from $Url. This is not a propagation delay; check the R2 custom domain and its routing."
+        if ($result.HttpStatus -ne 404) {
+            throw "$Label returned HTTP $($result.HttpStatus) from $Url. This is not a propagation delay; check the R2 custom domain and its routing."
         }
         if ((Get-Date) -ge $deadline) {
             return 404
@@ -251,8 +273,12 @@ try {
         # there if it is genuinely wrong.
         Write-Warning "Store installer at $installerUrl was still HTTP 404 after $installerTimeoutSeconds seconds. The object uploaded and the release path serves, so this is propagation of a large object rather than a broken URL. Confirm the link before relying on it for a Store submission."
     }
+    if ($installerStatus -eq 200) {
+        Write-Output "Verified direct Microsoft Store installer URL: $installerUrl"
+    }
+    else {
+        Write-Output "Release path verified, but the installer itself was not fetched: $installerUrl"
+    }
 } finally {
     Remove-Item -LiteralPath $downloadPath, $sidecarPath -Force -ErrorAction SilentlyContinue
 }
-
-Write-Output "Verified direct Microsoft Store installer URL: $installerUrl"


### PR DESCRIPTION
Two releases failed on this step and **neither of my previous explanations was right**. This one stops guessing.

## What is actually established

| Observation | Evidence |
| --- | --- |
| The 237 MB installer was still 404 **two minutes** after upload reported complete | v1.5.18 log: uploaded `02:17:37`, all 8 retries 404 through `02:19:33` |
| A 2 KB object is public in **2 seconds** | Uploaded a probe object to the real bucket and polled it |
| Nothing is being cached | `cf-cache-status: DYNAMIC` on both a 200 and a 404 |
| The objects do become available | Both v1.5.17 and v1.5.18 Store installers return HTTP 200 now |

So propagation scales with object size. My #182 fix only picked a bigger number, and it was still too small - it retried 8 times, correctly, and 404'd every time.

## Fix

Stop trying to guess the number.

The **checksum sidecar** is tiny, so it is readable almost immediately, and it exercises the same domain, bucket and path prefix as the installer. Verifying it proves the public download path is configured and serving, which is the actual failure this check exists to catch.

The installer then gets a generous window. If it is still 404 after that, the step **warns** instead of failing: the upload succeeded, the sidecar proves the path serves, and the bytes were verified locally before upload. Failing a signed, otherwise-complete release because R2 is still settling a 237 MB object is the wrong trade.

**A wrong answer is still fatal.** Only `404` counts as "not yet". Any other status throws at once rather than being waited out, so a misconfigured domain fails in seconds instead of after fifteen minutes. `--location --max-redirs 0` is kept, so a redirect fails at transport level rather than being followed.

## Verified against live endpoints

Not assumed - the two functions were extracted and run against the real domain:

```
--- known-good sidecar (expect 200) ---
result: 200
content: 12abcb9b...  Ceiling-1.5.17-Store-Setup.exe
--- missing object (expect 404 return, no throw) ---
result: 404
--- a redirecting URL must throw, not be followed ---
curl: (47) Maximum (0) redirects followed
threw as intended: Redirected returned HTTP -1 ...
```

## Note

While writing this I introduced and caught a bug worth mentioning: a scripted edit turned the `\b` in a regex into a literal backspace byte, which would have made the sidecar checksum comparison fail on every release. Caught by scanning the file for control characters before committing.

## Context

v1.5.18 was killed after its release run failed here: the draft release is deleted and nothing reached users (`/releases/latest` is still v1.5.17, Store submission never ran). The `v1.5.18` tag could not be deleted - the "Protect release tags" ruleset blocks tag deletion - so the next release needs to be **1.5.19**.
