### PR TITLE
Prevent concurrent state-store data loss

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/browser_import.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/browser_import.rs
@@ -93,9 +93,8 @@ pub fn import_browser_cookies(
     validate_single_line_secret(&cookie_header, "Cookie header", MAX_COOKIE_HEADER_LEN)?;
 
     // Persist as manual cookie.
-    let mut manual = ManualCookies::load_for_update().map_err(|e| e.to_string())?;
-    manual.set(pid.cli_name(), &cookie_header);
-    manual.save().map_err(|e| e.to_string())?;
+    ManualCookies::update(|manual| manual.set(pid.cli_name(), &cookie_header))
+        .map_err(|e| e.to_string())?;
 
     Ok(get_manual_cookies())
 }

--- a/apps/desktop-tauri/src-tauri/src/commands/credential_detection.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/credential_detection.rs
@@ -289,9 +289,11 @@ pub fn set_jetbrains_ide_path(path: String) -> Result<(), String> {
     if !pb.is_dir() {
         return Err(format!("JetBrains IDE path is not a directory: {trimmed}"));
     }
-    let mut settings = Settings::load();
-    settings.set_jetbrains_ide_base_path(pb.to_string_lossy().into_owned());
-    settings.save().map_err(|e| e.to_string())
+    Settings::update(|settings| {
+        settings.set_jetbrains_ide_base_path(pb.to_string_lossy().into_owned())
+    })
+    .map(|_| ())
+    .map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/apps/desktop-tauri/src-tauri/src/commands/credentials.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/credentials.rs
@@ -91,18 +91,15 @@ pub fn set_api_key(
     validate_single_line_secret(&api_key, "API key", MAX_API_KEY_LEN)?;
     let label = sanitize_optional_label(label)?;
 
-    let mut keys = ApiKeys::load_for_update().map_err(|e| e.to_string())?;
-    keys.set(&canonical_provider, api_key.trim(), label.as_deref());
-    keys.save().map_err(|e| e.to_string())?;
+    ApiKeys::update(|keys| keys.set(&canonical_provider, api_key.trim(), label.as_deref()))
+        .map_err(|e| e.to_string())?;
     Ok(get_api_keys())
 }
 
 #[tauri::command]
 pub fn remove_api_key(provider_id: String) -> Result<Vec<ApiKeyInfoBridge>, String> {
     let canonical_provider = canonical_provider_arg(&provider_id)?;
-    let mut keys = ApiKeys::load_for_update().map_err(|e| e.to_string())?;
-    keys.remove(&canonical_provider);
-    keys.save().map_err(|e| e.to_string())?;
+    ApiKeys::update(|keys| keys.remove(&canonical_provider)).map_err(|e| e.to_string())?;
     Ok(get_api_keys())
 }
 
@@ -142,17 +139,15 @@ pub fn set_manual_cookie(
         codexbar::core::TokenAccountSupport::normalized_cookie_header(id, &cookie_header)
     };
 
-    let mut cookies = ManualCookies::load_for_update().map_err(|e| e.to_string())?;
-    cookies.set(id.cli_name(), normalized.trim());
-    cookies.save().map_err(|e| e.to_string())?;
+    ManualCookies::update(|cookies| cookies.set(id.cli_name(), normalized.trim()))
+        .map_err(|e| e.to_string())?;
     Ok(get_manual_cookies())
 }
 
 #[tauri::command]
 pub fn remove_manual_cookie(provider_id: String) -> Result<Vec<CookieInfoBridge>, String> {
     let canonical_provider = canonical_provider_arg(&provider_id)?;
-    let mut cookies = ManualCookies::load_for_update().map_err(|e| e.to_string())?;
-    cookies.remove(&canonical_provider);
-    cookies.save().map_err(|e| e.to_string())?;
+    ManualCookies::update(|cookies| cookies.remove(&canonical_provider))
+        .map_err(|e| e.to_string())?;
     Ok(get_manual_cookies())
 }

--- a/apps/desktop-tauri/src-tauri/src/commands/locale_cmd.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/locale_cmd.rs
@@ -74,12 +74,17 @@ fn parse_locale_language(raw: &str) -> Option<Language> {
 pub fn set_ui_language(app: tauri::AppHandle, language: String) -> Result<(), String> {
     let lang =
         parse_locale_language(&language).ok_or_else(|| format!("unknown language: {language}"))?;
-    let mut settings = Settings::load();
-    if settings.ui_language == lang {
+    let (_, changed) = Settings::try_update(|settings| {
+        if settings.ui_language == lang {
+            return Ok(false);
+        }
+        settings.ui_language = lang;
+        Ok(true)
+    })
+    .map_err(|e| e.to_string())?;
+    if !changed {
         return Ok(());
     }
-    settings.ui_language = lang;
-    settings.save().map_err(|e| e.to_string())?;
     let _ = app.emit(events::LOCALE_CHANGED, language_label(lang));
     crate::tray_bridge::refresh_tray_presentation(&app);
     Ok(())

--- a/apps/desktop-tauri/src-tauri/src/commands/provider_detail.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/provider_detail.rs
@@ -208,31 +208,7 @@ pub fn revoke_provider_credentials(provider_id: String) -> Result<(), String> {
     // caller can follow up with a fresh login or import. Missing entries are
     // silently ignored; only I/O errors propagate.
     let id = parse_provider_arg(&provider_id)?;
-    let provider_id = id.cli_name();
-
-    // Read every store before writing any of them. Each load can now fail
-    // closed on an undecodable file, and revoke touches three stores, so
-    // interleaving reads and writes would let the first write land and a later
-    // read abort — leaving the provider revoked in one store and live in the
-    // others, with an error returned either way.
-    let mut keys = ApiKeys::load_for_update().map_err(|e| e.to_string())?;
-    let mut cookies = ManualCookies::load_for_update().map_err(|e| e.to_string())?;
-    let token_store = TokenAccountStore::new();
-    let mut token_accounts = token_store.load().map_err(|e| e.to_string())?;
-
-    keys.remove(provider_id);
-    keys.save().map_err(|e| e.to_string())?;
-
-    cookies.remove(provider_id);
-    cookies.save().map_err(|e| e.to_string())?;
-
-    if token_accounts.remove(&id).is_some() {
-        token_store
-            .save(&token_accounts)
-            .map_err(|e| e.to_string())?;
-    }
-
-    Ok(())
+    codexbar::settings::revoke_managed_credentials(id).map_err(|e| e.to_string())
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/apps/desktop-tauri/src-tauri/src/commands/provider_settings.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/provider_settings.rs
@@ -40,9 +40,10 @@ pub fn reorder_providers(
     app: tauri::AppHandle,
     ids: Vec<String>,
 ) -> Result<Vec<ProviderSummary>, String> {
-    let mut settings = Settings::load();
-    settings.provider_order = codexbar::settings::normalize_provider_order(&ids);
-    settings.save().map_err(|e| e.to_string())?;
+    let settings = Settings::update(|settings| {
+        settings.provider_order = codexbar::settings::normalize_provider_order(&ids)
+    })
+    .map_err(|e| e.to_string())?;
     crate::tray_bridge::refresh_tray_presentation(&app);
     // Notify open surfaces (tray flyout, pop-out window) so their provider grid
     // and cards re-render in the new order immediately after a drag-reorder.
@@ -105,9 +106,11 @@ pub fn set_provider_cookie_source(provider_id: String, source: String) -> Result
             "Invalid cookie source '{source}' for provider '{provider_id}'"
         ));
     }
-    let mut settings = Settings::load();
-    provider_cookie_source_set(&mut settings, &provider_id, source.to_string())?;
-    settings.save().map_err(|e| e.to_string())
+    Settings::try_update(|settings| {
+        provider_cookie_source_set(settings, &provider_id, source.to_string())
+    })
+    .map(|_| ())
+    .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -165,9 +168,9 @@ pub fn set_provider_region(provider_id: String, region: String) -> Result<(), St
             "Invalid region '{region}' for provider '{provider_id}'"
         ));
     }
-    let mut settings = Settings::load();
-    provider_region_set(&mut settings, &provider_id, region.to_string())?;
-    settings.save().map_err(|e| e.to_string())
+    Settings::try_update(|settings| provider_region_set(settings, &provider_id, region.to_string()))
+        .map(|_| ())
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -193,10 +196,13 @@ pub fn set_provider_workspace_id(provider_id: String, workspace_id: String) -> R
         format!("Provider '{provider_id}' does not expose a workspace/project id")
     })?;
     let workspace_id = codexbar::settings::validate_provider_workspace_value(id, &workspace_id)?;
-    let mut settings = Settings::load();
-    prevent_litellm_key_retargeting(id, settings.workspace_id(id), &workspace_id)?;
-    settings.set_workspace_id(id, workspace_id);
-    settings.save().map_err(|e| e.to_string())
+    Settings::try_update(|settings| {
+        prevent_litellm_key_retargeting(id, settings.workspace_id(id), &workspace_id)?;
+        settings.set_workspace_id(id, workspace_id);
+        Ok(())
+    })
+    .map(|_| ())
+    .map_err(|e| e.to_string())
 }
 
 fn prevent_litellm_key_retargeting(
@@ -318,9 +324,9 @@ pub fn set_provider_gateway_url(provider_id: String, gateway_url: String) -> Res
     codexbar::providers::wayfinder::parse_gateway_url(gateway_url)
         .map_err(|error| error.to_string())?;
 
-    let mut settings = Settings::load();
-    settings.set_gateway_url(id, gateway_url.to_string());
-    settings.save().map_err(|error| error.to_string())
+    Settings::update(|settings| settings.set_gateway_url(id, gateway_url.to_string()))
+        .map(|_| ())
+        .map_err(|error| error.to_string())
 }
 
 // ── Phase 6c — cookie source & region option catalogs ────────────────

--- a/apps/desktop-tauri/src-tauri/src/commands/settings.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/settings.rs
@@ -385,26 +385,26 @@ pub async fn update_settings(
     app: tauri::AppHandle,
     patch: SettingsUpdate,
 ) -> Result<SettingsSnapshot, String> {
-    let mut settings = Settings::load();
     let notify_float_bar = patch.notifies_float_bar();
     let refresh_provider_data = patch.refreshes_provider_data();
     let clear_local_usage_cache = patch.codex_custom_sessions_dirs.is_some();
     let rebuild_tray_menu = patch.rebuilds_tray_menu();
     let refresh_tray_presentation = patch.refreshes_tray_presentation();
-    let previous_language = settings.ui_language;
+    let (settings, (float_bar_patch, language_changed)) = Settings::try_update(|settings| {
+        let previous_language = settings.ui_language;
+        patch.validate_shortcut_changes(
+            &app,
+            &settings.global_shortcut,
+            &settings.taskbar_toggle_shortcut,
+        )?;
+        let float_bar_patch = patch.apply_to(settings)?;
+        Ok((float_bar_patch, settings.ui_language != previous_language))
+    })
+    .map_err(|e| e.to_string())?;
 
-    patch.validate_shortcut_changes(
-        &app,
-        &settings.global_shortcut,
-        &settings.taskbar_toggle_shortcut,
-    )?;
-    let float_bar_patch = patch.apply_to(&mut settings)?;
-
-    if settings.ui_language != previous_language {
+    if language_changed {
         let _ = app.emit(events::LOCALE_CHANGED, language_label(settings.ui_language));
     }
-
-    settings.save().map_err(|e| e.to_string())?;
     if clear_local_usage_cache {
         crate::commands::clear_provider_local_usage_cache();
     }

--- a/apps/desktop-tauri/src-tauri/src/floatbar/commands.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/commands.rs
@@ -11,27 +11,22 @@ use super::window as floatbar_window;
 
 #[tauri::command]
 pub async fn show_float_bar(app: AppHandle) -> Result<(), String> {
-    let mut settings = Settings::load();
-    settings.float_bar_enabled = true;
-    settings.save().map_err(|e| e.to_string())?;
+    let settings = Settings::update(|settings| settings.float_bar_enabled = true)
+        .map_err(|e| e.to_string())?;
 
     super::apply_state(&app, &settings)
 }
 
 #[tauri::command]
 pub fn hide_float_bar(app: AppHandle) -> Result<(), String> {
-    let mut settings = Settings::load();
-    settings.float_bar_enabled = false;
-    settings.save().map_err(|e| e.to_string())?;
+    Settings::update(|settings| settings.float_bar_enabled = false).map_err(|e| e.to_string())?;
     floatbar_window::hide(&app)
 }
 
 #[tauri::command]
 pub fn set_float_bar_opacity(app: AppHandle, opacity: u8) -> Result<(), String> {
     let opacity = clamp_float_bar_opacity(opacity);
-    let mut settings = Settings::load();
-    settings.float_bar_opacity = opacity;
-    settings.save().map_err(|e| e.to_string())?;
+    Settings::update(|settings| settings.float_bar_opacity = opacity).map_err(|e| e.to_string())?;
 
     if let Some(window) = app.get_webview_window(floatbar_window::FLOATBAR_LABEL) {
         floatbar_window::apply_no_activate(&window);
@@ -43,9 +38,8 @@ pub fn set_float_bar_opacity(app: AppHandle, opacity: u8) -> Result<(), String> 
 
 #[tauri::command]
 pub fn set_float_bar_click_through(app: AppHandle, enabled: bool) -> Result<(), String> {
-    let mut settings = Settings::load();
-    settings.float_bar_click_through = enabled;
-    settings.save().map_err(|e| e.to_string())?;
+    Settings::update(|settings| settings.float_bar_click_through = enabled)
+        .map_err(|e| e.to_string())?;
 
     if let Some(window) = app.get_webview_window(floatbar_window::FLOATBAR_LABEL) {
         floatbar_window::apply_no_activate(&window);
@@ -69,9 +63,8 @@ pub fn resize_float_bar(app: AppHandle, width: f64, height: f64) -> Result<(), S
 #[tauri::command]
 pub fn set_float_bar_orientation(app: AppHandle, orientation: String) -> Result<(), String> {
     let orientation = normalize_float_bar_orientation(&orientation);
-    let mut settings = Settings::load();
-    settings.float_bar_orientation = orientation;
-    settings.save().map_err(|e| e.to_string())?;
+    Settings::update(|settings| settings.float_bar_orientation = orientation.clone())
+        .map_err(|e| e.to_string())?;
 
     // The webview re-reads orientation from settings on every config
     // change — emit the live-update event so it re-lays-out without us

--- a/apps/desktop-tauri/src-tauri/src/floatbar/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/mod.rs
@@ -55,12 +55,15 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) -
 /// Toggle the floating bar from the tray menu. Persists the new state
 /// and shows or hides the window accordingly.
 pub fn toggle(app: &tauri::AppHandle) {
-    let mut settings = Settings::load();
-    settings.taskbar_widget_enabled = !settings.taskbar_widget_enabled;
-    if let Err(error) = settings.save() {
-        tracing::warn!(%error, "Could not persist taskbar widget visibility");
-        return;
-    }
+    let settings = match Settings::update(|settings| {
+        settings.taskbar_widget_enabled = !settings.taskbar_widget_enabled;
+    }) {
+        Ok(settings) => settings,
+        Err(error) => {
+            tracing::warn!(%error, "Could not persist taskbar widget visibility");
+            return;
+        }
+    };
     crate::taskbar_widget::apply_state(app, &settings);
 }
 

--- a/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
@@ -329,13 +329,13 @@ fn handle_menu_event(app: &AppHandle, id: &str) {
             });
         }
         Some(MenuAction::ToggleProvider(provider_id)) => {
-            let mut settings = Settings::load();
-            if settings.enabled_providers.contains(&provider_id) {
-                settings.enabled_providers.remove(&provider_id);
-            } else {
-                settings.enabled_providers.insert(provider_id);
-            }
-            let _ = settings.save();
+            let _ = Settings::update(|settings| {
+                if settings.enabled_providers.contains(&provider_id) {
+                    settings.enabled_providers.remove(&provider_id);
+                } else {
+                    settings.enabled_providers.insert(provider_id);
+                }
+            });
             crate::floatbar::notify_settings_changed(app);
             rebuild_tray_menu(app);
         }

--- a/rust/src/cli/config.rs
+++ b/rust/src/cli/config.rs
@@ -261,13 +261,13 @@ async fn list_providers() -> anyhow::Result<()> {
 /// Enable or disable a provider by CLI name.
 async fn set_provider_enabled(provider: &str, enabled: bool) -> anyhow::Result<()> {
     let id = parse_provider(provider)?;
-    let mut settings = Settings::load();
-    if enabled {
-        settings.enable_provider(id);
-    } else {
-        settings.disable_provider(id);
-    }
-    settings.save()?;
+    Settings::update(|settings| {
+        if enabled {
+            settings.enable_provider(id);
+        } else {
+            settings.disable_provider(id);
+        }
+    })?;
     let state = if enabled { "enabled" } else { "disabled" };
     println!("Config: {state} {}", id.display_name());
     Ok(())
@@ -284,14 +284,10 @@ async fn set_api_key(
     ensure_provider_accepts_api_key(id)?;
     let api_key = resolve_api_key_input(api_key, read_from_stdin)?;
 
-    let mut keys = ApiKeys::load_for_update()?;
-    keys.set(id.cli_name(), &api_key, None);
-    keys.save()?;
+    ApiKeys::update(|keys| keys.set(id.cli_name(), &api_key, None))?;
 
     if enable_provider {
-        let mut settings = Settings::load();
-        settings.enable_provider(id);
-        settings.save()?;
+        Settings::update(|settings| settings.enable_provider(id))?;
     }
 
     let suffix = if enable_provider { " and enabled" } else { "" };

--- a/rust/src/core/token_accounts.rs
+++ b/rust/src/core/token_accounts.rs
@@ -561,6 +561,16 @@ impl TokenAccountStore {
         &self,
         accounts: &HashMap<ProviderId, ProviderAccountData>,
     ) -> Result<(), TokenAccountError> {
+        crate::secure_file::with_state_write_lock(|| {
+            self.save_unlocked(accounts).map_err(std::io::Error::other)
+        })
+        .map_err(TokenAccountError::Io)
+    }
+
+    pub(crate) fn save_unlocked(
+        &self,
+        accounts: &HashMap<ProviderId, ProviderAccountData>,
+    ) -> Result<(), TokenAccountError> {
         // Read before create_dir_all/write so an undecodable existing file
         // fails closed instead of being replaced by a partial one.
         let mut providers: HashMap<String, ProviderAccountData> = self
@@ -614,9 +624,12 @@ impl TokenAccountStore {
         provider: ProviderId,
         data: &ProviderAccountData,
     ) -> Result<(), TokenAccountError> {
-        let mut all = self.load()?;
-        all.insert(provider, data.clone());
-        self.save(&all)
+        crate::secure_file::with_state_write_lock(|| {
+            let mut all = self.load().map_err(std::io::Error::other)?;
+            all.insert(provider, data.clone());
+            self.save_unlocked(&all).map_err(std::io::Error::other)
+        })
+        .map_err(TokenAccountError::Io)
     }
 }
 
@@ -783,6 +796,40 @@ mod tests {
         let loaded = store.load().expect("load after save");
         assert_eq!(loaded[&ProviderId::Claude].accounts.len(), 1);
         assert_eq!(loaded[&ProviderId::Cursor].accounts.len(), 1);
+    }
+
+    #[test]
+    fn concurrent_provider_saves_both_survive() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("token-accounts.json");
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+
+        let writers: Vec<_> = [ProviderId::Claude, ProviderId::Cursor]
+            .into_iter()
+            .map(|provider| {
+                let path = path.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    let mut data = ProviderAccountData::default();
+                    data.add_account(TokenAccount::new(
+                        format!("{provider:?}"),
+                        format!("secret-{provider:?}"),
+                    ));
+                    barrier.wait();
+                    TokenAccountStore::with_path(path)
+                        .save_provider(provider, &data)
+                        .expect("concurrent provider save");
+                })
+            })
+            .collect();
+        barrier.wait();
+        for writer in writers {
+            writer.join().expect("writer thread");
+        }
+
+        let stored = TokenAccountStore::with_path(path).load().expect("reload");
+        assert!(stored.contains_key(&ProviderId::Claude));
+        assert!(stored.contains_key(&ProviderId::Cursor));
     }
 
     /// Removing a known provider must still remove it — preservation applies

--- a/rust/src/secure_file.rs
+++ b/rust/src/secure_file.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::OsString;
 use std::io::{self, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use base64::Engine;
@@ -13,6 +13,116 @@ const VERSION: u32 = 1;
 const WINDOWS_DPAPI_USER: &str = "windows-dpapi-user";
 const WINDOWS_DPAPI_MACHINE: &str = "windows-dpapi-machine";
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+const STATE_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const STATE_LOCK_RETRY: std::time::Duration = std::time::Duration::from_millis(20);
+
+/// Serialize read-modify-write transactions across Ceiling processes.
+///
+/// Every settings and credential store shares one lock so operations spanning
+/// multiple files cannot interleave with a writer for any one of those files.
+pub fn with_state_write_lock<T>(operation: impl FnOnce() -> io::Result<T>) -> io::Result<T> {
+    let lock_path = dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("Ceiling")
+        .join("state-write.lock");
+    with_state_write_lock_at(&lock_path, operation)
+}
+
+pub(crate) fn with_state_write_lock_at<T>(
+    lock_path: &Path,
+    operation: impl FnOnce() -> io::Result<T>,
+) -> io::Result<T> {
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let _lock = StateWriteLock::acquire(lock_path)?;
+    operation()
+}
+
+struct StateWriteLock {
+    #[cfg(windows)]
+    handle: windows::Win32::Foundation::HANDLE,
+    #[cfg(not(windows))]
+    path: PathBuf,
+}
+
+impl StateWriteLock {
+    fn acquire(path: &Path) -> io::Result<Self> {
+        let deadline = std::time::Instant::now() + STATE_LOCK_TIMEOUT;
+        loop {
+            match Self::try_acquire(path) {
+                Ok(lock) => return Ok(lock),
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::WouldBlock | io::ErrorKind::PermissionDenied
+                    ) && std::time::Instant::now() < deadline =>
+                {
+                    std::thread::sleep(STATE_LOCK_RETRY);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    fn try_acquire(path: &Path) -> io::Result<Self> {
+        use std::os::windows::ffi::OsStrExt;
+        use windows::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE};
+        use windows::Win32::Storage::FileSystem::{
+            CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_MODE, OPEN_ALWAYS,
+        };
+        use windows::core::PCWSTR;
+
+        let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+        let handle = unsafe {
+            CreateFileW(
+                PCWSTR(wide.as_ptr()),
+                GENERIC_READ.0 | GENERIC_WRITE.0,
+                FILE_SHARE_MODE(0),
+                None,
+                OPEN_ALWAYS,
+                FILE_ATTRIBUTE_NORMAL,
+                None,
+            )
+        }
+        .map_err(|error| {
+            let code = error.code().0 as u32;
+            let win32_code = code & 0xffff;
+            if win32_code == 32 || win32_code == 33 {
+                io::Error::new(io::ErrorKind::WouldBlock, "state store is locked")
+            } else {
+                io::Error::other(format!("could not acquire state lock: {error}"))
+            }
+        })?;
+        Ok(Self { handle })
+    }
+
+    #[cfg(not(windows))]
+    fn try_acquire(path: &Path) -> io::Result<Self> {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+            .map(|_| Self {
+                path: path.to_path_buf(),
+            })
+    }
+}
+
+impl Drop for StateWriteLock {
+    fn drop(&mut self) {
+        #[cfg(windows)]
+        unsafe {
+            let _ = windows::Win32::Foundation::CloseHandle(self.handle);
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 struct ProtectedFile {

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -51,6 +51,42 @@ use raw::RawSettings;
 pub use status::*;
 pub use types::*;
 
+/// Remove every app-managed credential for a provider under one shared lock.
+///
+/// Filesystems do not provide an atomic transaction across these three files.
+/// We therefore read and validate all stores before the first write, exclude
+/// every competing writer until the last write, and make the operation
+/// idempotent. An I/O failure between atomic file replacements can leave a
+/// partial revocation, but retrying safely completes it; it can never restore
+/// a credential or lose another provider's concurrent update.
+pub fn revoke_managed_credentials(provider: ProviderId) -> anyhow::Result<()> {
+    crate::secure_file::with_state_write_lock(|| {
+        let keys_path = ApiKeys::keys_path()
+            .ok_or_else(|| std::io::Error::other("Could not determine API keys path"))?;
+        let cookies_path = ManualCookies::cookies_path()
+            .ok_or_else(|| std::io::Error::other("Could not determine cookies path"))?;
+        let token_store = crate::core::TokenAccountStore::new();
+
+        let mut keys = ApiKeys::try_load_from(&keys_path).map_err(std::io::Error::other)?;
+        let mut cookies =
+            ManualCookies::try_load_from(&cookies_path).map_err(std::io::Error::other)?;
+        let mut token_accounts = token_store.load().map_err(std::io::Error::other)?;
+
+        keys.remove(provider.cli_name());
+        cookies.remove(provider.cli_name());
+        token_accounts.remove(&provider);
+
+        keys.save_to(&keys_path).map_err(std::io::Error::other)?;
+        cookies
+            .save_to(&cookies_path)
+            .map_err(std::io::Error::other)?;
+        token_store
+            .save_unlocked(&token_accounts)
+            .map_err(std::io::Error::other)
+    })
+    .map_err(Into::into)
+}
+
 #[cfg(test)]
 mod tests;
 
@@ -612,6 +648,28 @@ impl Default for Settings {
 }
 
 impl Settings {
+    /// Apply a mutation to the latest settings while holding the shared
+    /// cross-process lock for the complete read-modify-write cycle.
+    pub fn update(operation: impl FnOnce(&mut Self)) -> anyhow::Result<Self> {
+        Self::try_update(|settings| {
+            operation(settings);
+            Ok(())
+        })
+        .map(|(settings, ())| settings)
+    }
+
+    pub fn try_update<T>(
+        operation: impl FnOnce(&mut Self) -> Result<T, String>,
+    ) -> anyhow::Result<(Self, T)> {
+        crate::secure_file::with_state_write_lock(|| {
+            let mut settings = Self::load_unlocked();
+            let result = operation(&mut settings).map_err(std::io::Error::other)?;
+            settings.save_unlocked().map_err(std::io::Error::other)?;
+            Ok((settings, result))
+        })
+        .map_err(Into::into)
+    }
+
     /// Preferred strip account for `provider_id`, if the user pinned one.
     pub fn taskbar_account_for(&self, provider_id: &str) -> Option<&str> {
         self.taskbar_account_by_provider
@@ -628,6 +686,43 @@ impl Settings {
 
     /// Load settings from disk
     pub fn load() -> Self {
+        let settings = Self::load_from_disk();
+        if !settings.has_legacy_credentials() {
+            return settings;
+        }
+
+        // Loading can become a write when an older settings file still embeds
+        // credentials. Re-read after taking the lock so two processes cannot
+        // migrate stale snapshots over newer secure-store contents.
+        match crate::secure_file::with_state_write_lock(|| Ok(Self::load_unlocked())) {
+            Ok(settings) => settings,
+            Err(error) => {
+                tracing::warn!(%error, "Failed to lock legacy settings credential migration");
+                settings
+            }
+        }
+    }
+
+    /// Load and migrate settings while the caller holds the state write lock.
+    fn load_unlocked() -> Self {
+        let mut settings = Self::load_from_disk();
+
+        if let Some(sanitized) = settings.migrate_legacy_credentials() {
+            match sanitized.and_then(|sanitized| {
+                Self::write_to_disk(&sanitized)?;
+                Ok(sanitized)
+            }) {
+                Ok(sanitized) => settings = sanitized,
+                Err(error) => {
+                    tracing::warn!(%error, "Failed to migrate legacy settings credentials");
+                }
+            }
+        }
+
+        settings
+    }
+
+    fn load_from_disk() -> Self {
         #[allow(unused_mut)]
         let mut settings = match Self::settings_path() {
             Some(path) if path.exists() => match crate::secure_file::read_string(&path) {
@@ -662,23 +757,18 @@ impl Settings {
             settings.start_at_login = Self::sync_start_at_login_registry();
         }
 
-        if let Some(sanitized) = settings.migrate_legacy_credentials() {
-            match sanitized.and_then(|sanitized| {
-                Self::write_to_disk(&sanitized)?;
-                Ok(sanitized)
-            }) {
-                Ok(sanitized) => settings = sanitized,
-                Err(error) => {
-                    tracing::warn!(%error, "Failed to migrate legacy settings credentials");
-                }
-            }
-        }
-
         settings
     }
 
     /// Save settings to disk
     pub fn save(&self) -> anyhow::Result<()> {
+        crate::secure_file::with_state_write_lock(|| {
+            self.save_unlocked().map_err(std::io::Error::other)
+        })
+        .map_err(Into::into)
+    }
+
+    fn save_unlocked(&self) -> anyhow::Result<()> {
         let sanitized = match self.migrate_legacy_credentials() {
             Some(result) => result?,
             None => self.clone(),
@@ -710,12 +800,7 @@ impl Settings {
         // build cannot resolve would be read in, never migrated, and dropped by
         // the next save — data loss inside the path that parks unknown ids to
         // prevent exactly that.
-        let has_legacy_credentials = self
-            .provider_configs
-            .values()
-            .chain(self.unrecognized_provider_configs.values())
-            .any(carries_legacy_credentials);
-        if !has_legacy_credentials {
+        if !self.has_legacy_credentials() {
             return None;
         }
 
@@ -771,13 +856,24 @@ impl Settings {
             // has been written successfully. A partial failure is safe to
             // retry because existing secure-store values remain authoritative.
             if cookies_changed {
-                manual_cookies.save()?;
+                let path = ManualCookies::cookies_path()
+                    .ok_or_else(|| anyhow::anyhow!("Could not determine cookies path"))?;
+                manual_cookies.save_to(&path)?;
             }
             if keys_changed {
-                api_keys.save()?;
+                let path = ApiKeys::keys_path()
+                    .ok_or_else(|| anyhow::anyhow!("Could not determine API keys path"))?;
+                api_keys.save_to(&path)?;
             }
             Ok(sanitized)
         })())
+    }
+
+    fn has_legacy_credentials(&self) -> bool {
+        self.provider_configs
+            .values()
+            .chain(self.unrecognized_provider_configs.values())
+            .any(carries_legacy_credentials)
     }
 
     fn start_at_login_exe_path(current_exe: &std::path::Path) -> std::path::PathBuf {

--- a/rust/src/settings/api_keys.rs
+++ b/rust/src/settings/api_keys.rs
@@ -18,6 +18,33 @@ pub struct ApiKeyEntry {
 }
 
 impl ApiKeys {
+    /// Apply one mutation against the latest on-disk store while holding the
+    /// process-wide state lock for the complete read-modify-write cycle.
+    pub fn update(operation: impl FnOnce(&mut Self)) -> anyhow::Result<Self> {
+        let path = Self::keys_path()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine API keys path"))?;
+        crate::secure_file::with_state_write_lock(|| {
+            let mut keys = Self::load_update_from(&path)?;
+            operation(&mut keys);
+            keys.save_to(&path).map_err(std::io::Error::other)?;
+            Ok(keys)
+        })
+        .map_err(Into::into)
+    }
+
+    fn update_at(
+        path: &std::path::Path,
+        operation: impl FnOnce(&mut Self),
+    ) -> anyhow::Result<Self> {
+        let lock_path = path.with_extension("state-write.lock");
+        crate::secure_file::with_state_write_lock_at(&lock_path, || {
+            let mut keys = Self::load_update_from(path)?;
+            operation(&mut keys);
+            keys.save_to(path).map_err(std::io::Error::other)?;
+            Ok(keys)
+        })
+        .map_err(Into::into)
+    }
     /// Get the API keys file path
     pub fn keys_path() -> Option<PathBuf> {
         dirs::config_dir().map(|p| p.join("Ceiling").join("api_keys.json"))
@@ -68,6 +95,16 @@ impl ApiKeys {
         }
         let content = crate::secure_file::read_string(path)?;
         Ok(serde_json::from_str(&content)?)
+    }
+
+    fn load_update_from(path: &std::path::Path) -> std::io::Result<Self> {
+        Self::try_load_from(path).map_err(|error| {
+            tracing::warn!(%error, "Saved API keys could not be decoded");
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Saved API keys could not be read; refusing to replace them",
+            )
+        })
     }
 
     /// Save API keys to disk
@@ -209,6 +246,34 @@ mod tests {
         let reloaded = ApiKeys::try_load_from(&path).expect("reload");
         assert_eq!(reloaded.get("groq"), Some("groq-secret-2"));
         assert_eq!(reloaded.get("openrouter"), Some("or-secret-replacement"));
+    }
+
+    #[test]
+    fn concurrent_provider_updates_both_survive() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = std::sync::Arc::new(dir.path().join("api_keys.json"));
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+
+        let writers: Vec<_> = [("openrouter", "or-secret"), ("groq", "groq-secret")]
+            .into_iter()
+            .map(|(provider, secret)| {
+                let path = path.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    ApiKeys::update_at(&path, |keys| keys.set(provider, secret, None))
+                        .expect("concurrent update");
+                })
+            })
+            .collect();
+        barrier.wait();
+        for writer in writers {
+            writer.join().expect("writer thread");
+        }
+
+        let keys = ApiKeys::try_load_from(&path).expect("reload");
+        assert_eq!(keys.get("openrouter"), Some("or-secret"));
+        assert_eq!(keys.get("groq"), Some("groq-secret"));
     }
 }
 

--- a/rust/src/settings/manual_cookies.rs
+++ b/rust/src/settings/manual_cookies.rs
@@ -15,6 +15,20 @@ pub struct ManualCookieEntry {
 }
 
 impl ManualCookies {
+    /// Apply a mutation while holding the shared state lock across load and
+    /// save, so another process cannot overwrite this update with stale data.
+    pub fn update(operation: impl FnOnce(&mut Self)) -> anyhow::Result<Self> {
+        let path = Self::cookies_path()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine cookies path"))?;
+        crate::secure_file::with_state_write_lock(|| {
+            let mut cookies = Self::load_update_from(&path)?;
+            operation(&mut cookies);
+            cookies.save_to(&path).map_err(std::io::Error::other)?;
+            Ok(cookies)
+        })
+        .map_err(Into::into)
+    }
+
     /// Get the cookies file path
     pub fn cookies_path() -> Option<PathBuf> {
         dirs::config_dir().map(|p| p.join("Ceiling").join("manual_cookies.json"))
@@ -51,10 +65,14 @@ impl ManualCookies {
         let Some(path) = Self::cookies_path() else {
             return Ok(Self::default());
         };
+        Self::try_load_from(&path)
+    }
+
+    pub(super) fn try_load_from(path: &std::path::Path) -> anyhow::Result<Self> {
         if !path.exists() {
             return Ok(Self::default());
         }
-        let content = crate::secure_file::read_string(&path)?;
+        let content = crate::secure_file::read_string(path)?;
         Ok(serde_json::from_str(&content)?)
     }
 
@@ -63,12 +81,26 @@ impl ManualCookies {
         let path = Self::cookies_path()
             .ok_or_else(|| anyhow::anyhow!("Could not determine cookies path"))?;
 
+        self.save_to(&path)
+    }
+
+    fn load_update_from(path: &std::path::Path) -> std::io::Result<Self> {
+        Self::try_load_from(path).map_err(|error| {
+            tracing::warn!(%error, "Saved manual cookies could not be decoded");
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Saved manual cookies could not be read; refusing to replace them",
+            )
+        })
+    }
+
+    pub(super) fn save_to(&self, path: &std::path::Path) -> anyhow::Result<()> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
         let json = serde_json::to_string_pretty(self)?;
-        crate::secure_file::write_string(&path, &json)?;
+        crate::secure_file::write_string(path, &json)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- serialize settings, API key, manual-cookie, and token-account mutations with one cross-process state lock
- migrate desktop and CLI read-modify-write call sites to locked update APIs
- revoke all app-managed credentials for a provider within one validated, retry-safe critical section
- lock and re-read legacy credential migrations before they write secure stores

Closes SBS-686.

## Validation
- `cargo test --manifest-path rust/Cargo.toml` (855 passed; rerun with System32 first in PATH because the initial run selected the npm `cmd` shim and hit Windows error 193)
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` (481 passed)
- `cargo test --manifest-path rust/Cargo.toml settings::tests --lib` (80 passed after final migration-lock audit)
- `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --all --manifest-path rust/Cargo.toml`
- `git diff --check`

No frontend files changed; hosted CI will run the frontend checks.