### PR TITLE
Show OpenCode Go monthly label on the taskbar strip

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -223,7 +223,7 @@ fn constraining_readout(
             out.push((Some("Model"), window));
         }
         if let Some(window) = snapshot.tertiary.as_ref() {
-            out.push((Some("Extra"), window));
+            out.push((snapshot.tertiary_label.as_deref().or(Some("Extra")), window));
         }
         for extra in &snapshot.extra_rate_windows {
             if extra.id == "reset-credits" {
@@ -2187,6 +2187,32 @@ mod tests {
         let readout = constraining_readout(&snapshot);
         assert_eq!(readout.label, Some("Session (5h)"));
         assert_eq!(readout.window.used_percent, 92.0);
+    }
+
+    #[test]
+    fn constraining_readout_uses_tertiary_label_when_it_binds() {
+        // OpenCode Go monthly bar: the tertiary window's own label must show on
+        // the taskbar, not the generic "Extra".
+        let mut snapshot = snap("opencodego", None, 10.0);
+        snapshot.primary_label = Some("Rolling".into());
+        snapshot.tertiary = Some(rate_window(100.0, Some(43_200)));
+        snapshot.tertiary_label = Some("Monthly".into());
+
+        let readout = constraining_readout(&snapshot);
+        assert_eq!(readout.label, Some("Monthly"));
+        assert_eq!(readout.window.used_percent, 100.0);
+    }
+
+    #[test]
+    fn constraining_readout_falls_back_to_extra_for_unnamed_tertiary() {
+        let mut snapshot = snap("opencodego", None, 10.0);
+        snapshot.primary_label = Some("Rolling".into());
+        snapshot.tertiary = Some(rate_window(100.0, Some(43_200)));
+        snapshot.tertiary_label = None;
+
+        let readout = constraining_readout(&snapshot);
+        assert_eq!(readout.label, Some("Extra"));
+        assert_eq!(readout.window.used_percent, 100.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The taskbar strip picks the constraining usage window and shows its label, but for the tertiary window it hardcoded the label to `"Extra"` and ignored the `tertiary_label` that #197 added to the data model. OpenCode Go's monthly bar therefore still read "Extra" on the taskbar even though the React surfaces (flyout, activity timeline) correctly showed "Monthly".

The native `taskbar_widget.rs` is the mirror of `capacityPresentation.ts`'s `constrainingWindow` (SOU-288); #197 updated the frontend but not this mirror. This change aligns them: the strip now uses `snapshot.tertiary_label` with `"Extra"` as the fallback when no label is set.

## Changes

- `apps/desktop-tauri/src-tauri/src/taskbar_widget.rs` - use `tertiary_label.as_deref().or(Some("Extra"))` in `constraining_readout`; add regression tests for both the labeled ("Monthly") and unnamed (falls back to "Extra") tertiary paths.

## Validation

- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml`: 466 passed (taskbar_widget: 28 passed, including the 2 new regression tests, which fail against the old hardcode).
- `cargo fmt --all` clean; `cargo clippy --all-targets -- -D warnings` clean.
