### PR TITLE
Refactor: Avoid unnecessary allocation in format_number

### DIFF
--- a/rust/src/cli/cost.rs
+++ b/rust/src/cli/cost.rs
@@ -281,12 +281,11 @@ fn print_json_output(results: &[CostResult], pretty: bool, days: u32) -> anyhow:
 fn format_number(n: u64) -> String {
     let s = n.to_string();
     let mut result = String::new();
-    let chars: Vec<char> = s.chars().collect();
-    for (i, c) in chars.iter().enumerate() {
-        if i > 0 && (chars.len() - i).is_multiple_of(3) {
+    for (i, c) in s.chars().enumerate() {
+        if i > 0 && (s.len() - i).is_multiple_of(3) {
             result.push(',');
         }
-        result.push(*c);
+        result.push(c);
     }
     result
 }


### PR DESCRIPTION
## Summary
Small optimization to the format_number function, removing an unnecessary `.collect()` call, saving an allocation. While the length of a string *can* be different than the length of its chars, (e.g., compound unicode characters), this remains equal for the input of u32.

## Verification
`cargo test format_number --manifest-path rust\Cargo.toml`
2/2 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved number-formatting efficiency without changing the displayed output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->