### PR TITLE
Fix Codex mini pricing normalization

### DIFF
--- a/rust/src/core/cost_pricing.rs
+++ b/rust/src/core/cost_pricing.rs
@@ -652,13 +652,9 @@ impl CostUsagePricing {
         let date_pattern = regex_lite::Regex::new(r"-\d{4}-\d{2}-\d{2}$").unwrap();
         if let Some(mat) = date_pattern.find(&trimmed) {
             let base = &trimmed[..mat.start()];
-            if base.contains("-codex-") && CODEX_PRICING.contains_key(base) {
-                return base.to_string();
+            if CODEX_PRICING.contains_key(base) || base == "gpt-5.6" {
+                return Self::normalize_codex_model(base);
             }
-            if base == "gpt-5.6" {
-                return "gpt-5.6-sol".to_string();
-            }
-            trimmed = base.to_string();
         }
 
         // Check if base model (without -codex suffix) exists in pricing

--- a/rust/src/core/cost_pricing.rs
+++ b/rust/src/core/cost_pricing.rs
@@ -643,17 +643,27 @@ impl CostUsagePricing {
             trimmed = rest.to_string();
         }
 
-        // Check if base model (without -codex suffix) exists in pricing
-        if let Some(idx) = trimmed.find("-codex") {
-            let base = &trimmed[..idx];
-            if CODEX_PRICING.contains_key(base) || base == "gpt-5.6" {
-                trimmed = base.to_string();
-            }
+        // Preserve canonical table entries before considering generic aliases.
+        // Some families have distinct `-codex-*` rates (for example mini).
+        if trimmed.contains("-codex-") && CODEX_PRICING.contains_key(trimmed.as_str()) {
+            return trimmed;
         }
 
         let date_pattern = regex_lite::Regex::new(r"-\d{4}-\d{2}-\d{2}$").unwrap();
         if let Some(mat) = date_pattern.find(&trimmed) {
             let base = &trimmed[..mat.start()];
+            if base.contains("-codex-") && CODEX_PRICING.contains_key(base) {
+                return base.to_string();
+            }
+            if base == "gpt-5.6" {
+                return "gpt-5.6-sol".to_string();
+            }
+            trimmed = base.to_string();
+        }
+
+        // Check if base model (without -codex suffix) exists in pricing
+        if let Some(idx) = trimmed.find("-codex") {
+            let base = &trimmed[..idx];
             if CODEX_PRICING.contains_key(base) || base == "gpt-5.6" {
                 trimmed = base.to_string();
             }

--- a/rust/src/core/cost_pricing_tests.rs
+++ b/rust/src/core/cost_pricing_tests.rs
@@ -67,11 +67,6 @@ fn assert_claude_rates_equal(actual: ClaudePricing, expected: ClaudePricing, mod
 fn every_codex_table_entry_has_valid_rates_and_resolves_to_a_price() {
     assert!(!CODEX_PRICING.is_empty());
     for (&model, pricing) in CODEX_PRICING.iter() {
-        // SBS-710 tracks this alias resolving to the full gpt-5.1 rate.
-        if model == "gpt-5.1-codex-mini" {
-            assert_eq!(CostUsagePricing::normalize_codex_model(model), "gpt-5.1");
-            continue;
-        }
         let normalized = CostUsagePricing::normalize_codex_model(model);
         assert!(
             CODEX_PRICING.contains_key(normalized.as_str()),
@@ -313,6 +308,26 @@ fn test_normalize_codex_model() {
         CostUsagePricing::normalize_codex_model("gpt-5-codex"),
         "gpt-5"
     );
+}
+
+#[test]
+fn codex_variant_pricing_entries_are_not_collapsed_to_the_base_model() {
+    for model in ["gpt-5.1-codex-max", "gpt-5.1-codex-mini"] {
+        assert_eq!(CostUsagePricing::normalize_codex_model(model), model);
+        assert_eq!(
+            CostUsagePricing::normalize_codex_model(&format!("openai/{model}-2026-01-01")),
+            model
+        );
+    }
+    assert_eq!(
+        CostUsagePricing::normalize_codex_model("gpt-5.1-codex"),
+        "gpt-5.1"
+    );
+
+    let mini = CostUsagePricing::codex_cost_usd("gpt-5.1-codex-mini", 1_000_000, 0, 0);
+    let base = CostUsagePricing::codex_cost_usd("gpt-5.1", 1_000_000, 0, 0);
+    assert_eq!(mini, Some(0.25));
+    assert_eq!(base, Some(1.25));
 }
 
 #[test]

--- a/rust/src/core/cost_pricing_tests.rs
+++ b/rust/src/core/cost_pricing_tests.rs
@@ -331,6 +331,13 @@ fn codex_variant_pricing_entries_are_not_collapsed_to_the_base_model() {
 }
 
 #[test]
+fn unknown_dated_codex_models_keep_their_full_name() {
+    for model in ["gpt-5.7-2026-01-01", "gpt-5.7-codex-2026-01-01"] {
+        assert_eq!(CostUsagePricing::normalize_codex_model(model), model);
+    }
+}
+
+#[test]
 fn test_normalize_claude_model() {
     assert_eq!(
         CostUsagePricing::normalize_claude_model("claude-sonnet-4-5"),


### PR DESCRIPTION
## Summary

- preserve canonical Codex variants such as gpt-5.1-codex-mini and gpt-5.1-codex-max during pricing lookup
- continue collapsing plain *-codex aliases to their established base model
- normalize dated and openai/ prefixed variant names to the correct distinct pricing entry
- add regression coverage proving mini input usage costs $0.25 per million tokens rather than the gpt-5.1 $1.25 rate

## Validation

- cargo test --manifest-path rust/Cargo.toml core::cost_pricing::tests (30 passed)
- cargo test --manifest-path rust/Cargo.toml cli::cost::tests (2 passed)
- cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings
- cargo fmt --all --manifest-path rust/Cargo.toml
- git diff --check

Fixes SBS-710.