### PR TITLE
A11y/usage bar progressbar

### DIFF
--- a/apps/desktop-tauri/src/surfaces/tray/UsageBar.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/tray/UsageBar.test.tsx
@@ -40,11 +40,14 @@ describe("UsageBar", () => {
     );
   });
 
-  it("clamps aria-valuenow to 100 when usage overshoots the window", () => {
+  it("clamps aria-valuenow to 100 but keeps the raw percentage in the label", () => {
     render(<UsageBar window={windowSnapshot({ usedPercent: 140 })} label="Session" />);
 
     const track = screen.getByRole("progressbar");
     expect(track).toHaveAttribute("aria-valuenow", "100");
-    expect(track).toHaveAttribute("aria-label", "Session usage: 100%");
+    // aria-valuenow must stay within aria-valuemax per the ARIA spec, but the
+    // label still reports the true 140% — a screen reader user must not be
+    // told they're at the limit when they're actually 40% over it.
+    expect(track).toHaveAttribute("aria-label", "Session usage: 140%");
   });
 });

--- a/apps/desktop-tauri/src/surfaces/tray/UsageBar.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/tray/UsageBar.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { RateWindowSnapshot } from "../../types/bridge";
+import UsageBar from "./UsageBar";
+
+function windowSnapshot(
+  overrides: Partial<RateWindowSnapshot> = {},
+): RateWindowSnapshot {
+  return {
+    usedPercent: 72,
+    remainingPercent: 28,
+    windowMinutes: 300,
+    resetsAt: null,
+    resetDescription: null,
+    isExhausted: false,
+    reservePercent: null,
+    reserveDescription: null,
+    ...overrides,
+  };
+}
+
+describe("UsageBar", () => {
+  it("exposes progressbar semantics with the clamped percentage", () => {
+    render(<UsageBar window={windowSnapshot({ usedPercent: 72 })} label="Weekly" />);
+
+    const track = screen.getByRole("progressbar");
+    expect(track).toHaveAttribute("aria-valuenow", "72");
+    expect(track).toHaveAttribute("aria-valuemin", "0");
+    expect(track).toHaveAttribute("aria-valuemax", "100");
+    expect(track).toHaveAttribute("aria-label", "Weekly usage: 72%");
+  });
+
+  it("falls back to a generic label when no label prop is given", () => {
+    render(<UsageBar window={windowSnapshot({ usedPercent: 40 })} />);
+
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-label",
+      "Usage: 40%",
+    );
+  });
+
+  it("clamps aria-valuenow to 100 when usage overshoots the window", () => {
+    render(<UsageBar window={windowSnapshot({ usedPercent: 140 })} label="Session" />);
+
+    const track = screen.getByRole("progressbar");
+    expect(track).toHaveAttribute("aria-valuenow", "100");
+    expect(track).toHaveAttribute("aria-label", "Session usage: 100%");
+  });
+});

--- a/apps/desktop-tauri/src/surfaces/tray/UsageBar.tsx
+++ b/apps/desktop-tauri/src/surfaces/tray/UsageBar.tsx
@@ -29,7 +29,11 @@ export default function UsageBar({ window: w, label, compact }: UsageBarProps) {
         aria-valuenow={pct}
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-label={label ? `${label} usage: ${pct}%` : `Usage: ${pct}%`}
+        aria-label={
+          label
+            ? `${label} usage: ${rawPct.toFixed(0)}%`
+            : `Usage: ${rawPct.toFixed(0)}%`
+        }
       >
         <div
           className="usage-bar__fill"

--- a/apps/desktop-tauri/src/surfaces/tray/UsageBar.tsx
+++ b/apps/desktop-tauri/src/surfaces/tray/UsageBar.tsx
@@ -23,7 +23,14 @@ export default function UsageBar({ window: w, label, compact }: UsageBarProps) {
   return (
     <div className={`usage-bar ${compact ? "usage-bar--compact" : ""}`}>
       {label && <span className="usage-bar__label">{label}</span>}
-      <div className="usage-bar__track">
+      <div
+        className="usage-bar__track"
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={label ? `${label} usage: ${pct}%` : `Usage: ${pct}%`}
+      >
         <div
           className="usage-bar__fill"
           data-level={level}


### PR DESCRIPTION
Adds role="progressbar" with aria-valuenow/aria-valuemin/aria-valuemax and a meaningful aria-label to the usage-bar__track div, per #76.

aria-valuenow and the label use the clamped pct (not rawPct), so the announced value never exceeds aria-valuemax={100}. Visible text still shows raw overshoot; flagging in case you'd rather these match.

Added UsageBar.test.tsx covering role, aria-valuenow, label with/without the label prop, and the clamp-to-100 case.

No visual change; only ARIA attributes added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved usage bar support for assistive technologies with progress indicators, value ranges, and percentage labels.
  * Ensured usage values above 100% are displayed safely.

* **Documentation**
  * Added contribution guidance, including links to beginner-friendly issues and project guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->