### PR TITLE
test: cover formatEta

### DIFF
--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/PaceSection.formatEta.test.ts
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/PaceSection.formatEta.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { formatEta } from "./PaceSection";
+
+describe("formatEta", () => {
+  it("formats zero as minutes", () => {
+    expect(formatEta(0)).toBe("0m");
+  });
+
+  it("clamps negative input at zero minutes", () => {
+    expect(formatEta(-30)).toBe("0m");
+  });
+
+  it("rounds seconds to minutes", () => {
+    expect(formatEta(59)).toBe("1m");
+    expect(formatEta(60)).toBe("1m");
+  });
+
+  it("keeps sub-hour values as minutes", () => {
+    expect(formatEta(59 * 60)).toBe("59m");
+  });
+
+  it("converts an hour boundary to hours", () => {
+    expect(formatEta(60 * 60)).toBe("1h");
+  });
+
+  it("converts 23h59m to a day under current rounding", () => {
+    expect(formatEta(23 * 3600 + 59 * 60)).toBe("1d");
+  });
+
+  it("converts a full day to days", () => {
+    expect(formatEta(24 * 3600)).toBe("1d");
+    expect(formatEta(48 * 3600)).toBe("2d");
+  });
+});

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/PaceSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/PaceSection.tsx
@@ -41,7 +41,7 @@ export function PaceSection({ pace, t }: Props) {
   );
 }
 
-function formatEta(seconds: number): string {
+export function formatEta(seconds: number): string {
   const mins = Math.max(0, Math.round(seconds / 60));
   if (mins < 60) return `${mins}m`;
   const hrs = Math.round(mins / 60);


### PR DESCRIPTION
## Summary

Exports `formatEta` and adds unit tests covering zero, negative clamping, second/minute rounding, hour and day boundaries, and multi-day values.

## Verification

- `pnpm exec vitest run src/surfaces/settings/providers/sections/PaceSection.formatEta.test.ts` passes (7 tests).

Closes #79