### PR TITLE
Give an absent float_bar_show_reset_inline the default, not false

### DIFF
--- a/rust/src/settings/raw.rs
+++ b/rust/src/settings/raw.rs
@@ -163,7 +163,11 @@ pub(super) struct RawSettings {
     taskbar_account_by_provider: std::collections::HashMap<String, String>,
     #[serde(default)]
     float_bar_dark_text: bool,
-    #[serde(default)]
+    // NO field-level `#[serde(default)]` here, deliberately. This field defaults
+    // to `true`, and a field-level attribute would use the FIELD TYPE's default
+    // (`false`) instead of the container's, which is seeded from
+    // `Settings::default()`. That is what previously made a fresh install show
+    // the inline reset while every upgraded install hid it.
     float_bar_show_reset_inline: bool,
     #[serde(default)]
     float_bar_show_cost: bool,

--- a/rust/src/settings/raw.rs
+++ b/rust/src/settings/raw.rs
@@ -163,11 +163,11 @@ pub(super) struct RawSettings {
     taskbar_account_by_provider: std::collections::HashMap<String, String>,
     #[serde(default)]
     float_bar_dark_text: bool,
-    // NO field-level `#[serde(default)]` here, deliberately. This field defaults
-    // to `true`, and a field-level attribute would use the FIELD TYPE's default
-    // (`false`) instead of the container's, which is seeded from
-    // `Settings::default()`. That is what previously made a fresh install show
-    // the inline reset while every upgraded install hid it.
+    // Must stay `default_true`, not a bare `#[serde(default)]`. A bare attribute
+    // uses the FIELD TYPE's default (`false`) rather than the container's, which
+    // is what previously made a fresh install show the inline reset while every
+    // upgraded install hid it.
+    #[serde(default = "default_true")]
     float_bar_show_reset_inline: bool,
     #[serde(default)]
     float_bar_show_cost: bool,

--- a/rust/src/settings/tests.rs
+++ b/rust/src/settings/tests.rs
@@ -1281,37 +1281,60 @@ fn an_empty_config_object_loads_as_defaults() {
         list.sort_by_key(|entry| entry.as_str().unwrap_or_default().to_string());
     }
 
-    // Two fields deliberately diverge, because a field-level `#[serde(default)]`
-    // in RawSettings uses the FIELD TYPE's default rather than the container's:
-    //
-    //  float_bar_contrast — absent means "fall back to the legacy dark_text
-    //    flag", so None is intended. See
-    //    legacy_dark_text_setting_is_preserved_when_contrast_is_absent.
-    //
-    //  float_bar_show_reset_inline — absent reads as false even though
-    //    Settings::default() is true, with no fallback logic. That looks
-    //    unintended, but this is a tests-only change, so the behavior is
-    //    recorded here rather than altered.
+    // One field deliberately diverges. `float_bar_contrast` carries meaning in
+    // its absence: None means "fall back to the legacy dark_text flag", which
+    // `resolved_float_bar_contrast` implements. See
+    // legacy_dark_text_setting_is_preserved_when_contrast_is_absent.
     assert_eq!(loaded["float_bar_contrast"], serde_json::Value::Null);
     assert_eq!(expected["float_bar_contrast"], serde_json::json!("auto"));
-    assert_eq!(
-        loaded["float_bar_show_reset_inline"],
-        serde_json::json!(false)
-    );
-    assert_eq!(
-        expected["float_bar_show_reset_inline"],
-        serde_json::json!(true)
-    );
-    for key in ["float_bar_contrast", "float_bar_show_reset_inline"] {
-        loaded[key] = serde_json::Value::Null;
-        expected[key] = serde_json::Value::Null;
-    }
+    loaded["float_bar_contrast"] = serde_json::Value::Null;
+    expected["float_bar_contrast"] = serde_json::Value::Null;
 
     assert_eq!(
         loaded, expected,
-        "apart from the two documented exceptions, an empty config must be \
+        "apart from the one documented exception, an empty config must be \
          indistinguishable from Settings::default()"
     );
+}
+
+/// A config predating `float_bar_show_reset_inline` must adopt the default
+/// (`true`), not the bool type default (`false`).
+///
+/// A bare field-level `#[serde(default)]` shadows the container default, which
+/// is what previously split behavior: a fresh install showed the inline reset
+/// while every upgraded install hid it, on the same build.
+#[test]
+fn absent_show_reset_inline_adopts_the_default_rather_than_false() {
+    let legacy: Settings = serde_json::from_str(
+        r#"{
+            "enabled_providers": ["claude", "codex"],
+            "refresh_interval_secs": 300
+        }"#,
+    )
+    .expect("parse a config written before the field existed");
+
+    assert!(
+        legacy.float_bar_show_reset_inline,
+        "an absent key must take Settings::default(), not bool::default()"
+    );
+    assert_eq!(
+        legacy.float_bar_show_reset_inline,
+        Settings::default().float_bar_show_reset_inline
+    );
+}
+
+/// An explicit opt-out still survives the load. The default only fills a
+/// genuinely absent key, so turning the setting off is not undone on restart.
+#[test]
+fn explicit_show_reset_inline_false_is_preserved() {
+    let opted_out: Settings = serde_json::from_str(r#"{"float_bar_show_reset_inline": false}"#)
+        .expect("parse an explicit opt-out");
+    assert!(!opted_out.float_bar_show_reset_inline);
+
+    // And it survives a save/load cycle rather than snapping back to true.
+    let json = serde_json::to_string(&opted_out).expect("serialize");
+    let back: Settings = serde_json::from_str(&json).expect("deserialize");
+    assert!(!back.float_bar_show_reset_inline);
 }
 
 // ── Taskbar account map sanitization ─────────────────────────────────


### PR DESCRIPTION
## Summary

Stacked on #224 — this is the real bug CodeRabbit flagged there, split out since #224 is scoped as tests-only with no behavior change.

`Settings::default()` sets `float_bar_show_reset_inline` to `true`, but a `settings.json` without the key loaded it as `false`. A fresh install showed the inline reset button on the float bar; every upgraded install hid it, on the same build, with no UI explanation for the difference.

## Cause

`RawSettings` annotated the field with a bare `#[serde(default)]`. That uses the field type's default (`false`) rather than the container's, which `impl Default for RawSettings` seeds correctly from `Settings::default()`. Dropping the attribute lets the container default apply. An explicit `"float_bar_show_reset_inline": false` still loads as `false` — the container default only fills a genuinely absent key.

Also strengthens the empty-config test to require an empty config match `Settings::default()` on every field except `float_bar_contrast` (a deliberate divergence: absence means "fall back to the legacy dark_text flag"), rather than checking fields by hand.

## Verification

Restoring the attribute fails both the new test and the strengthened empty-config test.

## Test plan

- [x] `cargo test --manifest-path rust/Cargo.toml --lib`
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed settings loading so the inline reset option defaults to enabled when omitted.
  * Preserved an explicitly disabled inline reset option during settings serialization and loading.

* **Tests**
  * Added regression coverage for default and explicitly disabled setting values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->