### PR TITLE
Bump postcss to 8.5.25 for GHSA-fxqj-rqcc-2cmp

### DIFF
--- a/apps/desktop-tauri/pnpm-lock.yaml
+++ b/apps/desktop-tauri/pnpm-lock.yaml
@@ -997,8 +997,8 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@27.5.1:
@@ -2074,7 +2074,7 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  postcss@8.5.18:
+  postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -2239,7 +2239,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.18
+      postcss: 8.5.25
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary
Bumps the transitive `postcss` dep from 8.5.18 to 8.5.25, clearing Dependabot alert #15.

`postcss <= 8.5.22` is an incomplete fix of GHSA-6g55-p6wh-862q ([GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) / CVE-2026-69153): when `from` is unset, an attacker-controlled `sourceMappingURL` can read arbitrary `.map` files. First patched in 8.5.23.

**Impact here is low.** `postcss` is a dev-only transitive dep (`vite` -> `postcss`), so it never reaches a shipped artifact. Filing it anyway to keep the alert list clean.

## Notes
- Lockfile-only. `vite` 6.4.3 already permits the patched range, so no `package.json` change was needed and no override was added.
- No direct dependency of ours pins postcss.

## Test plan
- [x] `pnpm run build` — clean, 177 modules
- [x] `pnpm vitest run` — 57 files, 375 tests passing
- [x] `pnpm why postcss` reports 8.5.25 across every path
