### PR TITLE
Assert the installed shortcut carries our AUMID

### DIFF
--- a/.github/release-notes-1.5.19.md
+++ b/.github/release-notes-1.5.19.md
@@ -1,34 +1,34 @@
 ## Highlights
 
-### Notification history actually works now
+### Claude accounts no longer report themselves as maxed out
 
-1.5.17 fixed Windows discarding Ceiling's alerts instead of keeping them in the notification center. On a clean install that fix did nothing.
+An account sitting at 1% could show its 5-hour session as **100% used**, and raise an exhausted alert for it.
 
-Windows only keeps notifications for an app it can identify, and it reads that identity from a Start Menu shortcut. The installer was not putting it there, so a fresh 1.5.17 install still lost every alert seconds after it appeared. It only looked correct on machines that happened to have an older shortcut left over.
+Anthropic reports usage as either whole percentages or fractions of the limit, so a lone `1` means 1% in one and 100% in the other. Ceiling guessed wrong whenever every window was still at 0 or 1, which is exactly what a lightly used account looks like.
+
+### Notifications stay in the notification center
+
+1.5.17 was meant to fix Windows throwing Ceiling's alerts away. On a clean install it did nothing.
+
+Windows only keeps a notification for an app it can identify, and it reads that identity from a Start Menu shortcut. The installer was not setting it, so a fresh install still lost every alert seconds after it appeared. It only looked fixed on machines that had an older shortcut left behind.
 
 **If you are on 1.5.17, install this one to pick up the corrected shortcut.**
 
-### Updates no longer loop forever
+### Updates no longer loop
 
-If you ran Ceiling from anywhere other than the installed folder, a local build or an install from older packaging, updating went in a circle: the installer succeeded somewhere else, the copy you were running stayed on the old version, and the same update was offered again on the next check, with nothing on screen explaining why.
+Running Ceiling from somewhere other than the installed folder, such as a local build or an install from older packaging, put updates in a circle. The installer succeeded elsewhere, the copy you were running stayed on the old version, and the same update came back on the next check with nothing on screen explaining why.
 
-Ceiling now notices that case and tells you which copy is running and which one the installer updates, instead of quietly repeating itself.
-
-Downloaded installers are also cleaned up once they are superseded. They were kept forever; one machine had accumulated 305 MB of them.
+Ceiling now spots that and names both copies instead of quietly repeating itself. Cached installers are cleaned up once superseded, too. They were kept forever, and one machine had 305 MB of them.
 
 ### Hide Personal Info hides personal info
 
 The setting only ever reached the Accounts list. The Overview, taskbar flyout, plan cards, activity timeline and provider detail all carried on showing the full address.
 
-All of them mask now, including account labels, which are filled in with your address by default and were a second copy of it. The domain stays visible so you can still tell your own accounts apart.
-
-### A barely used Claude account no longer reports itself as maxed out
-
-An account at 1% could show its 5-hour session as 100% used and raise an exhausted alert for it. Anthropic reports usage as either whole percentages or fractions of the limit, and a lone `1` means 1% in one and 100% in the other. Ceiling was guessing wrong when every window was still at 0 or 1, which is exactly what a lightly used account looks like.
+They all mask now, including account labels, which default to your address and were a second copy of it. The domain stays visible so you can still tell your own accounts apart.
 
 ## Also fixed
 
-- Switching between accounts on the Providers page works. Clicking the second account did nothing at all, because the chosen account was never sent to the backend.
+- Switching between accounts on the Providers page works. Clicking the second account did nothing, because the chosen account was never sent to the backend.
 - Enabled providers sort to the top of the Providers list, with the rest by name. A provider you had configured could otherwise sit far down among ones you do not use.
 
 ## Installers
@@ -38,6 +38,8 @@ An account at 1% could show its 5-hour session as 100% used and raise an exhaust
 - **Ceiling-1.5.19-Store-Setup.exe** - Microsoft Store package (WebView2 bundled)
 
 Portable builds show alerts as banners but do not keep them in the notification center. That needs a Start Menu shortcut, and Ceiling will not add one to a machine where you chose a portable build.
+
+1.5.18 was pulled before it shipped. Everything that was in it is here.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Internal
+- The release smoke test now asserts that the installed Start Menu shortcut carries Ceiling's AppUserModelID. That property is what lets Windows keep a notification, and 1.5.17 shipped without it: every gate checked source, while the one step that inspects the installed build never looked at it.
+
 ## [Ceiling] 1.5.19 - 2026-07-29
 
 Follow-up to 1.5.17, which shipped its own notification fix inert on a clean install. Also stops a lightly used Claude account reporting itself as maxed out, and makes Hide Personal Info do what it says.

--- a/scripts/windows-smoke-install.ps1
+++ b/scripts/windows-smoke-install.ps1
@@ -10,7 +10,11 @@ param(
 
     [switch]$RequireValidSignature,
 
-    [string]$ExpectedSigner = "CN=Brandon South"
+    [string]$ExpectedSigner = "CN=Brandon South",
+
+    # Must match CEILING_AUMID in rust/src/notifications.rs and AppUserModelId
+    # in rust/installer/codexbar.iss.
+    [string]$ExpectedAppUserModelId = "io.github.tsouth89.ceiling"
 )
 
 $ErrorActionPreference = "Stop"
@@ -172,6 +176,53 @@ if (-not $shortcut) {
     throw "Missing Start Menu shortcut. Checked: $($shortcutCandidates -join ', ')"
 }
 Write-Step "Start Menu shortcut: $shortcut"
+
+# The shortcut existing is not the same as it carrying an identity. Windows
+# keeps a toast in the notification center only for an app it can resolve, and
+# it resolves that from System.AppUserModel.ID on this shortcut. 1.5.17 shipped
+# with the installer setting no such property: every alert drew a banner and was
+# then discarded. Nothing caught it, because every other gate checks source
+# while this is the only step that inspects what was actually installed.
+# -TypeDefinition, not -MemberDefinition: this declares types, which the
+# member form cannot host.
+if (-not ('Ceiling.Lnk' -as [type])) {
+    Add-Type -Language CSharp -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+namespace Ceiling {
+  [ComImport, Guid("00021401-0000-0000-C000-000000000046")] internal class ShellLink {}
+  [ComImport, Guid("0000010b-0000-0000-C000-000000000046"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+  internal interface IPersistFile {
+    void GetClassID(out Guid pClassID); [PreserveSig] int IsDirty();
+    void Load([MarshalAs(UnmanagedType.LPWStr)] string fileName, int mode);
+    void Save([MarshalAs(UnmanagedType.LPWStr)] string fileName, [MarshalAs(UnmanagedType.Bool)] bool remember);
+    void SaveCompleted([MarshalAs(UnmanagedType.LPWStr)] string fileName);
+    void GetCurFile([MarshalAs(UnmanagedType.LPWStr)] out string fileName); }
+  [StructLayout(LayoutKind.Sequential)] internal struct PropertyKey { public Guid fmtid; public uint pid; }
+  [ComImport, Guid("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+  internal interface IPropertyStore {
+    void GetCount(out uint count); void GetAt(uint index, out PropertyKey key);
+    void GetValue(ref PropertyKey key, [In, Out] PropVariant value);
+    void SetValue(ref PropertyKey key, PropVariant value); void Commit(); }
+  [StructLayout(LayoutKind.Explicit)] internal class PropVariant : IDisposable {
+    [FieldOffset(0)] ushort valueType; [FieldOffset(8)] IntPtr pointer;
+    public string AsString() { return valueType == 31 && pointer != IntPtr.Zero ? Marshal.PtrToStringUni(pointer) : ""; }
+    public void Dispose() { if (pointer != IntPtr.Zero) { Marshal.FreeCoTaskMem(pointer); pointer = IntPtr.Zero; } } }
+  public static class Lnk {
+    public static string ReadAppUserModelId(string path) {
+      var key = new PropertyKey { fmtid = new Guid("9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3"), pid = 5 };
+      var link = new ShellLink();
+      ((IPersistFile)link).Load(path, 0);
+      using (var value = new PropVariant()) {
+        ((IPropertyStore)link).GetValue(ref key, value);
+        return value.AsString(); } } } }
+'@
+}
+$shortcutAumid = [Ceiling.Lnk]::ReadAppUserModelId($shortcut)
+if ($shortcutAumid -ne $ExpectedAppUserModelId) {
+    throw "Start Menu shortcut publishes AppUserModelID '$shortcutAumid' but Ceiling toasts under '$ExpectedAppUserModelId'. Windows will show alerts as banners and then discard them instead of keeping them in the notification center. Check AppUserModelID on the [Icons] entries in rust/installer/codexbar.iss."
+}
+Write-Step "shortcut AppUserModelID: $shortcutAumid"
 
 if (-not $LeaveInstalled) {
     $uninstallLog = Join-Path $logDir "uninstall.log"

--- a/scripts/windows-smoke-install.ps1
+++ b/scripts/windows-smoke-install.ps1
@@ -205,9 +205,19 @@ namespace Ceiling {
     void GetValue(ref PropertyKey key, [In, Out] PropVariant value);
     void SetValue(ref PropertyKey key, PropVariant value); void Commit(); }
   [StructLayout(LayoutKind.Explicit)] internal class PropVariant : IDisposable {
+    private const ushort VT_EMPTY = 0;
+    private const ushort VT_LPWSTR = 31;
     [FieldOffset(0)] ushort valueType; [FieldOffset(8)] IntPtr pointer;
-    public string AsString() { return valueType == 31 && pointer != IntPtr.Zero ? Marshal.PtrToStringUni(pointer) : ""; }
-    public void Dispose() { if (pointer != IntPtr.Zero) { Marshal.FreeCoTaskMem(pointer); pointer = IntPtr.Zero; } } }
+    public string AsString() {
+      return valueType == VT_LPWSTR && pointer != IntPtr.Zero ? Marshal.PtrToStringUni(pointer) : ""; }
+    // Free only what is actually a CoTaskMem string. The field at offset 8
+    // overlaps a union, so a non-string variant can leave arbitrary non-zero
+    // bits there, and handing those to FreeCoTaskMem corrupts the heap.
+    // Anything else is left alone: leaking a few bytes in a short-lived check
+    // is strictly better than freeing memory that was never allocated.
+    public void Dispose() {
+      if (valueType == VT_LPWSTR && pointer != IntPtr.Zero) { Marshal.FreeCoTaskMem(pointer); }
+      valueType = VT_EMPTY; pointer = IntPtr.Zero; } }
   public static class Lnk {
     public static string ReadAppUserModelId(string path) {
       var key = new PropertyKey { fmtid = new Guid("9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3"), pid = 5 };


### PR DESCRIPTION
1.5.17 shipped its own headline fix **inert**, and nothing caught it.

The installer created the Start Menu shortcut with no `AppUserModelID`, so Windows could not resolve who a toast came from and discarded every one it drew. The tests, both `clippy -D warnings` gates and release-doctor all check **source**. The one step that inspects what was actually installed - `windows-smoke-install.ps1` - asserted the shortcut *exists* but never read the property that makes it useful:

```powershell
$shortcut = $shortcutCandidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
if (-not $shortcut) { throw "Missing Start Menu shortcut..." }
Write-Step "Start Menu shortcut: $shortcut"
```

Since it already locates the shortcut, this only adds the assertion. Reading `System.AppUserModel.ID` requires `IPropertyStore`, hence the COM interop.

## Verified, not assumed

Run against real shortcuts under **both** shells:

```
=== pwsh 7 (CI uses this) ===
installed shortcut AUMID: [io.github.tsouth89.ceiling]
shortcut with NO aumid reads: []  <- this is what 1.5.17 shipped
=== Windows PowerShell 5.1 ===
installed shortcut AUMID: [io.github.tsouth89.ceiling]
shortcut with NO aumid reads: []
```

The empty case is the point: that is exactly what the 1.5.17 installer produced, and it is what this now fails on.

My first attempt used `Add-Type -MemberDefinition`, which cannot host type declarations. It **parsed cleanly** and failed only at runtime with `Value does not fall within the expected range`. Actually running it is what caught that, which is the same lesson as the bug it guards against.

## Guard coverage now

| Layer | Checks |
| --- | --- |
| `notifications.rs` test | the `.iss` defines the AUMID and puts it on the Start Menu icon |
| release-doctor | `AppId` literal matches |
| **smoke test (this PR)** | the **installed** shortcut actually carries it |

The first two check the source that produces the installer. Only this one checks the artifact users receive, which is where the bug lived.
