### PR TITLE
Fix Cursor on-demand-only payloads and OpenCode Go missing resets

### DIFF
--- a/rust/src/providers/cursor/api.rs
+++ b/rust/src/providers/cursor/api.rs
@@ -176,39 +176,41 @@ impl CursorApi {
                         inactives.push(InactiveRateWindow::new("cursor-api", "API", NOT_ENFORCED));
                     }
                 }
-
-                let on_demand = individual.on_demand.as_ref().or_else(|| {
-                    summary
-                        .team_usage
-                        .as_ref()
-                        .and_then(|t| t.on_demand.as_ref())
-                });
-
-                let (metered, notice) = on_demand_windows(on_demand, window_minutes, billing_end);
-                extras.extend(metered);
-                inactives.extend(notice);
-
-                // On-demand owns the cost slot: it is the only Cursor lane that
-                // bills real money. Plan usage is metered at internal rates and
-                // charged nothing, so it must never outrank actual spend here.
-                cost_snapshot = Self::on_demand_cost(on_demand, billing_end, ON_DEMAND_PERIOD)
-                    .or_else(|| plan_cost_snapshot(plan, billing_end));
             } else if let Some(overall) = &individual.overall {
                 // Overall is a single reported pool — keep it as monthly + cost only.
                 monthly_percent = Self::usage_percent(overall);
+                // Overall fills the cost slot as a monthly pool. On-demand still
+                // surfaces as its own meter below; it must not replace this total.
                 cost_snapshot = Self::on_demand_cost(Some(overall), billing_end, MONTHLY_PERIOD);
+            }
 
-                // `overall` does not replace on-demand: the overdraft meter is
-                // reported separately and would otherwise never be read here.
-                let on_demand = individual.on_demand.as_ref().or_else(|| {
-                    summary
-                        .team_usage
-                        .as_ref()
-                        .and_then(|t| t.on_demand.as_ref())
-                });
-                let (metered, notice) = on_demand_windows(on_demand, window_minutes, billing_end);
-                extras.extend(metered);
-                inactives.extend(notice);
+            // On-demand is a sibling of plan/overall on IndividualUsage. Read it
+            // once for every individual shape — including payloads that only
+            // carry onDemand and omit both plan and overall.
+            let on_demand = individual.on_demand.as_ref().or_else(|| {
+                summary
+                    .team_usage
+                    .as_ref()
+                    .and_then(|t| t.on_demand.as_ref())
+            });
+            let (metered, notice) = on_demand_windows(on_demand, window_minutes, billing_end);
+            extras.extend(metered);
+            inactives.extend(notice);
+
+            // Cost ownership by shape:
+            // - plan: on-demand (real money) outranks plan internal units
+            // - overall: already set above; leave the monthly pool cost alone
+            // - on-demand only: on-demand is the only billed signal
+            if individual.plan.is_some() {
+                cost_snapshot = Self::on_demand_cost(on_demand, billing_end, ON_DEMAND_PERIOD)
+                    .or_else(|| {
+                        individual
+                            .plan
+                            .as_ref()
+                            .and_then(|plan| plan_cost_snapshot(plan, billing_end))
+                    });
+            } else if individual.overall.is_none() {
+                cost_snapshot = Self::on_demand_cost(on_demand, billing_end, ON_DEMAND_PERIOD);
             }
         } else if let Some(team) = &summary.team_usage {
             if let Some(pooled) = &team.pooled {
@@ -712,6 +714,35 @@ mod tests {
         assert!(usage.extra_rate_windows.is_empty());
         assert!(usage.inactive_rate_windows.is_empty());
         assert!(cost.is_none());
+    }
+
+    #[test]
+    fn test_cursor_on_demand_only_individual_usage() {
+        // individualUsage may carry only onDemand (plan and overall both null).
+        // That shape used to fall through both arms and drop the overdraft lane.
+        let json = r#"{
+            "billingCycleEnd": "2026-04-01T00:00:00Z",
+            "membershipType": "pro",
+            "individualUsage": {
+                "onDemand": {
+                    "enabled": true,
+                    "used": 350,
+                    "limit": 1000
+                }
+            }
+        }"#;
+
+        let summary = parse_summary(json);
+        let (usage, cost) = api().build_result(summary, None).unwrap();
+
+        let on_demand = extra(&usage, "cursor-on-demand");
+        assert_eq!(on_demand.title, "On-demand");
+        assert!((on_demand.window.used_percent - 35.0).abs() < 0.01);
+
+        let cost = cost.expect("on-demand-only payload still reports spend");
+        assert!((cost.used - 3.5).abs() < 0.01);
+        assert_eq!(cost.limit, Some(10.0));
+        assert_eq!(cost.period, "On-demand");
     }
 
     #[test]

--- a/rust/src/providers/opencodego/mod.rs
+++ b/rust/src/providers/opencodego/mod.rs
@@ -155,7 +155,9 @@ impl OpenCodeGoProvider {
         let primary = RateWindow::with_details(
             rolling,
             Some(300),
-            Some(now + chrono::Duration::seconds(raw_rolling.1)),
+            raw_rolling
+                .1
+                .map(|secs| now + chrono::Duration::seconds(secs)),
             None,
         );
         let mut snap = UsageSnapshot::new(primary).with_login_method("OpenCode Go");
@@ -164,7 +166,7 @@ impl OpenCodeGoProvider {
             snap = snap.with_secondary(RateWindow::with_details(
                 pct,
                 Some(10080),
-                Some(now + chrono::Duration::seconds(reset)),
+                reset.map(|secs| now + chrono::Duration::seconds(secs)),
                 None,
             ));
         }
@@ -174,7 +176,7 @@ impl OpenCodeGoProvider {
                 .with_tertiary(RateWindow::with_details(
                     pct,
                     Some(43200),
-                    Some(now + chrono::Duration::seconds(reset)),
+                    reset.map(|secs| now + chrono::Duration::seconds(secs)),
                     None,
                 ))
                 .with_tertiary_label("Monthly");
@@ -193,7 +195,11 @@ impl OpenCodeGoProvider {
 
     /// Extract raw `(usage, resetInSec)` for a usage block by name, before any
     /// percent-scale normalization.
-    fn extract_window(text: &str, names: &[&str]) -> Option<(f64, i64)> {
+    ///
+    /// Reset is `None` when the percent matched but no reset field did. Callers
+    /// must not invent a `resets_at` of "now" for that case — that is a claim
+    /// about schedule, not an unknown.
+    fn extract_window(text: &str, names: &[&str]) -> Option<(f64, Option<i64>)> {
         for name in names {
             let percent_pattern = format!(
                 r#"{}[^}}]*?(?:usagePercent|usedPercent|percentUsed|percent)\s*[:=]\s*([0-9]+(?:\.[0-9]+)?)"#,
@@ -206,10 +212,8 @@ impl OpenCodeGoProvider {
 
             let percent = Self::extract_number(&percent_pattern, text);
             if let Some(p) = percent {
-                let reset = Self::extract_number(&reset_pattern, text)
-                    .map(|n| n as i64)
-                    .unwrap_or(0);
-                return Some((p, reset.max(0)));
+                let reset = Self::extract_number(&reset_pattern, text).map(|n| (n as i64).max(0));
+                return Some((p, reset));
             }
         }
         None
@@ -542,5 +546,25 @@ mod tests {
             renewal.window.resets_at.unwrap().to_rfc3339(),
             "2026-06-01T12:00:00+00:00"
         );
+    }
+
+    #[test]
+    fn missing_reset_field_does_not_claim_resets_now() {
+        // Percent matched, reset key omitted → schedule is unknown. Substituting
+        // 0s would set resets_at to the fetch timestamp and poison pace/reset
+        // detection with a fake "resets this instant" claim.
+        let text = r#"
+            rollingUsage: { usagePercent: 42.5 }
+            weeklyUsage: { usagePercent: 13, resetInSec: 86400 }
+        "#;
+        let snap = OpenCodeGoProvider::parse_usage_text(text).unwrap();
+        assert!(
+            snap.primary.resets_at.is_none(),
+            "unknown reset must stay None, got {:?}",
+            snap.primary.resets_at
+        );
+        let secondary = snap.secondary.expect("weekly still parses with reset");
+        assert!(secondary.resets_at.is_some());
+        assert!((snap.primary.used_percent - 42.5).abs() < 0.001);
     }
 }


### PR DESCRIPTION
## Summary
- **Cursor (SOU-547):** Read `individualUsage.onDemand` once for every individual payload shape, including when only `onDemand` is present (no `plan` / `overall`). That used to fall through both arms and drop the overdraft meter and cost.
- **OpenCode Go (SOU-548):** When the percent field matches but the reset field does not, leave `resets_at` as `None` instead of substituting `0` and claiming the window resets at fetch time.

## Test plan
- [x] `cargo test --manifest-path rust/Cargo.toml --lib -- providers::cursor::api`
- [x] `cargo test --manifest-path rust/Cargo.toml --lib -- opencodego missing_reset`
- [x] New unit tests: on-demand-only Cursor payload; missing OpenCode Go reset field

Linear: SOU-547, SOU-548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-demand usage is now shown as a separate meter, including when it is the only usage reported.
  * Cost reporting now more accurately prioritizes plan, overall usage, and on-demand data.

* **Bug Fixes**
  * Usage-window reset times remain unspecified when the service does not provide reset information, instead of displaying an incorrect time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->