### PR TITLE
Extract the tray panel sizing math and test it

### DIFF
--- a/apps/desktop-tauri/src/hooks/useTrayPanelLayout.ts
+++ b/apps/desktop-tauri/src/hooks/useTrayPanelLayout.ts
@@ -9,12 +9,15 @@ import {
   reanchorTrayPanel,
   revealTrayPanelWindow,
 } from "../lib/tauri";
-
-const TRAY_WIDTH = 328;
-const TRAY_MAX_MEASURE_HEIGHT = 920;
-const TRAY_OVERVIEW_MIN_HEIGHT = 200;
-const TRAY_DETAIL_MIN_HEIGHT = 420;
-const TRAY_DENSE_OVERVIEW_HEIGHT = 776;
+import {
+  clampTrayHeight,
+  isUserDragResize,
+  measureTrayContentHeight,
+  shouldApplyAutoFitSize,
+  trayMaxHeight,
+  trayMinHeight,
+  TRAY_WIDTH,
+} from "../lib/trayPanelLayout";
 
 export interface TrayPanelLayoutOptions {
   canMeasure: boolean;
@@ -105,15 +108,12 @@ export function useTrayPanelLayout({
     void (async () => {
       try {
         unlisten = await win.onResized(({ payload }) => {
-          if (programmaticInFlightRef.current > 0) return;
-          const last = lastSizeRef.current;
-          if (
-            last &&
-            Math.abs(payload.width - last.width) <= 3 &&
-            Math.abs(payload.height - last.height) <= 3
-          ) {
-            return;
-          }
+          const isDrag = isUserDragResize({
+            programmaticInFlight: programmaticInFlightRef.current,
+            lastApplied: lastSizeRef.current,
+            event: { width: payload.width, height: payload.height },
+          });
+          if (!isDrag) return;
           onUserResizeRef.current?.(payload.width, payload.height);
         });
       } catch {
@@ -182,11 +182,7 @@ export function useTrayPanelLayout({
   useEffect(() => {
     if (!autoFit || !canMeasure) return;
 
-    const minHeight = detailMode
-      ? TRAY_DETAIL_MIN_HEIGHT
-      : denseOverview
-        ? TRAY_DENSE_OVERVIEW_HEIGHT
-        : TRAY_OVERVIEW_MIN_HEIGHT;
+    const minHeight = trayMinHeight({ detailMode, denseOverview });
 
     const resize = async () => {
       const run = ++resizeRunRef.current;
@@ -195,13 +191,7 @@ export function useTrayPanelLayout({
       const html = document.documentElement;
       const pageBody = document.body;
       const workArea = await getWorkAreaRect().catch(() => null);
-      const maxHeight = Math.max(
-        minHeight,
-        Math.min(
-          TRAY_MAX_MEASURE_HEIGHT,
-          (workArea?.height ?? TRAY_MAX_MEASURE_HEIGHT) - 16,
-        ),
-      );
+      const maxHeight = trayMaxHeight(minHeight, workArea?.height ?? null);
 
       const body = surface.querySelector<HTMLElement>(".menu-surface__body");
       const stack = surface.querySelector<HTMLElement>(".menu-stack");
@@ -261,31 +251,25 @@ export function useTrayPanelLayout({
         if (run !== resizeRunRef.current) return;
 
         const surfaceRect = surface.getBoundingClientRect();
-        let contentHeight = Math.max(
-          surface.scrollHeight,
-          Math.ceil(surfaceRect.height),
-        );
-        let maxBottom = surfaceRect.top + contentHeight;
         const bodyRect = body?.getBoundingClientRect();
-        if (bodyRect && bodyRect.height > 0 && bodyRect.bottom > maxBottom) {
-          maxBottom = bodyRect.bottom;
-        }
         const footer = surface.querySelector<HTMLElement>(".menu-surface__footer");
         const footerRect = footer?.getBoundingClientRect();
-        if (footerRect && footerRect.height > 0 && footerRect.bottom > maxBottom) {
-          maxBottom = footerRect.bottom;
-        }
-        contentHeight = Math.ceil(maxBottom - surfaceRect.top) + 4;
+        const contentHeight = measureTrayContentHeight({
+          surfaceTop: surfaceRect.top,
+          surfaceHeight: surfaceRect.height,
+          surfaceScrollHeight: surface.scrollHeight,
+          body: bodyRect,
+          footer: footerRect,
+        });
 
-        const height = Math.min(Math.max(contentHeight, minHeight), maxHeight);
+        const height = clampTrayHeight(contentHeight, minHeight, maxHeight);
         surface.style.maxHeight = `${height}px`;
         committedHeight = true;
 
-        const previousSize = autoFitLogicalRef.current;
-        const shouldResize =
-          previousSize === null ||
-          previousSize.width !== TRAY_WIDTH ||
-          Math.abs(previousSize.height - height) > 2;
+        const shouldResize = shouldApplyAutoFitSize(autoFitLogicalRef.current, {
+          width: TRAY_WIDTH,
+          height,
+        });
         if (shouldResize) {
           autoFitLogicalRef.current = { width: TRAY_WIDTH, height };
           await applySize(new LogicalSize(TRAY_WIDTH, height));

--- a/apps/desktop-tauri/src/lib/trayPanelLayout.test.ts
+++ b/apps/desktop-tauri/src/lib/trayPanelLayout.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  clampTrayHeight,
+  isUserDragResize,
+  measureTrayContentHeight,
+  shouldApplyAutoFitSize,
+  trayMaxHeight,
+  trayMinHeight,
+  TRAY_DENSE_OVERVIEW_HEIGHT,
+  TRAY_DETAIL_MIN_HEIGHT,
+  TRAY_MAX_MEASURE_HEIGHT,
+  TRAY_OVERVIEW_MIN_HEIGHT,
+  TRAY_WIDTH,
+} from "./trayPanelLayout";
+
+describe("trayMinHeight", () => {
+  it("gives detail mode the tallest floor", () => {
+    expect(trayMinHeight({ detailMode: true, denseOverview: false })).toBe(
+      TRAY_DETAIL_MIN_HEIGHT,
+    );
+  });
+
+  it("prefers detail mode over dense overview when both are set", () => {
+    expect(trayMinHeight({ detailMode: true, denseOverview: true })).toBe(
+      TRAY_DETAIL_MIN_HEIGHT,
+    );
+  });
+
+  it("uses the dense floor for a dense overview", () => {
+    expect(trayMinHeight({ detailMode: false, denseOverview: true })).toBe(
+      TRAY_DENSE_OVERVIEW_HEIGHT,
+    );
+  });
+
+  it("falls back to the plain overview floor", () => {
+    expect(trayMinHeight({ detailMode: false, denseOverview: false })).toBe(
+      TRAY_OVERVIEW_MIN_HEIGHT,
+    );
+  });
+});
+
+describe("trayMaxHeight", () => {
+  it("leaves a margin below the work area", () => {
+    expect(trayMaxHeight(TRAY_OVERVIEW_MIN_HEIGHT, 800)).toBe(784);
+  });
+
+  it("never exceeds the measure limit on a tall screen", () => {
+    expect(trayMaxHeight(TRAY_OVERVIEW_MIN_HEIGHT, 4000)).toBe(
+      TRAY_MAX_MEASURE_HEIGHT,
+    );
+  });
+
+  it("falls back to the measure limit when the work area is unknown", () => {
+    // getWorkAreaRect() rejected. Collapsing the panel would be worse than
+    // guessing, so the fallback is the measure limit minus the margin.
+    expect(trayMaxHeight(TRAY_OVERVIEW_MIN_HEIGHT, null)).toBe(
+      TRAY_MAX_MEASURE_HEIGHT - 16,
+    );
+  });
+
+  it("lets the min height win on a very short work area", () => {
+    // A 300px work area would otherwise cap detail mode at 284, below its own
+    // floor. The panel deliberately overflows rather than rendering unusably
+    // small.
+    expect(trayMaxHeight(TRAY_DETAIL_MIN_HEIGHT, 300)).toBe(
+      TRAY_DETAIL_MIN_HEIGHT,
+    );
+  });
+
+  it("returns a max that is never below the min it was given", () => {
+    for (const workArea of [0, 1, 100, 300, 500, 900, 2000, null]) {
+      expect(
+        trayMaxHeight(TRAY_DETAIL_MIN_HEIGHT, workArea),
+      ).toBeGreaterThanOrEqual(TRAY_DETAIL_MIN_HEIGHT);
+    }
+  });
+});
+
+describe("clampTrayHeight", () => {
+  it("keeps content that already fits", () => {
+    expect(clampTrayHeight(500, 200, 900)).toBe(500);
+  });
+
+  it("raises content shorter than the floor", () => {
+    expect(clampTrayHeight(50, 200, 900)).toBe(200);
+  });
+
+  it("caps content taller than the ceiling", () => {
+    expect(clampTrayHeight(5000, 200, 900)).toBe(900);
+  });
+
+  it("returns the floor when floor and ceiling collapse together", () => {
+    expect(clampTrayHeight(10, 420, 420)).toBe(420);
+    expect(clampTrayHeight(9000, 420, 420)).toBe(420);
+  });
+});
+
+describe("measureTrayContentHeight", () => {
+  const base = {
+    surfaceTop: 0,
+    surfaceHeight: 300,
+    surfaceScrollHeight: 300,
+  };
+
+  it("uses the surface's own extent plus bottom padding", () => {
+    expect(measureTrayContentHeight(base)).toBe(304);
+  });
+
+  it("prefers scrollHeight when the surface is visually clipped", () => {
+    expect(
+      measureTrayContentHeight({ ...base, surfaceHeight: 300, surfaceScrollHeight: 700 }),
+    ).toBe(704);
+  });
+
+  it("rounds a fractional surface height up", () => {
+    expect(
+      measureTrayContentHeight({ ...base, surfaceHeight: 300.2, surfaceScrollHeight: 0 }),
+    ).toBe(305);
+  });
+
+  it("extends to a body that overflows the surface", () => {
+    expect(
+      measureTrayContentHeight({ ...base, body: { height: 500, bottom: 520 } }),
+    ).toBe(524);
+  });
+
+  it("extends to a footer that sits below the body", () => {
+    expect(
+      measureTrayContentHeight({
+        ...base,
+        body: { height: 500, bottom: 520 },
+        footer: { height: 40, bottom: 560 },
+      }),
+    ).toBe(564);
+  });
+
+  it("ignores a zero-height body or footer", () => {
+    // A hidden element reports bottom === top, which would otherwise drag the
+    // measurement upward and clip the panel.
+    expect(
+      measureTrayContentHeight({
+        ...base,
+        body: { height: 0, bottom: 9999 },
+        footer: { height: 0, bottom: 9999 },
+      }),
+    ).toBe(304);
+  });
+
+  it("ignores a body that does not reach past the surface", () => {
+    expect(
+      measureTrayContentHeight({ ...base, body: { height: 100, bottom: 120 } }),
+    ).toBe(304);
+  });
+
+  it("measures relative to the surface, not the viewport", () => {
+    // The surface can be scrolled away from the top of the document. Height is
+    // an extent, so a non-zero top must not inflate it.
+    expect(
+      measureTrayContentHeight({
+        surfaceTop: 150,
+        surfaceHeight: 300,
+        surfaceScrollHeight: 300,
+        footer: { height: 40, bottom: 470 },
+      }),
+    ).toBe(324);
+  });
+
+  it("handles a negative surfaceTop from an off-screen surface", () => {
+    expect(
+      measureTrayContentHeight({
+        surfaceTop: -80,
+        surfaceHeight: 300,
+        surfaceScrollHeight: 300,
+      }),
+    ).toBe(304);
+  });
+});
+
+describe("shouldApplyAutoFitSize", () => {
+  it("always resizes on the first pass", () => {
+    expect(shouldApplyAutoFitSize(null, { width: TRAY_WIDTH, height: 400 })).toBe(
+      true,
+    );
+  });
+
+  it("resizes when the width changes", () => {
+    expect(
+      shouldApplyAutoFitSize(
+        { width: 300, height: 400 },
+        { width: TRAY_WIDTH, height: 400 },
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores height jitter within the epsilon", () => {
+    // Measurement noise must not cost a resize plus a re-anchor every pass.
+    expect(
+      shouldApplyAutoFitSize(
+        { width: TRAY_WIDTH, height: 400 },
+        { width: TRAY_WIDTH, height: 402 },
+      ),
+    ).toBe(false);
+    expect(
+      shouldApplyAutoFitSize(
+        { width: TRAY_WIDTH, height: 400 },
+        { width: TRAY_WIDTH, height: 398 },
+      ),
+    ).toBe(false);
+  });
+
+  it("resizes once the height moves past the epsilon", () => {
+    expect(
+      shouldApplyAutoFitSize(
+        { width: TRAY_WIDTH, height: 400 },
+        { width: TRAY_WIDTH, height: 403 },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not resize when nothing changed", () => {
+    expect(
+      shouldApplyAutoFitSize(
+        { width: TRAY_WIDTH, height: 400 },
+        { width: TRAY_WIDTH, height: 400 },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isUserDragResize", () => {
+  const lastApplied = { width: 656, height: 800 };
+
+  it("ignores events while a programmatic resize is in flight", () => {
+    expect(
+      isUserDragResize({
+        programmaticInFlight: 1,
+        lastApplied,
+        event: { width: 1200, height: 1200 },
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores an echo of the size we just applied", () => {
+    expect(
+      isUserDragResize({
+        programmaticInFlight: 0,
+        lastApplied,
+        event: { width: 656, height: 800 },
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores rounding noise within tolerance on both axes", () => {
+    expect(
+      isUserDragResize({
+        programmaticInFlight: 0,
+        lastApplied,
+        event: { width: 659, height: 797 },
+      }),
+    ).toBe(false);
+  });
+
+  it("reports a drag once either axis moves past tolerance", () => {
+    expect(
+      isUserDragResize({
+        programmaticInFlight: 0,
+        lastApplied,
+        event: { width: 660, height: 800 },
+      }),
+    ).toBe(true);
+    expect(
+      isUserDragResize({
+        programmaticInFlight: 0,
+        lastApplied,
+        event: { width: 656, height: 804 },
+      }),
+    ).toBe(true);
+  });
+
+  it("treats any resize as a drag before we have applied a size", () => {
+    expect(
+      isUserDragResize({
+        programmaticInFlight: 0,
+        lastApplied: null,
+        event: { width: 656, height: 800 },
+      }),
+    ).toBe(true);
+  });
+
+  it("stays suppressed while several programmatic resizes overlap", () => {
+    // The auto-fit pass fires a burst of setSize calls; the counter must gate
+    // all of them, not just the first.
+    expect(
+      isUserDragResize({
+        programmaticInFlight: 3,
+        lastApplied: null,
+        event: { width: 999, height: 999 },
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop-tauri/src/lib/trayPanelLayout.ts
+++ b/apps/desktop-tauri/src/lib/trayPanelLayout.ts
@@ -1,0 +1,180 @@
+/**
+ * Pure sizing math for the tray flyout.
+ *
+ * Extracted from `useTrayPanelLayout` so the arithmetic can be tested without a
+ * window, a Tauri bridge, or a live DOM. The hook keeps the effects: measuring
+ * the surface, calling `setSize`, and re-anchoring.
+ *
+ * Positioning is NOT here. Where the flyout sits is decided by
+ * `reanchorTrayPanel()` on the Rust side; this module only decides how big it is.
+ */
+
+export const TRAY_WIDTH = 328;
+export const TRAY_MAX_MEASURE_HEIGHT = 920;
+export const TRAY_OVERVIEW_MIN_HEIGHT = 200;
+export const TRAY_DETAIL_MIN_HEIGHT = 420;
+export const TRAY_DENSE_OVERVIEW_HEIGHT = 776;
+
+/** Gap left between the flyout and the edge of the work area. */
+const WORK_AREA_MARGIN = 16;
+
+/** Slack added below the measured content so the last row is never clipped. */
+const CONTENT_BOTTOM_PADDING = 4;
+
+/**
+ * Re-applying a size costs a window resize plus a re-anchor, so ignore
+ * sub-pixel churn from the measure pass.
+ */
+const HEIGHT_CHANGE_EPSILON = 2;
+
+/**
+ * A user drag has to move the border by more than this before we treat it as
+ * intentional. Physical pixels, compared against the last size we applied.
+ */
+const USER_RESIZE_TOLERANCE = 3;
+
+export interface TraySizeInputs {
+  detailMode: boolean;
+  denseOverview: boolean;
+}
+
+/**
+ * The floor for the flyout. Detail mode needs room for a provider pane, and a
+ * dense overview is tall enough that starting small just causes a second resize.
+ */
+export function trayMinHeight({ detailMode, denseOverview }: TraySizeInputs): number {
+  if (detailMode) return TRAY_DETAIL_MIN_HEIGHT;
+  if (denseOverview) return TRAY_DENSE_OVERVIEW_HEIGHT;
+  return TRAY_OVERVIEW_MIN_HEIGHT;
+}
+
+/**
+ * The ceiling for the flyout: the work area minus a margin, capped by the
+ * measure limit, but never below `minHeight`.
+ *
+ * `workAreaHeight` is null when the work-area query fails. Falling back to the
+ * measure limit keeps the panel usable rather than collapsing it.
+ *
+ * Note the min-height floor wins over the work area. On a very short work area
+ * the panel deliberately overflows rather than rendering unusably small.
+ */
+export function trayMaxHeight(
+  minHeight: number,
+  workAreaHeight: number | null,
+): number {
+  return Math.max(
+    minHeight,
+    Math.min(
+      TRAY_MAX_MEASURE_HEIGHT,
+      (workAreaHeight ?? TRAY_MAX_MEASURE_HEIGHT) - WORK_AREA_MARGIN,
+    ),
+  );
+}
+
+/** Clamp measured content into the allowed band. */
+export function clampTrayHeight(
+  contentHeight: number,
+  minHeight: number,
+  maxHeight: number,
+): number {
+  return Math.min(Math.max(contentHeight, minHeight), maxHeight);
+}
+
+export interface RectExtent {
+  height: number;
+  bottom: number;
+}
+
+export interface TrayContentMetrics {
+  /** `getBoundingClientRect().top` of the tray surface. */
+  surfaceTop: number;
+  /** `getBoundingClientRect().height` of the tray surface. */
+  surfaceHeight: number;
+  /** `scrollHeight` of the tray surface. */
+  surfaceScrollHeight: number;
+  /** The scrollable body, when present. */
+  body?: RectExtent | null;
+  /** The pinned footer, when present. */
+  footer?: RectExtent | null;
+}
+
+/**
+ * How tall the content actually is, in logical pixels.
+ *
+ * The surface's own box is not enough: during the measure pass the body and
+ * footer can extend past it, so the real extent is the lowest bottom edge of
+ * the three. Zero-height rects are ignored because a hidden element reports
+ * `bottom === top`, which would otherwise drag the measurement upward.
+ */
+export function measureTrayContentHeight({
+  surfaceTop,
+  surfaceHeight,
+  surfaceScrollHeight,
+  body = null,
+  footer = null,
+}: TrayContentMetrics): number {
+  const ownHeight = Math.max(surfaceScrollHeight, Math.ceil(surfaceHeight));
+  let maxBottom = surfaceTop + ownHeight;
+
+  if (body && body.height > 0 && body.bottom > maxBottom) {
+    maxBottom = body.bottom;
+  }
+  if (footer && footer.height > 0 && footer.bottom > maxBottom) {
+    maxBottom = footer.bottom;
+  }
+
+  return Math.ceil(maxBottom - surfaceTop) + CONTENT_BOTTOM_PADDING;
+}
+
+export interface AppliedSize {
+  width: number;
+  height: number;
+}
+
+/**
+ * Whether an auto-fit pass should actually resize the window.
+ *
+ * `previous` is null before the first auto-fit. Width is compared exactly since
+ * it is a constant; height gets an epsilon because measurement jitters.
+ */
+export function shouldApplyAutoFitSize(
+  previous: AppliedSize | null,
+  next: AppliedSize,
+): boolean {
+  if (previous === null) return true;
+  if (previous.width !== next.width) return true;
+  return Math.abs(previous.height - next.height) > HEIGHT_CHANGE_EPSILON;
+}
+
+export interface ResizeEventContext {
+  /** How many programmatic resizes are in flight. */
+  programmaticInFlight: number;
+  /** Actual physical size after the last resize we performed. */
+  lastApplied: AppliedSize | null;
+  /** Physical size reported by the event. */
+  event: AppliedSize;
+}
+
+/**
+ * Whether a resize event came from the user dragging the border.
+ *
+ * Everything here is in PHYSICAL pixels on both sides. Tauri's scale factor,
+ * the webview's `devicePixelRatio`, and Win32 can disagree on a scaled display,
+ * and converting between them is what previously compounded into a per-open
+ * size growth. Comparing physical to physical needs no conversion at all.
+ */
+export function isUserDragResize({
+  programmaticInFlight,
+  lastApplied,
+  event,
+}: ResizeEventContext): boolean {
+  if (programmaticInFlight > 0) return false;
+  if (
+    lastApplied &&
+    Math.abs(event.width - lastApplied.width) <= USER_RESIZE_TOLERANCE &&
+    Math.abs(event.height - lastApplied.height) <= USER_RESIZE_TOLERANCE
+  ) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Closes #223.

## Correction to the issue

I filed #223 saying this hook handles "multiple monitors, mixed DPI, taskbars docked to each edge, and clamping so the panel never opens off screen." Reading it properly, that is wrong. Placement is decided by `reanchorTrayPanel()` on the Rust side. The hook never computes a coordinate and never enumerates a monitor.

What it does own is **sizing**, and that was genuinely untestable because the arithmetic was interleaved with `setSize`, work-area queries, and DOM style mutation. So the refactor still applies, just to a smaller and more honest target.

The DPI concern in the issue is real, but it is narrower than described: physical and logical pixels are deliberately never converted, because Tauri's scale factor, the webview's `devicePixelRatio`, and Win32 can disagree on a scaled display. That disagreement previously compounded into a per-open size growth. `isUserDragResize` is the guard, and it now has tests.

## What moved

Five pure functions into `lib/trayPanelLayout.ts`:

| Function | What it decides |
|---|---|
| `trayMinHeight` | the detail / dense / plain floor |
| `trayMaxHeight` | work-area margin, measure-limit cap, null-work-area fallback |
| `clampTrayHeight` | the final band |
| `measureTrayContentHeight` | lowest bottom edge across surface, body, footer |
| `shouldApplyAutoFitSize` / `isUserDragResize` | the two epsilon comparisons |

The hook keeps every effect: measuring, `setSize`, re-anchor, reveal, and the DOM style save/restore. The diff on the hook is a straight substitution, no reordering and no changed conditions.

## Cases worth calling out

- **Null work area.** `getWorkAreaRect()` can reject. Falling back to the measure limit keeps the panel usable rather than collapsing it.
- **Very short work area.** The min-height floor deliberately beats the work area, so the panel overflows rather than rendering unusably small. That was implicit in the nesting of `Math.max`/`Math.min`; it is now stated and tested.
- **Zero-height body or footer.** A hidden element reports `bottom === top`, which would drag the measurement upward and clip the panel. The `height > 0` guards are load-bearing.
- **Overlapping programmatic resizes.** The auto-fit pass fires a burst of `setSize` calls, so the in-flight counter has to gate all of them, not just the first.

## Test plan

- [x] `pnpm vitest run` — 58 files, 408 tests passing (was 375, +33)
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm run build` — clean
- [x] New file line endings normalized to CRLF to match the rest of the repo

Pure extraction, no behavior change.
