### PR TITLE
docs: add contributing on-ramp section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ For the active implementation state and the next work items, see
 [docs/CLI.md](docs/CLI.md). Maintainers should follow the
 [release checklist](docs/RELEASING.md) for public builds.
 
+## Contributing
+
+New here? Start with an issue tagged [`good first issue`](https://github.com/tsouth89/ceiling/labels/good%20first%20issue), then read [CONTRIBUTING.md](https://github.com/tsouth89/ceiling/blob/main/CONTRIBUTING.md) for the workflow.
+
 ## Lineage, license, and credits
 
 Ceiling is an independent Windows-focused fork of

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For the active implementation state and the next work items, see
 
 ## Contributing
 
-New here? Start with an issue tagged [`good first issue`](https://github.com/tsouth89/ceiling/labels/good%20first%20issue), then read [CONTRIBUTING.md](https://github.com/tsouth89/ceiling/blob/main/CONTRIBUTING.md) for the workflow.
+New here? Start with an issue tagged [`good first issue`](https://github.com/tsouth89/ceiling/labels/good%20first%20issue), then read [CONTRIBUTING.md](https://github.com/tsouth89/ceiling/blob/main/CONTRIBUTING.md) for the workflow. See [docs/CLI.md](docs/CLI.md) for the `codexbar` CLI reference.
 
 ## Lineage, license, and credits
 


### PR DESCRIPTION
Adds a short "Contributing" section after Development, linking to the good first issue label and CONTRIBUTING.md, per #84.

Left out the docs/CLI.md link for now since that doc doesn't exist yet — happy to add it in a follow-up once it lands, or add it here now if you'd rather I do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Contributing section with guidance for newcomers.
  * Linked to good-first-issue tickets, contribution workflow documentation, and the codexbar CLI reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->