### PR TITLE
Add a workflow to delete a blocked Store submission

### DIFF
--- a/.github/workflows/delete-store-submission.yml
+++ b/.github/workflows/delete-store-submission.yml
@@ -1,0 +1,110 @@
+name: Delete pending Microsoft Store submission
+
+# Ceiling ships to the Store as a flat MSI/EXE product, and Partner Center does
+# not offer a delete control for an in-progress submission on that product type.
+# The Store allows one active submission at a time, so a submission still in
+# certification blocks every later release with:
+#
+#   error - Product already has One Active Submission In-Progress
+#
+# This clears that block. It deletes the pending submission only; the listing
+# that is already live in the Store is untouched.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_product_id:
+        description: Type the Partner Center product ID to confirm the deletion
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: microsoft-store-submission
+  cancel-in-progress: false
+
+jobs:
+  delete:
+    name: Delete the pending submission
+    runs-on: windows-latest
+    timeout-minutes: 30
+    # Shares the manual-dispatch environment with the validation workflow, which
+    # is kept apart from the tag-only release environment holding the signing
+    # and R2 credentials.
+    environment: store-validation
+
+    steps:
+      - name: Set up Microsoft Store Developer CLI
+        uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0 # v1.4
+
+      - name: Configure Partner Center credentials
+        shell: pwsh
+        env:
+          PARTNER_CENTER_TENANT_ID: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
+          PARTNER_CENTER_SELLER_ID: ${{ secrets.PARTNER_CENTER_SELLER_ID }}
+          PARTNER_CENTER_CLIENT_ID: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
+          PARTNER_CENTER_CLIENT_SECRET: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
+        run: |
+          foreach ($name in @(
+            "PARTNER_CENTER_TENANT_ID",
+            "PARTNER_CENTER_SELLER_ID",
+            "PARTNER_CENTER_CLIENT_ID",
+            "PARTNER_CENTER_CLIENT_SECRET"
+          )) {
+            if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
+              throw "The store-validation environment is missing secret $name."
+            }
+          }
+          msstore settings --enableTelemetry false
+          msstore reconfigure `
+            --tenantId $env:PARTNER_CENTER_TENANT_ID `
+            --sellerId $env:PARTNER_CENTER_SELLER_ID `
+            --clientId $env:PARTNER_CENTER_CLIENT_ID `
+            --clientSecret $env:PARTNER_CENTER_CLIENT_SECRET
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store CLI authentication failed."
+          }
+
+      - name: Confirm the product ID
+        shell: pwsh
+        env:
+          PARTNER_CENTER_PRODUCT_ID: ${{ vars.PARTNER_CENTER_PRODUCT_ID }}
+          CONFIRM_PRODUCT_ID: ${{ inputs.confirm_product_id }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:PARTNER_CENTER_PRODUCT_ID)) {
+            throw "The store-validation environment is missing variable PARTNER_CENTER_PRODUCT_ID."
+          }
+          # Deleting a submission cannot be undone, so a stray dispatch must not
+          # be enough on its own to do it.
+          if ($env:CONFIRM_PRODUCT_ID.Trim() -ne $env:PARTNER_CENTER_PRODUCT_ID.Trim()) {
+            throw "The confirmation value does not match the configured product ID. Nothing was deleted."
+          }
+
+      - name: Record the submission before deleting it
+        shell: pwsh
+        env:
+          PARTNER_CENTER_PRODUCT_ID: ${{ vars.PARTNER_CENTER_PRODUCT_ID }}
+        run: |
+          # Leaves the status in the log so the run itself says what was removed.
+          msstore submission status $env:PARTNER_CENTER_PRODUCT_ID
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not read the current submission status."
+          }
+
+      - name: Delete the pending submission
+        shell: pwsh
+        env:
+          PARTNER_CENTER_PRODUCT_ID: ${{ vars.PARTNER_CENTER_PRODUCT_ID }}
+        run: |
+          msstore submission delete $env:PARTNER_CENTER_PRODUCT_ID --no-confirm
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store submission delete failed."
+          }
+          "### Deleted the pending Microsoft Store submission" |
+            Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "Product: $env:PARTNER_CENTER_PRODUCT_ID" |
+            Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "The published listing is unchanged. A new submission can now be started." |
+            Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -88,6 +88,31 @@ submit it for certification. Leave the enable variable `false` if Store
 submission should temporarily remain manual. Never reuse or overwrite a
 versioned R2 URL after Microsoft has certified it.
 
+### When a release is blocked by an in-flight submission
+
+The Store allows one active submission per product, so a release tagged while
+the previous one is still in certification fails its Store step with:
+
+```
+error - Product already has One Active Submission In-Progress. SubmissionId: <id>
+```
+
+Ceiling is a flat MSI/EXE product, and Partner Center does not offer a delete
+control for a pending submission on that product type, so this cannot be
+cleared from the Partner Center UI. Two ways out:
+
+- **Wait.** Once certification finishes, the slot frees itself and the release
+  can be rerun with no further action.
+- **Delete the pending submission.** Run **Delete pending Microsoft Store
+  submission** from GitHub Actions, typing the Partner Center product ID as the
+  confirmation. It runs `msstore submission delete` against the same
+  `store-validation` environment as the validation workflow. Only the pending
+  submission is removed; the listing already live in the Store is untouched.
+
+Either way, resume the blocked release with `gh run rerun <run-id> --failed`,
+which restarts at the Store step and reuses the already-signed binaries rather
+than rebuilding them.
+
 For a local unsigned packaging rehearsal, use the managed Windows checkout:
 
 ```powershell


### PR DESCRIPTION
Unblocks 1.5.24's Store submission, and every future release that lands in the same state.

## The problem

The Store allows one active submission per product. 1.5.24 was tagged while 1.5.23 was still in certification, so its Store step failed:

```
error - Product already has One Active Submission In-Progress. SubmissionId: 1152921505701582121
```

The handoff for this said the fix was to delete the submission in Partner Center by hand, and that it couldn't be automated because the credentials live only in the tag-gated `release` environment. Both halves turned out to be wrong:

- **Partner Center offers no delete control here.** Ceiling submits as a flat MSI/EXE product — the workflow sends an installer URL, not an MSIX package — and Partner Center's submission management for unpackaged products does not expose the delete/cancel affordance that MSIX apps get. There was no manual path to follow.
- **The credentials are not release-only.** The `store-validation` environment holds the same four `PARTNER_CENTER_*` secrets plus `PARTNER_CENTER_PRODUCT_ID`, and already backs `validate-store-submission.yml` on `workflow_dispatch`. `docs/RELEASING.md` documents this; the handoff note contradicted it.

## The change

A dispatchable **Delete pending Microsoft Store submission** workflow running `msstore submission delete <productId> --no-confirm` in `store-validation`. No new secrets or environments.

Deleting a submission is irreversible, so the run is gated twice over: the dispatcher must type the Partner Center product ID as confirmation, and `msstore submission status` runs first so the log records what was removed before it goes. It shares the `microsoft-store-submission` concurrency group with the validation workflow, so the two cannot interleave.

Only the pending submission is deleted. The listing already live in the Store is untouched.

`docs/RELEASING.md` gains a section on the blocked-release case, including the alternative of simply waiting for certification to finish, and the `gh run rerun <run-id> --failed` step that resumes a blocked release at the Store step without rebuilding the signed binaries.

## Note on using it

`workflow_dispatch` workflows are only dispatchable once they exist on the default branch, so this has to merge before it can be run against the stuck submission.

## Verification

YAML parses; steps resolve in order. The credentialed path is unrunnable outside CI by design, so the workflow itself is untested until its first dispatch — it mirrors the authentication and validation steps of `validate-store-submission.yml`, which last ran green on 2026-07-29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual workflow to help remove a pending Microsoft Store submission when a release is blocked.
  * The workflow checks the configured product, verifies current submission status, and reports the outcome in the run summary.

* **Documentation**
  * Expanded release guidance with steps for handling blocked Store releases.
  * Added instructions for waiting on certification, deleting a pending submission, and rerunning the failed Store step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->