### PR TITLE
Isolate configured Claude account credentials

### DIFF
--- a/rust/src/providers/claude/mod.rs
+++ b/rust/src/providers/claude/mod.rs
@@ -45,6 +45,20 @@ pub struct ClaudeProvider {
     admin_fetcher: ClaudeAdminApiFetcher,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaudeAutoPolicy {
+    FallbackChain,
+    ScopedOAuthOnly,
+}
+
+fn claude_auto_policy(ctx: &FetchContext) -> ClaudeAutoPolicy {
+    if ctx.account_config_dir.is_some() {
+        ClaudeAutoPolicy::ScopedOAuthOnly
+    } else {
+        ClaudeAutoPolicy::FallbackChain
+    }
+}
+
 impl ClaudeProvider {
     pub fn new() -> Self {
         Self {
@@ -444,6 +458,19 @@ impl ClaudeProvider {
         &self,
         ctx: &FetchContext,
     ) -> Result<ProviderFetchResult, ProviderError> {
+        // A configured account is a promise that this reading belongs to one
+        // specific CLAUDE_CONFIG_DIR. Global sources such as Claude Desktop,
+        // browser cookies, environment tokens, and an ambient CLI session have
+        // no account identity attached, so consulting them here can render the
+        // same seat under every configured account card.
+        if claude_auto_policy(ctx) == ClaudeAutoPolicy::ScopedOAuthOnly {
+            tracing::debug!(
+                config_dir = ?ctx.account_config_dir,
+                "using only directory-scoped OAuth for configured Claude account"
+            );
+            return self.fetch_via_oauth(ctx).await;
+        }
+
         let mut failures = Vec::new();
 
         if let Some(result) = self.try_auto_admin_api(ctx, &mut failures).await {
@@ -1038,6 +1065,24 @@ mod tests {
     use chrono::{DateTime, Utc};
 
     use super::*;
+
+    #[test]
+    fn configured_account_auto_mode_is_scoped_oauth_only() {
+        let configured = FetchContext {
+            account_config_dir: Some(std::path::PathBuf::from(r"C:\Users\person\.claude-work")),
+            ..FetchContext::default()
+        };
+        assert_eq!(
+            claude_auto_policy(&configured),
+            ClaudeAutoPolicy::ScopedOAuthOnly
+        );
+
+        let ambient = FetchContext::default();
+        assert_eq!(
+            claude_auto_policy(&ambient),
+            ClaudeAutoPolicy::FallbackChain
+        );
+    }
 
     #[test]
     fn names_a_pro_seat_from_its_subscription_type() {

--- a/rust/src/providers/claude/mod.rs
+++ b/rust/src/providers/claude/mod.rs
@@ -59,6 +59,28 @@ fn claude_auto_policy(ctx: &FetchContext) -> ClaudeAutoPolicy {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum ClaudeOAuthSource<'a> {
+    Scoped(&'a std::path::Path),
+    AccessToken(&'a str),
+    Ambient,
+}
+
+fn claude_oauth_source(ctx: &FetchContext) -> ClaudeOAuthSource<'_> {
+    if let Some(dir) = ctx.account_config_dir.as_deref() {
+        return ClaudeOAuthSource::Scoped(dir);
+    }
+
+    match ctx
+        .api_key
+        .as_deref()
+        .filter(|token| !token.trim().is_empty())
+    {
+        Some(token) => ClaudeOAuthSource::AccessToken(token),
+        None => ClaudeOAuthSource::Ambient,
+    }
+}
+
 impl ClaudeProvider {
     pub fn new() -> Self {
         Self {
@@ -516,19 +538,17 @@ impl ClaudeProvider {
         ctx: &FetchContext,
     ) -> Result<ProviderFetchResult, ProviderError> {
         tracing::debug!("Attempting OAuth fetch for Claude");
-        if let Some(token) = ctx
-            .api_key
-            .as_deref()
-            .filter(|token| !token.trim().is_empty())
-        {
-            return self.oauth_fetcher.fetch_with_access_token(token).await;
-        }
-
-        // A configured account pins the credential to its own CLAUDE_CONFIG_DIR;
-        // otherwise follow whichever account the CLI is signed in as.
-        match &ctx.account_config_dir {
-            Some(dir) => self.oauth_fetcher.scoped(dir.clone()).fetch().await,
-            None => self.oauth_fetcher.fetch().await,
+        // A configured account always pins the credential to its own
+        // CLAUDE_CONFIG_DIR. Ambient overrides must not leak one account's
+        // identity or usage into another configured account card.
+        match claude_oauth_source(ctx) {
+            ClaudeOAuthSource::Scoped(dir) => {
+                self.oauth_fetcher.scoped(dir.to_path_buf()).fetch().await
+            }
+            ClaudeOAuthSource::AccessToken(token) => {
+                self.oauth_fetcher.fetch_with_access_token(token).await
+            }
+            ClaudeOAuthSource::Ambient => self.oauth_fetcher.fetch().await,
         }
     }
 
@@ -1081,6 +1101,29 @@ mod tests {
         assert_eq!(
             claude_auto_policy(&ambient),
             ClaudeAutoPolicy::FallbackChain
+        );
+    }
+
+    #[test]
+    fn configured_account_oauth_ignores_ambient_access_token() {
+        let configured = FetchContext {
+            account_config_dir: Some(std::path::PathBuf::from(r"C:\Users\person\.claude-work")),
+            api_key: Some("ambient-token".to_string()),
+            ..FetchContext::default()
+        };
+
+        assert_eq!(
+            claude_oauth_source(&configured),
+            ClaudeOAuthSource::Scoped(std::path::Path::new(r"C:\Users\person\.claude-work"))
+        );
+
+        let ambient = FetchContext {
+            api_key: Some("ambient-token".to_string()),
+            ..FetchContext::default()
+        };
+        assert_eq!(
+            claude_oauth_source(&ambient),
+            ClaudeOAuthSource::AccessToken("ambient-token")
         );
     }
 


### PR DESCRIPTION
## Summary
- make configured Claude account directories use only directory-scoped OAuth in Auto mode
- prevent global Claude Desktop, browser, environment, keyring, or ambient CLI identity from being rendered under multiple configured account cards
- preserve the existing fallback chain for ambient single-account usage
- add regression coverage for the source-selection policy

## Validation
- cargo test --manifest-path rust/Cargo.toml (852 passed)
- cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml (481 passed)
- cargo clippy --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all-targets -- -D warnings

Linear: SBS-695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic authentication policy handling for Claude accounts.
  * Configured accounts now use directory-scoped OAuth authentication.
  * Unconfigured accounts retain multiple authentication options with automatic fallback.

* **Tests**
  * Added coverage for both configured and unconfigured account authentication policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->