### PR TITLE
Protect critical usage boundary behavior

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -431,9 +431,6 @@ async fn refresh_provider(
         (snapshot, Vec::new(), false)
     };
     crate::usage_history::record_snapshot(&snapshot);
-    // Track open quota runs every sample so a confirmed reset can close a run
-    // with peak used % and observation span (SOU-298).
-    crate::quota_run_history::record_snapshot(&snapshot);
     events::emit_provider_updated(&app, &snapshot);
     let notification_settings = Settings::load();
 
@@ -462,6 +459,10 @@ async fn refresh_provider(
     if !capacity_events.is_empty() {
         crate::quota_run_history::record_capacity_events(&capacity_events, &snapshot);
     }
+    // Apply classified resets before the snapshot-driven fallback. Otherwise
+    // the observed drop opens a new run that the classified event immediately
+    // closes again as a zero-duration duplicate.
+    crate::quota_run_history::record_snapshot(&snapshot);
     if capacity_events.is_empty() {
         return;
     }

--- a/apps/desktop-tauri/src-tauri/src/quota_run_history.rs
+++ b/apps/desktop-tauri/src-tauri/src/quota_run_history.rs
@@ -205,13 +205,14 @@ pub fn record_snapshot(snapshot: &ProviderUsageSnapshot) {
             if drop >= USED_DROP_CLOSE {
                 // Capacity events should finalize with a classified kind. If we
                 // only see a drop here, still close so runs are not lost.
+                let end_used_percent = open.last_used_percent;
                 let finished = finalize_open(
                     open.clone(),
                     observed_at,
-                    window.used_percent,
+                    end_used_percent,
                     QuotaRunResetKind::ObservedDrop,
                     false,
-                    None,
+                    Some(window.used_percent),
                 );
                 push_run(&mut guard, &scope, finished);
                 guard.open.remove(&open_key);
@@ -967,6 +968,69 @@ mod tests {
         assert_eq!(run.after_reset_used_percent, Some(8.0));
         assert_eq!(run.window_minutes, Some(300));
         assert!(run.observed_duration_seconds >= 4 * 3600 - 5);
+    }
+
+    #[test]
+    fn observed_drop_closes_the_run_and_starts_the_next_cycle() {
+        let _guard = test_lock();
+        clear_for_test();
+        let provider = "codex-observed-drop";
+        let email = "drop@job.test";
+        let start = Utc::now() - Duration::hours(4);
+        let reset = start + Duration::hours(5);
+
+        record_snapshot(&snapshot(provider, email, start, 5.0, reset));
+        record_snapshot(&snapshot(
+            provider,
+            email,
+            start + Duration::hours(2),
+            90.0,
+            reset,
+        ));
+        let after = start + Duration::hours(4);
+        record_snapshot(&snapshot(
+            provider,
+            email,
+            after,
+            70.0,
+            after + Duration::hours(5),
+        ));
+
+        let runs = list_runs(provider, Some(email), Some("acct-work"));
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].reset_kind, QuotaRunResetKind::ObservedDrop);
+        assert!((runs[0].peak_used_percent - 90.0).abs() < 0.01);
+        assert!((runs[0].end_used_percent - 90.0).abs() < 0.01);
+        assert_eq!(runs[0].after_reset_used_percent, Some(70.0));
+
+        let guard = store().lock().unwrap();
+        let next = guard.open.values().next().expect("new open run");
+        assert_eq!(next.started_at, after);
+        assert!((next.last_used_percent - 70.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn drop_just_below_threshold_does_not_close_the_run() {
+        let _guard = test_lock();
+        clear_for_test();
+        let provider = "codex-small-drop";
+        let email = "small-drop@job.test";
+        let start = Utc::now() - Duration::hours(1);
+        let reset = start + Duration::hours(5);
+
+        record_snapshot(&snapshot(provider, email, start, 50.0, reset));
+        record_snapshot(&snapshot(
+            provider,
+            email,
+            start + Duration::minutes(30),
+            30.01,
+            reset,
+        ));
+
+        assert!(list_runs(provider, Some(email), Some("acct-work")).is_empty());
+        let guard = store().lock().unwrap();
+        let open = guard.open.values().next().expect("open run remains");
+        assert!((open.last_used_percent - 30.01).abs() < 0.001);
     }
 
     #[test]

--- a/apps/desktop-tauri/src-tauri/src/quota_run_history.rs
+++ b/apps/desktop-tauri/src-tauri/src/quota_run_history.rs
@@ -1010,6 +1010,52 @@ mod tests {
     }
 
     #[test]
+    fn classified_reset_before_snapshot_does_not_create_a_duplicate_run() {
+        let _guard = test_lock();
+        clear_for_test();
+        let provider = "codex-classified-order";
+        let email = "classified@job.test";
+        let start = Utc::now() - Duration::hours(4);
+        let reset = start + Duration::hours(5);
+
+        record_snapshot(&snapshot(provider, email, start, 5.0, reset));
+        record_snapshot(&snapshot(
+            provider,
+            email,
+            start + Duration::hours(2),
+            90.0,
+            reset,
+        ));
+
+        let after = start + Duration::hours(4);
+        let post_reset = snapshot(provider, email, after, 8.0, after + Duration::hours(5));
+        let event = reset_event(
+            provider,
+            CapacityEventKind::ScheduledReset,
+            90.0,
+            8.0,
+            after,
+            false,
+        );
+
+        // This is the production order in commands/providers.rs.
+        record_capacity_events(&[event], &post_reset);
+        record_snapshot(&post_reset);
+
+        let runs = list_runs(provider, Some(email), Some("acct-work"));
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].reset_kind, QuotaRunResetKind::Scheduled);
+        assert!((runs[0].end_used_percent - 90.0).abs() < 0.01);
+        assert_eq!(runs[0].after_reset_used_percent, Some(8.0));
+
+        let guard = store().lock().unwrap();
+        assert_eq!(guard.open.len(), 1);
+        let next = guard.open.values().next().expect("new open run");
+        assert_eq!(next.started_at, after);
+        assert!((next.last_used_percent - 8.0).abs() < 0.01);
+    }
+
+    #[test]
     fn drop_just_below_threshold_does_not_close_the_run() {
         let _guard = test_lock();
         clear_for_test();

--- a/rust/src/browser/cookies.rs
+++ b/rust/src/browser/cookies.rs
@@ -714,11 +714,18 @@ pub fn get_cookie_header(domain: &str) -> Result<String, CookieError> {
 
 /// Get a cookie header string from the first domain that has readable cookies.
 pub fn get_cookie_header_for_domains(domains: &[&str]) -> Result<String, CookieError> {
+    select_cookie_header_for_domains(domains, get_cookie_header)
+}
+
+fn select_cookie_header_for_domains(
+    domains: &[&str],
+    mut lookup: impl FnMut(&str) -> Result<String, CookieError>,
+) -> Result<String, CookieError> {
     let mut app_bound_encryption_seen = false;
     let mut last_error = None;
 
     for domain in domains {
-        match get_cookie_header(domain) {
+        match lookup(domain) {
             Ok(header) if !header.trim().is_empty() => return Ok(header),
             Ok(_) => {}
             Err(CookieError::AppBoundEncryption) => app_bound_encryption_seen = true,
@@ -748,6 +755,47 @@ pub fn get_cookie_header_from_browser(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn multi_domain_lookup_prefers_a_later_readable_cookie_over_abe() {
+        let mut calls = 0;
+        let result = select_cookie_header_for_domains(&["first.test", "second.test"], |_| {
+            calls += 1;
+            if calls == 1 {
+                Err(CookieError::AppBoundEncryption)
+            } else {
+                Ok("session=readable".to_string())
+            }
+        });
+
+        assert_eq!(result.unwrap(), "session=readable");
+        assert_eq!(calls, 2);
+    }
+
+    #[test]
+    fn multi_domain_lookup_keeps_abe_actionable_when_nothing_succeeds() {
+        let error = select_cookie_header_for_domains(&["first.test", "second.test"], |_| {
+            Err(CookieError::AppBoundEncryption)
+        })
+        .unwrap_err();
+        assert!(matches!(error, CookieError::AppBoundEncryption));
+    }
+
+    #[test]
+    fn multi_domain_lookup_preserves_not_found_without_abe() {
+        let mut calls = 0;
+        let error = select_cookie_header_for_domains(&["first.test", "second.test"], |_| {
+            calls += 1;
+            if calls == 1 {
+                Ok("  ".to_string())
+            } else {
+                Err(CookieError::NotFound("second.test".to_string()))
+            }
+        })
+        .unwrap_err();
+
+        assert!(matches!(error, CookieError::NotFound(domain) if domain == "second.test"));
+    }
 
     #[test]
     fn temporary_cookie_database_is_removed_on_drop() {

--- a/rust/src/core/usage_pace.rs
+++ b/rust/src/core/usage_pace.rs
@@ -244,6 +244,8 @@ mod tests {
 
         assert_eq!(pace.stage, PaceStage::OnTrack);
         assert!(pace.delta_percent.abs() < 2.0);
+        assert!(pace.will_last_to_reset);
+        assert!(pace.eta_seconds.is_none());
     }
 
     #[test]
@@ -258,6 +260,36 @@ mod tests {
 
         assert!(pace.stage.is_ahead());
         assert!(pace.delta_percent > 0.0);
+        assert!(!pace.will_last_to_reset);
+        let eta = pace.eta_seconds.expect("exhaustion ETA");
+        assert!(eta > 0.0);
+        assert!(eta < (resets_at - now).num_seconds() as f64);
+    }
+
+    #[test]
+    fn zero_usage_after_elapsed_time_will_last_to_reset() {
+        let now = Utc::now();
+        let resets_at = now + Duration::days(3) + Duration::hours(12);
+        let window = RateWindow::with_details(0.0, Some(10080), Some(resets_at), None);
+
+        let pace = UsagePace::weekly(&window, Some(now), 10080).unwrap();
+        assert!(pace.will_last_to_reset);
+        assert!(pace.eta_seconds.is_none());
+    }
+
+    #[test]
+    fn invalid_weekly_window_boundaries_return_none() {
+        let now = Utc::now();
+        let valid_reset = now + Duration::hours(1);
+        let zero_minutes = RateWindow::with_details(0.0, Some(0), Some(valid_reset), None);
+        assert!(UsagePace::weekly(&zero_minutes, Some(now), 10080).is_none());
+
+        let past = RateWindow::with_details(0.0, Some(60), Some(now), None);
+        assert!(UsagePace::weekly(&past, Some(now), 10080).is_none());
+
+        let beyond =
+            RateWindow::with_details(0.0, Some(60), Some(now + Duration::minutes(61)), None);
+        assert!(UsagePace::weekly(&beyond, Some(now), 10080).is_none());
     }
 
     #[test]

--- a/rust/src/providers/claude/oauth/mod.rs
+++ b/rust/src/providers/claude/oauth/mod.rs
@@ -38,9 +38,13 @@ pub struct ClaudeOAuthCredentials {
 impl ClaudeOAuthCredentials {
     /// Check if the token is expired
     pub fn is_expired(&self) -> bool {
+        self.is_expired_at(Utc::now())
+    }
+
+    fn is_expired_at(&self, now: DateTime<Utc>) -> bool {
         if let Some(expires_at) = self.expires_at {
             // Consider expired if within 5 minutes of expiry
-            expires_at <= Utc::now() + chrono::Duration::minutes(5)
+            expires_at <= now + chrono::Duration::minutes(5)
         } else {
             // No expiry info = don't assume expired, try it
             false
@@ -435,6 +439,7 @@ mod tests {
         ClaudeOAuthCredentials, ClaudeOAuthFetcher, OAuthUsageResponse, UsageWindow,
         UtilizationScale,
     };
+    use chrono::{Duration as ChronoDuration, TimeZone, Utc};
     use reqwest::header::HeaderValue;
     use std::time::Duration;
 
@@ -447,6 +452,24 @@ mod tests {
             rate_limit_tier: Some("default_claude_ai".to_string()),
             subscription_type: None,
         }
+    }
+
+    #[test]
+    fn token_expiry_honors_the_five_minute_refresh_skew() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 9, 12, 0, 0).unwrap();
+        let mut credentials = test_credentials();
+
+        credentials.expires_at = Some(now + ChronoDuration::minutes(6));
+        assert!(!credentials.is_expired_at(now));
+
+        credentials.expires_at = Some(now + ChronoDuration::minutes(1));
+        assert!(credentials.is_expired_at(now));
+
+        credentials.expires_at = Some(now - ChronoDuration::seconds(1));
+        assert!(credentials.is_expired_at(now));
+
+        credentials.expires_at = None;
+        assert!(!credentials.is_expired_at(now));
     }
 
     #[test]

--- a/rust/src/providers/claude/oauth/mod.rs
+++ b/rust/src/providers/claude/oauth/mod.rs
@@ -462,6 +462,9 @@ mod tests {
         credentials.expires_at = Some(now + ChronoDuration::minutes(6));
         assert!(!credentials.is_expired_at(now));
 
+        credentials.expires_at = Some(now + ChronoDuration::minutes(5));
+        assert!(credentials.is_expired_at(now));
+
         credentials.expires_at = Some(now + ChronoDuration::minutes(1));
         assert!(credentials.is_expired_at(now));
 

--- a/rust/src/providers/claude/web_api.rs
+++ b/rust/src/providers/claude/web_api.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use super::UtilizationScale;
 use super::usage_api::{ClaudeExtraUsage, ClaudeUsageResponse, ClaudeUsageWindow};
-use crate::browser::cookies::{get_cookie_header, get_cookie_header_from_browser};
+use crate::browser::cookies::get_cookie_header_from_browser;
 use crate::browser::detection::{BrowserProfile, BrowserType, DetectedBrowser};
 use crate::core::{PromoSignal, ProviderError, ProviderFetchResult, RateWindow};
 
@@ -265,22 +265,8 @@ impl ClaudeWebApiFetcher {
             "anthropic.com",
         ];
 
-        for domain in domains {
-            match get_cookie_header(domain) {
-                Ok(cookie_header) if !cookie_header.is_empty() => {
-                    tracing::debug!("Found cookies for {}", domain);
-                    return self.fetch_with_cookie_header(&cookie_header).await;
-                }
-                Ok(_) => {
-                    tracing::debug!("No cookies found for {}", domain);
-                }
-                Err(e) => {
-                    tracing::debug!("Failed to get cookies for {}: {}", domain, e);
-                }
-            }
-        }
-
-        Err(ProviderError::NoCookies)
+        let cookie_header = crate::providers::browser_cookie_header(&domains)?;
+        self.fetch_with_cookie_header(&cookie_header).await
     }
 
     /// Fetch usage with a provided cookie header


### PR DESCRIPTION
## Summary
- pin quota-run observed-drop behavior at and just below the 20-point reset threshold
- preserve the last pre-reset usage as the completed run endpoint and record the low reading as post-reset usage
- cover Claude OAuth's five-minute refresh skew with a deterministic clock
- cover usage-pace will-last, exhaustion ETA, zero-usage, and invalid-window boundaries
- exercise multi-domain browser-cookie fallback across App-Bound Encryption, empty headers, and readable later domains

Closes SBS-641.
Closes SBS-643.
Closes SBS-646.
Closes SBS-647.

## Validation
- `cargo test --manifest-path rust/Cargo.toml` (859 library tests, CLI test, and doc tests passed)
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` (483 passed)
- focused Claude OAuth suite (28 passed)
- focused usage pace suite (6 passed)
- focused browser cookies suite (10 passed)
- focused quota run history suite (10 passed)
- `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --all --manifest-path rust/Cargo.toml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved usage tracking when consumption drops, accurately closing completed usage periods and starting new ones when appropriate.
  - Improved cookie retrieval across multiple domains, allowing fallback when a domain returns no cookies or a supported encryption-related result.
  - Improved token expiration handling, including the expected five-minute expiration buffer.
  - Improved usage-pace calculations for exhaustion estimates, zero usage, and invalid time-window inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->