### PR TITLE
Show Cursor on-demand usage at a glance

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -140,10 +140,36 @@ fn cursor_actionable_windows(
     out
 }
 
+fn cursor_on_demand_readout(
+    snapshot: &crate::commands::ProviderUsageSnapshot,
+) -> Option<ConstrainingReadout<'_>> {
+    snapshot
+        .extra_rate_windows
+        .iter()
+        .find(|extra| extra.id == "cursor-on-demand")
+        .map(|extra| ConstrainingReadout {
+            label: Some(match extra.title.trim() {
+                "" => "On-demand",
+                label => label,
+            }),
+            window: &extra.window,
+        })
+}
+
 fn cursor_strip_readout(
     snapshot: &crate::commands::ProviderUsageSnapshot,
 ) -> ConstrainingReadout<'_> {
     let actionable = cursor_actionable_windows(snapshot);
+    let on_demand = cursor_on_demand_readout(snapshot);
+    let has_on_demand_spend = snapshot
+        .extra_rate_windows
+        .iter()
+        .find(|extra| extra.id == "cursor-on-demand")
+        .and_then(|extra| extra.amount.as_ref())
+        .is_some_and(|amount| amount.used > 0.0);
+    if has_on_demand_spend && let Some(readout) = on_demand {
+        return readout;
+    }
     if !actionable.is_empty() {
         // Hottest non-exhausted Auto/API lane.
         let mut with_room: Option<ConstrainingReadout<'_>> = None;
@@ -170,6 +196,11 @@ fn cursor_strip_readout(
         if let Some(best) = with_room {
             return best;
         }
+        if is_blocking_window(&snapshot.primary)
+            && let Some(readout) = on_demand
+        {
+            return readout;
+        }
         // All actionable lanes exhausted: soonest reset.
         let mut exhausted: Option<ConstrainingReadout<'_>> = None;
         for (label, window) in &actionable {
@@ -195,6 +226,11 @@ fn cursor_strip_readout(
         if let Some(best) = exhausted {
             return best;
         }
+    }
+    if is_blocking_window(&snapshot.primary)
+        && let Some(readout) = on_demand
+    {
+        return readout;
     }
     ConstrainingReadout {
         label: snapshot.primary_label.as_deref(),
@@ -2392,6 +2428,40 @@ mod tests {
         let readout = constraining_readout(&snapshot);
         assert_eq!(readout.label, Some("API"));
         assert_eq!(readout.window.used_percent, 100.0);
+    }
+
+    #[test]
+    fn cursor_strip_surfaces_on_demand_after_included_usage_is_exhausted() {
+        let mut snapshot = snap("cursor", None, 100.0);
+        snapshot.primary_label = Some("Plan".into());
+        snapshot.secondary = Some(rate_window(100.0, Some(43_200)));
+        snapshot.secondary_label = Some("Auto".into());
+        snapshot
+            .extra_rate_windows
+            .push(crate::commands::NamedRateWindowSnapshot {
+                id: "cursor-api".into(),
+                title: "API".into(),
+                window: rate_window(100.0, Some(43_200)),
+                amount: None,
+            });
+        snapshot
+            .extra_rate_windows
+            .push(crate::commands::NamedRateWindowSnapshot {
+                id: "cursor-on-demand".into(),
+                title: "On-demand".into(),
+                window: rate_window(56.0, Some(43_200)),
+                amount: Some(crate::commands::WindowAmountBridge {
+                    used: 1002.16,
+                    limit: Some(1800.0),
+                    currency_code: "USD".into(),
+                    formatted_used: "$1,002.16".into(),
+                    formatted_limit: Some("$1,800.00".into()),
+                }),
+            });
+
+        let readout = constraining_readout(&snapshot);
+        assert_eq!(readout.label, Some("On-demand"));
+        assert_eq!(readout.window.used_percent, 56.0);
     }
 
     #[test]

--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -196,9 +196,7 @@ fn cursor_strip_readout(
         if let Some(best) = with_room {
             return best;
         }
-        if is_blocking_window(&snapshot.primary)
-            && let Some(readout) = on_demand
-        {
+        if let Some(readout) = on_demand {
             return readout;
         }
         // All actionable lanes exhausted: soonest reset.
@@ -2462,6 +2460,40 @@ mod tests {
         let readout = constraining_readout(&snapshot);
         assert_eq!(readout.label, Some("On-demand"));
         assert_eq!(readout.window.used_percent, 56.0);
+    }
+
+    #[test]
+    fn cursor_strip_surfaces_zero_spend_when_actionable_lanes_are_exhausted() {
+        let mut snapshot = snap("cursor", None, 50.0);
+        snapshot.primary_label = Some("Plan".into());
+        snapshot.secondary = Some(rate_window(100.0, Some(43_200)));
+        snapshot.secondary_label = Some("Auto".into());
+        snapshot
+            .extra_rate_windows
+            .push(crate::commands::NamedRateWindowSnapshot {
+                id: "cursor-api".into(),
+                title: "API".into(),
+                window: rate_window(100.0, Some(43_200)),
+                amount: None,
+            });
+        snapshot
+            .extra_rate_windows
+            .push(crate::commands::NamedRateWindowSnapshot {
+                id: "cursor-on-demand".into(),
+                title: "On-demand".into(),
+                window: rate_window(0.0, Some(43_200)),
+                amount: Some(crate::commands::WindowAmountBridge {
+                    used: 0.0,
+                    limit: Some(1800.0),
+                    currency_code: "USD".into(),
+                    formatted_used: "$0.00".into(),
+                    formatted_limit: Some("$1,800.00".into()),
+                }),
+            });
+
+        let readout = constraining_readout(&snapshot);
+        assert_eq!(readout.label, Some("On-demand"));
+        assert_eq!(readout.window.used_percent, 0.0);
     }
 
     #[test]

--- a/apps/desktop-tauri/src-tauri/src/usage_history.rs
+++ b/apps/desktop-tauri/src-tauri/src/usage_history.rs
@@ -366,19 +366,17 @@ mod tests {
         }
     }
 
-    #[test]
-    fn a_named_tertiary_window_charts_under_its_own_name() {
-        // OpenCode Go's third window is Monthly, not Cursor's API.
-        let mut snapshot = ProviderUsageSnapshot {
-            provider_id: "opencodego".into(),
-            display_name: "OpenCode Go".into(),
-            primary: window_snapshot(34.0),
-            primary_label: Some("Rolling (5h)".into()),
-            secondary: Some(window_snapshot(32.0)),
-            secondary_label: Some("Weekly".into()),
+    fn provider_snapshot(provider_id: &str, display_name: &str) -> ProviderUsageSnapshot {
+        ProviderUsageSnapshot {
+            provider_id: provider_id.into(),
+            display_name: display_name.into(),
+            primary: window_snapshot(0.0),
+            primary_label: Some("Plan".into()),
+            secondary: None,
+            secondary_label: None,
             model_specific: None,
-            tertiary: Some(window_snapshot(57.0)),
-            tertiary_label: Some("Monthly".into()),
+            tertiary: None,
+            tertiary_label: None,
             extra_rate_windows: Vec::new(),
             inactive_rate_windows: Vec::new(),
             promo_signals: Vec::new(),
@@ -397,7 +395,19 @@ mod tests {
             account_tint: None,
             fetch_duration_ms: None,
             wayfinder_usage: None,
-        };
+        }
+    }
+
+    #[test]
+    fn a_named_tertiary_window_charts_under_its_own_name() {
+        // OpenCode Go's third window is Monthly, not Cursor's API.
+        let mut snapshot = provider_snapshot("opencodego", "OpenCode Go");
+        snapshot.primary = window_snapshot(34.0);
+        snapshot.primary_label = Some("Rolling (5h)".into());
+        snapshot.secondary = Some(window_snapshot(32.0));
+        snapshot.secondary_label = Some("Weekly".into());
+        snapshot.tertiary = Some(window_snapshot(57.0));
+        snapshot.tertiary_label = Some("Monthly".into());
 
         let windows = snapshot_windows(&snapshot);
         let named: Vec<_> = windows
@@ -618,7 +628,7 @@ mod tests {
                     used_percent: 0.0,
                 },
                 UsageHistoryWindow {
-                    id: "cursor-on-demand".into(),
+                    id: "on-demand".into(),
                     label: "On-demand".into(),
                     used_percent: 56.0,
                 },
@@ -629,7 +639,35 @@ mod tests {
 
         assert_eq!(visible[0].windows.len(), 2);
         assert_eq!(visible[0].windows[0].id, "plan");
-        assert_eq!(visible[0].windows[1].id, "cursor-on-demand");
+        assert_eq!(visible[0].windows[1].id, "on-demand");
         assert_eq!(visible[0].windows[1].used_percent, 56.0);
+    }
+
+    #[test]
+    fn cursor_snapshot_records_the_production_on_demand_series() {
+        let mut snapshot = provider_snapshot("cursor", "Cursor");
+        snapshot
+            .extra_rate_windows
+            .push(crate::commands::NamedRateWindowSnapshot {
+                id: "cursor-on-demand".into(),
+                title: "On-demand".into(),
+                window: window_snapshot(56.0),
+                amount: None,
+            });
+        snapshot
+            .extra_rate_windows
+            .push(crate::commands::NamedRateWindowSnapshot {
+                id: "cursor-promotional".into(),
+                title: "Promotional".into(),
+                window: window_snapshot(0.0),
+                amount: None,
+            });
+
+        let windows = snapshot_windows(&snapshot);
+
+        assert!(windows.iter().any(|window| {
+            window.id == "on-demand" && window.label == "On-demand" && window.used_percent == 56.0
+        }));
+        assert!(!windows.iter().any(|window| window.id == "promotional"));
     }
 }

--- a/apps/desktop-tauri/src-tauri/src/usage_history.rs
+++ b/apps/desktop-tauri/src-tauri/src/usage_history.rs
@@ -151,9 +151,12 @@ fn visible_history(provider_id: &str, points: &[UsageHistoryPoint]) -> Vec<Usage
     let mut points = points.to_vec();
     if provider_id.eq_ignore_ascii_case("cursor") {
         for point in &mut points {
-            point.windows.retain(|window| {
-                !matches!(window.id.as_str(), "promotional" | "on-demand" | "ondemand")
-            });
+            // Promotional was an inferred meter and remains hidden. On-demand
+            // is a real capped lane, so keep its percentage in the reset
+            // schedule; money is shown on the live overview/detail surfaces.
+            point
+                .windows
+                .retain(|window| window.id.as_str() != "promotional");
         }
     }
     points
@@ -192,9 +195,7 @@ fn snapshot_windows(snapshot: &ProviderUsageSnapshot) -> Vec<UsageHistoryWindow>
         push_window(&mut windows, &extra.id, Some(&extra.title), &extra.window);
     }
     if snapshot.provider_id.eq_ignore_ascii_case("cursor") {
-        windows.retain(|window| {
-            !matches!(window.id.as_str(), "promotional" | "on-demand" | "ondemand")
-        });
+        windows.retain(|window| window.id.as_str() != "promotional");
     }
     windows
 }
@@ -602,7 +603,7 @@ mod tests {
     }
 
     #[test]
-    fn cursor_history_hides_promotional_and_on_demand_pools() {
+    fn cursor_history_hides_promotional_but_keeps_real_on_demand_usage() {
         let points = vec![UsageHistoryPoint {
             recorded_at: "2026-07-14T10:00:00Z".into(),
             windows: vec![
@@ -617,16 +618,18 @@ mod tests {
                     used_percent: 0.0,
                 },
                 UsageHistoryWindow {
-                    id: "on-demand".into(),
+                    id: "cursor-on-demand".into(),
                     label: "On-demand".into(),
-                    used_percent: 0.0,
+                    used_percent: 56.0,
                 },
             ],
         }];
 
         let visible = visible_history("cursor", &points);
 
-        assert_eq!(visible[0].windows.len(), 1);
+        assert_eq!(visible[0].windows.len(), 2);
         assert_eq!(visible[0].windows[0].id, "plan");
+        assert_eq!(visible[0].windows[1].id, "cursor-on-demand");
+        assert_eq!(visible[0].windows[1].used_percent, 56.0);
     }
 }

--- a/apps/desktop-tauri/src/components/PlanStatusCard.test.tsx
+++ b/apps/desktop-tauri/src/components/PlanStatusCard.test.tsx
@@ -8,6 +8,7 @@ vi.mock("../hooks/useLocale", () => ({
     t: (key: string) => {
       if (key === "PanelLeftSuffix") return "left";
       if (key === "PanelUsedSuffix") return "used";
+      if (key === "PanelAmountOf") return "of";
       return key;
     },
   }),
@@ -168,6 +169,38 @@ describe("PlanStatusCard", () => {
     expect(screen.getByText("Auto")).toBeTruthy();
     expect(screen.getByText("API")).toBeTruthy();
     expect(screen.getByText(/8% used/)).toBeTruthy();
+  });
+
+  it("shows Cursor on-demand dollars once included usage is exhausted", () => {
+    render(
+      <PlanStatusCard
+        provider={provider({
+          primary: window(100),
+          secondary: window(100),
+          extraRateWindows: [
+            { id: "cursor-api", title: "API", window: window(100) },
+            {
+              id: "cursor-on-demand",
+              title: "On-demand",
+              window: window(56),
+              amount: {
+                used: 1002.16,
+                limit: 1800,
+                currencyCode: "USD",
+                formattedUsed: "$1,002.16",
+                formattedLimit: "$1,800.00",
+              },
+            },
+          ],
+        })}
+        resetTimeRelative
+        showAsUsed
+      />,
+    );
+
+    expect(screen.getByText("On-demand")).toBeInTheDocument();
+    expect(screen.getByText("56% used")).toBeInTheDocument();
+    expect(screen.getByText("$1,002.16 of $1,800.00")).toBeInTheDocument();
   });
 
   it("still shows reset timing when the session is exhausted", () => {

--- a/apps/desktop-tauri/src/components/PlanStatusCard.tsx
+++ b/apps/desktop-tauri/src/components/PlanStatusCard.tsx
@@ -143,6 +143,13 @@ function MeterRow({
           </>
         )}
       </div>
+      {meter.amount && (
+        <div className="plan-status-card__meter-amount">
+          {meter.amount.formattedLimit
+            ? `${meter.amount.formattedUsed} ${t("PanelAmountOf")} ${meter.amount.formattedLimit}`
+            : meter.amount.formattedUsed}
+        </div>
+      )}
       <div
         className="pace-overlay"
         aria-hidden

--- a/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
@@ -368,6 +368,72 @@ describe("capacityPresentation", () => {
     ]);
   });
 
+  it("surfaces active Cursor on-demand spend after included usage is exhausted", () => {
+    const snap = provider({
+      primary: window(100),
+      primaryLabel: "Plan",
+      secondary: window(100),
+      secondaryLabel: "Auto",
+      extraRateWindows: [
+        { id: "cursor-api", title: "API", window: window(100) },
+        {
+          id: "cursor-on-demand",
+          title: "On-demand",
+          window: window(56),
+          amount: {
+            used: 1002.16,
+            limit: 1800,
+            currencyCode: "USD",
+            formattedUsed: "$1,002.16",
+            formattedLimit: "$1,800.00",
+          },
+        },
+      ],
+    });
+
+    const strip = constrainingWindow(snap);
+    expect(strip.label).toBe("On-demand");
+    expect(strip.window.usedPercent).toBe(56);
+
+    const meters = glanceMeters(snap);
+    expect(meters.companions.map((meter) => meter.label)).toEqual([
+      "Auto",
+      "API",
+      "On-demand",
+    ]);
+    expect(meters.companions[2].amount?.formattedUsed).toBe("$1,002.16");
+  });
+
+  it("keeps unused Cursor on-demand out of a healthy overview", () => {
+    const snap = provider({
+      primary: window(40),
+      primaryLabel: "Plan",
+      secondary: window(20),
+      secondaryLabel: "Auto",
+      extraRateWindows: [
+        { id: "cursor-api", title: "API", window: window(10) },
+        {
+          id: "cursor-on-demand",
+          title: "On-demand",
+          window: window(0),
+          amount: {
+            used: 0,
+            limit: 1800,
+            currencyCode: "USD",
+            formattedUsed: "$0.00",
+            formattedLimit: "$1,800.00",
+          },
+        },
+      ],
+    });
+
+    expect(glanceMeters(snap).companions.map((meter) => meter.label)).toEqual([
+      "Auto",
+      "API",
+    ]);
+    expect(constrainingWindow(snap).label).toBe("Auto");
+  });
+
   it("keeps Claude weekly visible even when it is quieter than the session", () => {
     const meters = glanceMeters(
       provider({

--- a/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
@@ -434,6 +434,67 @@ describe("capacityPresentation", () => {
     expect(constrainingWindow(snap).label).toBe("Auto");
   });
 
+  it("keeps unused Cursor on-demand hidden while Auto still has room", () => {
+    const snap = provider({
+      primary: window(100),
+      primaryLabel: "Plan",
+      secondary: window(20),
+      secondaryLabel: "Auto",
+      extraRateWindows: [
+        { id: "cursor-api", title: "API", window: window(100) },
+        {
+          id: "cursor-on-demand",
+          title: "On-demand",
+          window: window(0),
+          amount: {
+            used: 0,
+            limit: 1800,
+            currencyCode: "USD",
+            formattedUsed: "$0.00",
+            formattedLimit: "$1,800.00",
+          },
+        },
+      ],
+    });
+
+    expect(glanceMeters(snap).companions.map((meter) => meter.label)).toEqual([
+      "Auto",
+      "API",
+    ]);
+    expect(constrainingWindow(snap).label).toBe("Auto");
+  });
+
+  it("shows the zero-spend boundary when every Cursor lane is exhausted", () => {
+    const snap = provider({
+      primary: window(50),
+      primaryLabel: "Plan",
+      secondary: window(100),
+      secondaryLabel: "Auto",
+      extraRateWindows: [
+        { id: "cursor-api", title: "API", window: window(100) },
+        {
+          id: "cursor-on-demand",
+          title: "On-demand",
+          window: window(0),
+          amount: {
+            used: 0,
+            limit: 1800,
+            currencyCode: "USD",
+            formattedUsed: "$0.00",
+            formattedLimit: "$1,800.00",
+          },
+        },
+      ],
+    });
+
+    expect(constrainingWindow(snap).label).toBe("On-demand");
+    expect(glanceMeters(snap).companions.map((meter) => meter.label)).toEqual([
+      "Auto",
+      "API",
+      "On-demand",
+    ]);
+  });
+
   it("keeps Claude weekly visible even when it is quieter than the session", () => {
     const meters = glanceMeters(
       provider({

--- a/apps/desktop-tauri/src/lib/capacityPresentation.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.ts
@@ -96,6 +96,28 @@ function cursorActionableWindows(
   return out;
 }
 
+function cursorOnDemandWindow(
+  provider: ProviderUsageSnapshot,
+): ConstrainingWindow | null {
+  const extra = (provider.extraRateWindows ?? []).find(
+    (candidate) => candidate.id === "cursor-on-demand",
+  );
+  if (!extra) return null;
+  return {
+    id: `extra-${extra.id}`,
+    label: extra.title?.trim() || "On-demand",
+    window: extra.window,
+    amount: extra.amount,
+  };
+}
+
+function cursorOnDemandIsActive(
+  provider: ProviderUsageSnapshot,
+  onDemand: ConstrainingWindow,
+): boolean {
+  return (onDemand.amount?.used ?? 0) > 0 || isBlocking(provider.primary);
+}
+
 /** Hottest non-exhausted window, then soonest reset on a used-% tie. */
 function hottestWithRoom(
   windows: ConstrainingWindow[],
@@ -146,12 +168,20 @@ function cursorStripWindow(
   provider: ProviderUsageSnapshot,
 ): ConstrainingWindow {
   const actionable = cursorActionableWindows(provider);
+  const onDemand = cursorOnDemandWindow(provider);
+  // Once real-money billing starts it is the most important glance signal,
+  // even if Cursor's included-pool counters have not advanced in lockstep.
+  if (onDemand && (onDemand.amount?.used ?? 0) > 0) return onDemand;
   if (actionable.length > 0) {
     const withRoom = hottestWithRoom(actionable);
     if (withRoom) return withRoom;
+    // Included Auto/API capacity is gone. Show the lane Cursor will bill next,
+    // including the useful $0-at-the-boundary state.
+    if (onDemand && isBlocking(provider.primary)) return onDemand;
     const exhausted = soonestExhausted(actionable);
     if (exhausted) return exhausted;
   }
+  if (onDemand && cursorOnDemandIsActive(provider, onDemand)) return onDemand;
   return {
     id: "primary",
     label: provider.primaryLabel?.trim() || "Plan",
@@ -239,13 +269,20 @@ export function glanceMeters(provider: ProviderUsageSnapshot): GlanceMeters {
   const candidates = nonPrimaryWindows(provider);
   const pinned = PINNED_COMPANION_IDS[provider.providerId];
   if (pinned) {
+    const companions = pinned
+      .map((id) => candidates.find((candidate) => candidate.id === id))
+      .filter((candidate): candidate is ConstrainingWindow => Boolean(candidate));
+    if (provider.providerId === "cursor") {
+      const onDemand = candidates.find(
+        (candidate) => candidate.id === "extra-cursor-on-demand",
+      );
+      if (onDemand && cursorOnDemandIsActive(provider, onDemand)) {
+        companions.push(onDemand);
+      }
+    }
     return {
       primary,
-      companions: pinned
-        .map((id) => candidates.find((candidate) => candidate.id === id))
-        .filter((candidate): candidate is ConstrainingWindow =>
-          Boolean(candidate),
-        ),
+      companions,
     };
   }
 

--- a/apps/desktop-tauri/src/lib/capacityPresentation.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.ts
@@ -115,7 +115,11 @@ function cursorOnDemandIsActive(
   provider: ProviderUsageSnapshot,
   onDemand: ConstrainingWindow,
 ): boolean {
-  return (onDemand.amount?.used ?? 0) > 0 || isBlocking(provider.primary);
+  if ((onDemand.amount?.used ?? 0) > 0) return true;
+  const actionable = cursorActionableWindows(provider);
+  return actionable.length > 0
+    ? hottestWithRoom(actionable) === null
+    : isBlocking(provider.primary);
 }
 
 /** Hottest non-exhausted window, then soonest reset on a used-% tie. */
@@ -177,7 +181,7 @@ function cursorStripWindow(
     if (withRoom) return withRoom;
     // Included Auto/API capacity is gone. Show the lane Cursor will bill next,
     // including the useful $0-at-the-boundary state.
-    if (onDemand && isBlocking(provider.primary)) return onDemand;
+    if (onDemand) return onDemand;
     const exhausted = soonestExhausted(actionable);
     if (exhausted) return exhausted;
   }

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -4596,6 +4596,18 @@ html:has(.menu-surface--tray) {
   color: var(--text-secondary);
 }
 
+.plan-status-card__meter-amount {
+  margin-top: 2px;
+  font-size: 11px;
+  font-weight: 550;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+
+.menu-surface--tray .plan-status-card__meter-amount {
+  font-size: 10px;
+}
+
 .plan-status-card__meter-reset {
   margin-left: auto;
   font-size: 10px;


### PR DESCRIPTION
## Summary
- show active Cursor On-demand usage and formatted spend on the Overview card
- prefer On-demand in the native taskbar strip after spending starts or included usage is exhausted
- retain real On-demand percentages in Activity while continuing to hide the obsolete promotional meter
- keep unused `$0` On-demand capacity out of healthy Overview cards

## Validation
- `npm test -- --run` (463 tests)
- `npm run build` (TypeScript, locale drift check, and Vite production build)
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` (480 tests)
- `cargo test --manifest-path rust/Cargo.toml` (872 tests plus CLI and doc tests)
- strict Clippy and formatting checks on both Rust manifests
- exact reporter-state visual check: 56% and `$1,002.16 of $1,800.00`, with no horizontal overflow

Closes #191