### PR TITLE
test: add unit tests for usageLevel threshold classifier

### DIFF
--- a/apps/desktop-tauri/src/surfaces/tray/UsageBar.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/tray/UsageBar.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import type { RateWindowSnapshot } from "../../types/bridge";
-import UsageBar from "./UsageBar";
+import UsageBar, { usageLevel } from "./UsageBar";
 
 function windowSnapshot(
   overrides: Partial<RateWindowSnapshot> = {},
@@ -49,5 +49,27 @@ describe("UsageBar", () => {
     // label still reports the true 140% — a screen reader user must not be
     // told they're at the limit when they're actually 40% over it.
     expect(track).toHaveAttribute("aria-label", "Session usage: 140%");
+  });
+});
+
+describe("usageLevel", () => {
+  it("returns normal below the high threshold", () => {
+    expect(usageLevel(0, false)).toBe("normal");
+    expect(usageLevel(69, false)).toBe("normal");
+  });
+
+  it("returns high at and above 70, below the critical threshold", () => {
+    expect(usageLevel(70, false)).toBe("high");
+    expect(usageLevel(89, false)).toBe("high");
+  });
+
+  it("returns critical at and above 90", () => {
+    expect(usageLevel(90, false)).toBe("critical");
+    expect(usageLevel(100, false)).toBe("critical");
+  });
+
+  it("returns exhausted when exhausted is true, regardless of a low percentage", () => {
+    expect(usageLevel(0, true)).toBe("exhausted");
+    expect(usageLevel(40, true)).toBe("exhausted");
   });
 });

--- a/apps/desktop-tauri/src/surfaces/tray/UsageBar.tsx
+++ b/apps/desktop-tauri/src/surfaces/tray/UsageBar.tsx
@@ -8,7 +8,7 @@ interface UsageBarProps {
 
 type UsageLevel = "normal" | "high" | "critical" | "exhausted";
 
-function usageLevel(pct: number, exhausted: boolean): UsageLevel {
+export function usageLevel(pct: number, exhausted: boolean): UsageLevel {
   if (exhausted) return "exhausted";
   if (pct >= 90) return "critical";
   if (pct >= 70) return "high";


### PR DESCRIPTION
fixes #78 

Exports `usageLevel` and adds unit tests for the threshold classifier, per #78.

**What's covered:**
- Both sides of each boundary: `0`, `69` (normal), `70`, `89` (high), `90`, `100` (critical)
- `exhausted = true` overriding a low percentage (e.g. `usageLevel(0, true)` → `"exhausted"`)

**Changes:**
- `UsageBar.tsx`: added `export` to `usageLevel` so it's testable in isolation — no logic changed
- `UsageBar.test.tsx`: new `describe("usageLevel", ...)` block alongside the existing ARIA tests from #237

Uses the existing vitest setup (`pnpm --dir apps/desktop-tauri test`). All 460 tests pass, no regressions.

No visual or behavioral change — pure test coverage addition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for usage classifications across normal, high, critical, and exhausted states.
* **Refactor**
  * Improved the usage classification component’s testability without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->