### PR TITLE
Don't fail a release when the Store slot is busy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,15 +367,52 @@ jobs:
         env:
           PARTNER_CENTER_PRODUCT_ID: ${{ vars.PARTNER_CENTER_PRODUCT_ID }}
         run: |
+          # The Store allows one active submission per product, so a release
+          # tagged while the previous one is still certifying cannot submit. That
+          # is a queueing conflict, not a broken release: the binaries, the
+          # GitHub release, and the R2 upload are all already done and correct.
+          # Skip the Store step and report it instead of failing the whole run.
+          $blocked = 'One Active Submission In-Progress'
+
+          function Skip-StoreSubmission {
+            "### Microsoft Store submission skipped" |
+              Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            "The Store already has an active submission, which allows only one at a time." |
+              Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            "Everything else in this release succeeded. To submit once the active" |
+              Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            "submission clears, run **Validate Microsoft Store submission** with" |
+              Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            "``publish`` checked and version ``$env:RELEASE_VERSION``. To clear it now," |
+              Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            "use *Cancel review* in Partner Center (see docs/RELEASING.md)." |
+              Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            "Installer: $env:STORE_INSTALLER_URL" |
+              Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            Write-Host "::warning::Microsoft Store submission skipped - the product already has an active submission."
+          }
+
           $package = Get-Content -LiteralPath $env:STORE_PACKAGE_PATH -Raw
-          msstore submission update $env:PARTNER_CENTER_PRODUCT_ID $package
+          $updateOutput = msstore submission update $env:PARTNER_CENTER_PRODUCT_ID $package 2>&1 | Out-String
+          Write-Host $updateOutput
           if ($LASTEXITCODE -ne 0) {
+            if ($updateOutput -match $blocked) {
+              Skip-StoreSubmission
+              exit 0
+            }
             throw "Microsoft Store package update failed."
           }
-          msstore submission publish $env:PARTNER_CENTER_PRODUCT_ID
+
+          $publishOutput = msstore submission publish $env:PARTNER_CENTER_PRODUCT_ID 2>&1 | Out-String
+          Write-Host $publishOutput
           if ($LASTEXITCODE -ne 0) {
+            if ($publishOutput -match $blocked) {
+              Skip-StoreSubmission
+              exit 0
+            }
             throw "Microsoft Store submission failed."
           }
+
           "### Submitted Ceiling to Microsoft Store" |
             Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
           "Installer: $env:STORE_INSTALLER_URL" |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -120,8 +120,19 @@ has no delete or cancel operation at all, so Partner Center is the only way to
 retract a submission. Cancelling stays available through certification and is
 lost once publishing begins.
 
-Then resume a blocked release with `gh run rerun <run-id> --failed`, which
-restarts at the Store step and reuses the already-signed binaries.
+Do **not** try to resume the blocked release with `gh run rerun --failed`. A
+rerun restarts the whole job rather than resuming at the failed step, so it
+rebuilds and re-signs. Signing embeds an RFC 3161 timestamp, so the new
+installer never matches the bytes already published for that version, and
+`publish-store-installer.ps1` refuses to overwrite an immutable release object.
+The rerun dies at the R2 step, long before reaching the Store.
+
+Submit the deferred version with the validation workflow instead, which reuses
+the installer already in R2 and rebuilds nothing:
+
+```powershell
+gh workflow run validate-store-submission.yml -f version=<version> -f publish=true
+```
 
 For a local unsigned packaging rehearsal, use the managed Windows checkout:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -88,6 +88,41 @@ submit it for certification. Leave the enable variable `false` if Store
 submission should temporarily remain manual. Never reuse or overwrite a
 versioned R2 URL after Microsoft has certified it.
 
+### When a release collides with an in-flight submission
+
+The Store allows one active submission per product, so tagging a release while
+the previous one is still certifying cannot submit:
+
+```text
+error - Product already has One Active Submission In-Progress. SubmissionId: <id>
+```
+
+That is a queueing conflict, not a broken release. The release run treats it as
+one: the Store step reports the collision as a warning and skips, and the run
+still passes, because the binaries, the GitHub release, and the R2 upload have
+all already succeeded. Only the Store submission is deferred.
+
+To submit the deferred version once the active submission clears, run
+**Validate Microsoft Store submission** with `publish` checked and that version.
+
+To clear the active submission instead, cancel it in Partner Center:
+
+1. Apps and Games overview, then open the app.
+2. On the Application overview page, go to the **Update app** card (the **App
+   setup** card for a first submission).
+3. Click the three dots at the top right of that card and choose
+   **Cancel review**, then confirm. It returns to draft within about a minute.
+
+It is a menu on a card rather than an action in a submissions list, which is why
+it is easy to miss. Note that Ceiling is a flat MSI/EXE product: `msstore
+submission delete` is documented only for MSIX, and the MSI/EXE submission API
+has no delete or cancel operation at all, so Partner Center is the only way to
+retract a submission. Cancelling stays available through certification and is
+lost once publishing begins.
+
+Then resume a blocked release with `gh run rerun <run-id> --failed`, which
+restarts at the Store step and reuses the already-signed binaries.
+
 For a local unsigned packaging rehearsal, use the managed Windows checkout:
 
 ```powershell


### PR DESCRIPTION
Replaces #210, which was built on a command that does not exist for our product type.

## The problem

The Store allows one active submission per product. 1.5.24 was tagged while 1.5.23 was still certifying, so the Store step failed and took the whole release run red with it:

```text
error - Product already has One Active Submission In-Progress. SubmissionId: 1152921505701582121
```

Nothing was actually wrong with that release. The binaries were built and signed, the GitHub release was created, and the immutable R2 upload was verified. Only the Store submission couldn't proceed, and only because of queueing.

## The change

The Store step now recognizes that error from either `msstore submission update` or `msstore submission publish`, emits a `::warning::` and a step-summary note explaining how to submit later, and exits 0. Every other failure still throws and still fails the release.

The deferred version is submitted afterwards by running **Validate Microsoft Store submission** with `publish` checked — no rebuild, since the R2 installer URL is immutable and already verified.

## Why not just delete the blocking submission

Two attempts died here, both documented in `docs/RELEASING.md` so nobody re-derives them:

- **`msstore submission delete` is MSIX-only.** Microsoft ships two command references from the same doc commit. [`commands`](https://learn.microsoft.com/en-us/windows/apps/publish/msstore-dev-cli/commands) (MSIX) lists `delete`; [`commands-exe`](https://learn.microsoft.com/en-us/windows/apps/publish/msstore-dev-cli/commands-exe) (MSI/EXE) lists the same seven sub-commands without it. Ceiling is a flat MSI/EXE product. This is what #210 got wrong.
- **The MSI/EXE submission API has no delete either.** [`api.store.microsoft.com/submission/v1/...`](https://learn.microsoft.com/en-us/windows/apps/publish/store-submission-api) documents get, update, commit, status and submit, and no delete/cancel/discard. The `DELETE .../submissions/{id}` endpoint that turns up in searches belongs to the legacy `manage.devcenter.microsoft.com` UWP API, which does not cover flat products.

The only way to retract one is Partner Center's **Cancel review**, on the three-dot menu of the **Update app** card on the Application overview page — a menu on a card, not an action in a submissions list, which is why it reads as missing. Per the [certification process doc](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/msi/app-certification-process), it stays available through certification and is lost once publishing begins: "Your app will be published after it is certified. When this phase has begun, you can no longer cancel your submission."

All of that is now in `docs/RELEASING.md` next to the recovery steps.

## Verification

`release.yml` parses; the guarded step keeps two `throw` paths for real failures alongside the two skip paths.

The PowerShell was checked against a failing native command, since the guard depends on behavior that is easy to assume and get wrong:

- `$LASTEXITCODE` survives `native-cmd 2>&1 | Out-String` — confirmed `1`, so the exit check still sees the failure.
- The match against the error text confirmed `True`.
- The doubled backticks in the summary string render as markdown inline code rather than PowerShell escapes.

The credentialed path only runs in the tag-gated `release` environment, so the guard itself is untested until a release actually collides. Its failure mode is the current behavior — a red run — rather than a silently skipped submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Microsoft Store releases now complete successfully when a submission is already in progress.
  * Other Store submission failures continue to be reported as errors.

* **Documentation**
  * Added guidance for resolving active Microsoft Store submissions.
  * Documented how to retry submission safely without rerunning the full release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->