### PR TITLE
check: verify ftl catalogs in locale drift

### DIFF
--- a/apps/desktop-tauri/scripts/check-locale-drift.mjs
+++ b/apps/desktop-tauri/scripts/check-locale-drift.mjs
@@ -17,6 +17,10 @@ const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..", "..", "..");
 const rustPath = resolve(repoRoot, "rust", "src", "locale.rs");
 const tsPath = resolve(here, "..", "src", "i18n", "keys.ts");
+const ftlPaths = {
+  "en-US": resolve(repoRoot, "rust", "src", "locale", "en-US.ftl"),
+  "zh-CN": resolve(repoRoot, "rust", "src", "locale", "zh-CN.ftl"),
+};
 
 function die(code, msg) {
   console.error(`[check-locale] ${msg}`);
@@ -25,11 +29,19 @@ function die(code, msg) {
 
 let rustSrc;
 let tsSrc;
+const ftlSrc = {};
 try {
   rustSrc = readFileSync(rustPath, "utf8");
   tsSrc = readFileSync(tsPath, "utf8");
+  for (const [name, path] of Object.entries(ftlPaths)) {
+    ftlSrc[name] = readFileSync(path, "utf8");
+  }
 } catch (err) {
   die(2, `failed to read source files: ${err.message}`);
+}
+
+function ftlKeys(src) {
+  return [...src.matchAll(/^([A-Za-z0-9_]+)\s*=/gm)].map((match) => match[1]);
 }
 
 // Extract Rust LocaleKey variants from the single source list.
@@ -85,6 +97,40 @@ if (rustKeys.length !== tsKeys.length || onlyInRust.length || onlyInTs.length) {
   process.exit(1);
 }
 
+let catalogFailed = false;
+const declared = new Set(rustKeys);
+for (const [name, src] of Object.entries(ftlSrc)) {
+  const keys = ftlKeys(src);
+  if (keys.length === 0) {
+    die(2, `parsed zero keys from ${name}.ftl`);
+  }
+  const catalogSet = new Set(keys);
+  const missing = rustKeys.filter((k) => !catalogSet.has(k));
+  const extra = keys.filter((k) => !declared.has(k));
+  const label = name === "zh-CN" ? "WARN" : "ERROR";
+
+  if (missing.length || extra.length) {
+    if (name === "zh-CN") {
+      console.warn(`[check-locale] ${label}: ${name} catalog drifted`);
+    } else {
+      console.error(`[check-locale] ${label}: ${name} catalog drifted`);
+      catalogFailed = true;
+    }
+    if (missing.length) {
+      console.error(`  missing from ${name} (${missing.length}):`);
+      for (const k of missing) console.error(`    - ${k}`);
+    }
+    if (extra.length) {
+      console.error(`  only in ${name} (${extra.length}):`);
+      for (const k of extra) console.error(`    - ${k}`);
+    }
+  }
+}
+
+if (catalogFailed) {
+  process.exit(1);
+}
+
 console.log(
-  `[check-locale] OK — ${rustKeys.length} locale keys match between Rust and TS`,
+  `[check-locale] OK — ${rustKeys.length} locale keys match between Rust, TS, and FTL catalogs`,
 );


### PR DESCRIPTION
## Summary

Extends `check-locale-drift.mjs` to parse `en-US.ftl` and `zh-CN.ftl` and verify them against the declared Rust/TS key set. Missing or extra `en-US` keys fail the check; `zh-CN` drift is reported as a warning because it falls back to English.

## Verification

- `pnpm --dir apps/desktop-tauri run check-locale` passes: 654 keys match across Rust, TS, and both FTL catalogs.

Closes #217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved localization validation to detect missing or unexpected translation entries across supported catalogs.
  - Added clearer reporting for successful checks, warnings, and validation failures.
  - Empty or unreadable translation files are now reported as validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->