### PR TITLE
Give tab strips keyboard navigation

### DIFF
--- a/apps/desktop-tauri/src/hooks/useTabListKeyboard.test.tsx
+++ b/apps/desktop-tauri/src/hooks/useTabListKeyboard.test.tsx
@@ -1,0 +1,180 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useTabListKeyboard, type TabListActivation } from "./useTabListKeyboard";
+
+const TABS = ["alpha", "beta", "gamma"] as const;
+type Tab = (typeof TABS)[number];
+
+function Harness({
+  activation,
+  onSelect,
+  initial = "alpha",
+  disabled = [],
+}: {
+  activation?: TabListActivation;
+  onSelect?: (id: Tab) => void;
+  initial?: Tab;
+  disabled?: Tab[];
+}) {
+  const [selected, setSelected] = useState<Tab>(initial);
+  const { tabListProps, getTabProps, getPanelProps } = useTabListKeyboard<Tab>({
+    tabIds: TABS,
+    selectedId: selected,
+    onSelect: (id) => {
+      setSelected(id);
+      onSelect?.(id);
+    },
+    activation,
+  });
+
+  return (
+    <div>
+      <div {...tabListProps} aria-label="Sections">
+        {TABS.map((id) => (
+          <button
+            key={id}
+            type="button"
+            {...getTabProps(id)}
+            disabled={disabled.includes(id)}
+            onClick={() => {
+              setSelected(id);
+              onSelect?.(id);
+            }}
+          >
+            {id}
+          </button>
+        ))}
+      </div>
+      <div {...getPanelProps()}>{selected} panel</div>
+    </div>
+  );
+}
+
+const tab = (name: Tab) => screen.getByRole("tab", { name });
+
+describe("useTabListKeyboard", () => {
+  it("gives the strip a single tab stop on the selected tab", () => {
+    render(<Harness initial="beta" />);
+    expect(tab("alpha").tabIndex).toBe(-1);
+    expect(tab("beta").tabIndex).toBe(0);
+    expect(tab("gamma").tabIndex).toBe(-1);
+  });
+
+  it("keeps the strip reachable when nothing is selected yet", () => {
+    function Unselected() {
+      const { tabListProps, getTabProps } = useTabListKeyboard<Tab>({
+        tabIds: TABS,
+        selectedId: null,
+        onSelect: () => {},
+      });
+      return (
+        <div {...tabListProps}>
+          {TABS.map((id) => (
+            <button key={id} type="button" {...getTabProps(id)}>
+              {id}
+            </button>
+          ))}
+        </div>
+      );
+    }
+    render(<Unselected />);
+    expect(tab("alpha").tabIndex).toBe(0);
+    expect(tab("alpha").getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("moves to the next tab on ArrowRight and selects it automatically", () => {
+    const onSelect = vi.fn();
+    render(<Harness onSelect={onSelect} />);
+    fireEvent.keyDown(tab("alpha"), { key: "ArrowRight" });
+    expect(onSelect).toHaveBeenCalledWith("beta");
+    expect(tab("beta")).toBe(document.activeElement);
+    expect(tab("beta").getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("wraps at both ends", () => {
+    const onSelect = vi.fn();
+    render(<Harness onSelect={onSelect} />);
+    fireEvent.keyDown(tab("alpha"), { key: "ArrowLeft" });
+    expect(onSelect).toHaveBeenLastCalledWith("gamma");
+    fireEvent.keyDown(tab("gamma"), { key: "ArrowRight" });
+    expect(onSelect).toHaveBeenLastCalledWith("alpha");
+  });
+
+  it("jumps to the ends with Home and End", () => {
+    const onSelect = vi.fn();
+    render(<Harness initial="beta" onSelect={onSelect} />);
+    fireEvent.keyDown(tab("beta"), { key: "End" });
+    expect(onSelect).toHaveBeenLastCalledWith("gamma");
+    fireEvent.keyDown(tab("gamma"), { key: "Home" });
+    expect(onSelect).toHaveBeenLastCalledWith("alpha");
+  });
+
+  it("ignores keys that are not strip movement", () => {
+    const onSelect = vi.fn();
+    render(<Harness onSelect={onSelect} />);
+    fireEvent.keyDown(tab("alpha"), { key: "ArrowDown" });
+    fireEvent.keyDown(tab("alpha"), { key: "a" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("skips disabled tabs", () => {
+    const onSelect = vi.fn();
+    render(<Harness onSelect={onSelect} disabled={["beta"]} />);
+    fireEvent.keyDown(tab("alpha"), { key: "ArrowRight" });
+    expect(onSelect).toHaveBeenCalledWith("gamma");
+  });
+
+  it("moves focus without selecting under manual activation", () => {
+    const onSelect = vi.fn();
+    render(<Harness activation="manual" onSelect={onSelect} />);
+    fireEvent.keyDown(tab("alpha"), { key: "ArrowRight" });
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(tab("beta")).toBe(document.activeElement);
+    expect(tab("alpha").getAttribute("aria-selected")).toBe("true");
+
+    // The tabs are real buttons, so Enter commits through the click handler.
+    fireEvent.click(tab("beta"));
+    expect(onSelect).toHaveBeenCalledWith("beta");
+  });
+
+  it("pairs the selected tab with its panel and leaves the others unpaired", () => {
+    render(<Harness initial="beta" />);
+    const panel = screen.getByRole("tabpanel");
+    expect(tab("beta").getAttribute("aria-controls")).toBe(panel.id);
+    expect(panel.getAttribute("aria-labelledby")).toBe(tab("beta").id);
+    expect(tab("alpha").getAttribute("aria-controls")).toBeNull();
+    expect(tab("gamma").getAttribute("aria-controls")).toBeNull();
+  });
+
+  it("makes the panel focusable so a keyboard user can reach and scroll it", () => {
+    render(<Harness />);
+    expect(screen.getByRole("tabpanel").tabIndex).toBe(0);
+  });
+
+  it("names no tab from the panel when nothing is selected", () => {
+    // A dangling aria-labelledby is worse than an unnamed panel: it promises a
+    // label that assistive tech cannot resolve.
+    function Unselected() {
+      const { getPanelProps } = useTabListKeyboard<Tab>({
+        tabIds: TABS,
+        selectedId: null,
+        onSelect: () => {},
+      });
+      return <div {...getPanelProps()}>panel</div>;
+    }
+    render(<Unselected />);
+    const panel = screen.getByRole("tabpanel");
+    expect(panel.getAttribute("aria-labelledby")).toBeNull();
+    expect(panel.getAttribute("id")).toBeNull();
+  });
+
+  it("follows the selection so the panel always names the current tab", () => {
+    render(<Harness />);
+    fireEvent.keyDown(tab("alpha"), { key: "ArrowRight" });
+    const panel = screen.getByRole("tabpanel");
+    expect(panel.getAttribute("aria-labelledby")).toBe(tab("beta").id);
+    expect(tab("beta").getAttribute("aria-controls")).toBe(panel.id);
+  });
+});

--- a/apps/desktop-tauri/src/hooks/useTabListKeyboard.test.tsx
+++ b/apps/desktop-tauri/src/hooks/useTabListKeyboard.test.tsx
@@ -27,6 +27,7 @@ function Harness({
       onSelect?.(id);
     },
     activation,
+    isTabDisabled: (id) => disabled.includes(id),
   });
 
   return (
@@ -137,6 +138,34 @@ describe("useTabListKeyboard", () => {
     // The tabs are real buttons, so Enter commits through the click handler.
     fireEvent.click(tab("beta"));
     expect(onSelect).toHaveBeenCalledWith("beta");
+  });
+
+  it("moves the tab stop to the focused tab, not the selected one", () => {
+    // Under manual activation the two differ. If the stop stayed on the
+    // selection, the strip would offer a second stop and Tab-back would land
+    // somewhere the user did not leave.
+    render(<Harness activation="manual" />);
+    fireEvent.keyDown(tab("alpha"), { key: "ArrowRight" });
+    expect(tab("beta").tabIndex).toBe(0);
+    expect(tab("alpha").tabIndex).toBe(-1);
+    expect(tab("alpha").getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("does not re-select when the key cannot move anywhere", () => {
+    // Settings sends an IPC surface-mode message from its select handler, so a
+    // no-op Home is not free.
+    const onSelect = vi.fn();
+    render(<Harness onSelect={onSelect} />);
+    fireEvent.keyDown(tab("alpha"), { key: "Home" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("keeps the tab stop off a disabled selected tab", () => {
+    // A disabled button cannot take focus, so leaving the stop there would drop
+    // the whole strip out of the tab order.
+    render(<Harness initial="alpha" disabled={["alpha"]} />);
+    expect(tab("alpha").tabIndex).toBe(-1);
+    expect(tab("beta").tabIndex).toBe(0);
   });
 
   it("pairs the selected tab with its panel and leaves the others unpaired", () => {

--- a/apps/desktop-tauri/src/hooks/useTabListKeyboard.ts
+++ b/apps/desktop-tauri/src/hooks/useTabListKeyboard.ts
@@ -1,0 +1,129 @@
+import { useId } from "react";
+
+/**
+ * Whether arrowing to a tab also selects it.
+ *
+ * WAI-ARIA Authoring Practices asks for automatic activation when the panel
+ * appears without noticeable latency, and manual activation otherwise. A strip
+ * whose panel triggers a provider fetch should be `"manual"`, so arrowing past
+ * three accounts does not fire three network refreshes. Manual activation needs
+ * no extra key handling here: the tabs are real `<button>` elements, so Enter
+ * and Space already fire their `onClick`.
+ */
+export type TabListActivation = "automatic" | "manual";
+
+/** Tabs are ordered left to right, so Left/Right move and Home/End jump. */
+const MOVE_KEYS = new Set(["ArrowLeft", "ArrowRight", "Home", "End"]);
+
+function enabledTabsIn(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>('[role="tab"]:not([disabled])'),
+  );
+}
+
+/**
+ * Keyboard behavior and ARIA wiring for a `role="tablist"` strip (#219).
+ *
+ * Gives a strip the two things the role promises and none of ours had: arrow
+ * keys move between tabs, and the strip is a single Tab stop rather than one
+ * per tab (roving `tabindex`). Focus wraps at both ends. It also pairs each tab
+ * with its panel through `aria-controls` / `aria-labelledby`.
+ *
+ * Every caller renders only the selected panel, so `aria-controls` is set on
+ * the selected tab alone — pointing it at an element that is not in the
+ * document would be worse than omitting it.
+ */
+export function useTabListKeyboard<Id extends string>({
+  tabIds,
+  selectedId,
+  onSelect,
+  activation = "automatic",
+}: {
+  tabIds: readonly Id[];
+  selectedId: Id | null | undefined;
+  onSelect: (id: Id) => void;
+  activation?: TabListActivation;
+}) {
+  const baseId = useId();
+
+  // With nothing selected the first tab holds the strip's Tab stop, so the
+  // strip stays reachable instead of dropping out of the tab order entirely.
+  const selectedIndex = selectedId == null ? -1 : tabIds.indexOf(selectedId);
+  const tabStopIndex = selectedIndex >= 0 ? selectedIndex : 0;
+
+  const tabDomId = (index: number) => `${baseId}-tab-${index}`;
+  const panelDomId = (index: number) => `${baseId}-panel-${index}`;
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (!MOVE_KEYS.has(event.key)) return;
+
+    const tabs = enabledTabsIn(event.currentTarget);
+    if (tabs.length === 0) return;
+
+    // Read the origin off the event rather than `document.activeElement`: a
+    // click-then-arrow in a real window and a `fireEvent.keyDown` in a test
+    // then behave the same way.
+    const origin = (event.target as HTMLElement | null)?.closest<HTMLElement>(
+      '[role="tab"]',
+    );
+    const from = origin ? tabs.indexOf(origin) : -1;
+
+    let next: number;
+    switch (event.key) {
+      case "ArrowRight":
+        next = from < 0 ? 0 : (from + 1) % tabs.length;
+        break;
+      case "ArrowLeft":
+        next = from < 0 ? tabs.length - 1 : (from - 1 + tabs.length) % tabs.length;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      default:
+        next = tabs.length - 1;
+        break;
+    }
+
+    event.preventDefault();
+    const target = tabs[next];
+    target.focus();
+    if (activation === "automatic") {
+      const id = target.dataset.tabId;
+      if (id !== undefined) onSelect(id as Id);
+    }
+  };
+
+  return {
+    tabListProps: { role: "tablist" as const, onKeyDown },
+
+    getTabProps: (id: Id) => {
+      const index = tabIds.indexOf(id);
+      const selected = index >= 0 && index === selectedIndex;
+      return {
+        role: "tab" as const,
+        id: tabDomId(index),
+        "data-tab-id": id,
+        "aria-selected": selected,
+        "aria-controls": selected ? panelDomId(index) : undefined,
+        tabIndex: index === tabStopIndex ? 0 : -1,
+      };
+    },
+
+    /**
+     * Describes the panel of whichever tab is selected — callers render one
+     * panel at a time, and deriving it here means the two ends of
+     * `aria-controls` / `aria-labelledby` cannot drift apart.
+     *
+     * Spread this only where the strip itself is rendered: a panel naming a tab
+     * that is not in the document is worse than a plain container. `tabIndex: 0`
+     * is deliberate — it matches the APG tabs pattern, and several of these
+     * panels are scroll containers a keyboard user otherwise cannot scroll.
+     */
+    getPanelProps: () => ({
+      role: "tabpanel" as const,
+      id: selectedIndex >= 0 ? panelDomId(selectedIndex) : undefined,
+      "aria-labelledby": selectedIndex >= 0 ? tabDomId(selectedIndex) : undefined,
+      tabIndex: 0,
+    }),
+  };
+}

--- a/apps/desktop-tauri/src/hooks/useTabListKeyboard.ts
+++ b/apps/desktop-tauri/src/hooks/useTabListKeyboard.ts
@@ -1,4 +1,4 @@
-import { useId } from "react";
+import { useId, useState } from "react";
 
 /**
  * Whether arrowing to a tab also selects it.
@@ -38,18 +38,36 @@ export function useTabListKeyboard<Id extends string>({
   selectedId,
   onSelect,
   activation = "automatic",
+  isTabDisabled,
 }: {
   tabIds: readonly Id[];
   selectedId: Id | null | undefined;
   onSelect: (id: Id) => void;
   activation?: TabListActivation;
+  /** Mirrors whatever the caller passes to each tab's `disabled` prop. */
+  isTabDisabled?: (id: Id) => boolean;
 }) {
   const baseId = useId();
+  const [focusedId, setFocusedId] = useState<Id | null>(null);
 
-  // With nothing selected the first tab holds the strip's Tab stop, so the
-  // strip stays reachable instead of dropping out of the tab order entirely.
   const selectedIndex = selectedId == null ? -1 : tabIds.indexOf(selectedId);
-  const tabStopIndex = selectedIndex >= 0 ? selectedIndex : 0;
+  const usable = (index: number) =>
+    index >= 0 && index < tabIds.length && !isTabDisabled?.(tabIds[index]);
+
+  // The Tab stop follows focus while the user is moving through the strip —
+  // that is what roving tabindex means, and under manual activation the focused
+  // tab is not the selected one. It falls back to the selection, then to the
+  // first usable tab: a disabled tab cannot take focus, so parking the stop on
+  // one would drop the whole strip out of the tab order.
+  const focusedIndex = focusedId == null ? -1 : tabIds.indexOf(focusedId);
+  const tabStopIndex = usable(focusedIndex)
+    ? focusedIndex
+    : usable(selectedIndex)
+      ? selectedIndex
+      : Math.max(
+          tabIds.findIndex((_, index) => usable(index)),
+          0,
+        );
 
   const tabDomId = (index: number) => `${baseId}-tab-${index}`;
   const panelDomId = (index: number) => `${baseId}-panel-${index}`;
@@ -85,12 +103,16 @@ export function useTabListKeyboard<Id extends string>({
     }
 
     event.preventDefault();
+    // Home on the first tab, End on the last: focus is already there, and
+    // re-selecting would re-run the caller's handler for no movement. Settings
+    // sends an IPC surface-mode message from its handler.
+    if (next === from) return;
+
     const target = tabs[next];
+    const id = target.dataset.tabId as Id | undefined;
+    if (id !== undefined) setFocusedId(id);
     target.focus();
-    if (activation === "automatic") {
-      const id = target.dataset.tabId;
-      if (id !== undefined) onSelect(id as Id);
-    }
+    if (activation === "automatic" && id !== undefined) onSelect(id);
   };
 
   return {
@@ -106,6 +128,9 @@ export function useTabListKeyboard<Id extends string>({
         "aria-selected": selected,
         "aria-controls": selected ? panelDomId(index) : undefined,
         tabIndex: index === tabStopIndex ? 0 : -1,
+        // Clicking a tab focuses it too, so the stop tracks however focus got
+        // there rather than only the arrow keys.
+        onFocus: () => setFocusedId(id),
       };
     },
 

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -734,6 +734,14 @@ html {
   outline-offset: 1px;
 }
 
+/* Tab panels are focusable so a keyboard user can scroll them and so Tab out of
+   a tab strip lands on the content it selected (#219). Inset so the ring stays
+   inside a panel that is itself a scroll container. */
+[role="tabpanel"]:focus-visible {
+  outline: 2px solid var(--accent, #0a84ff);
+  outline-offset: -2px;
+}
+
 .toggle:disabled,
 .provider-detail-toggle input[type="checkbox"]:disabled,
 .providers-sidebar__checkbox:disabled {
@@ -7711,6 +7719,15 @@ body:has(.dashboard-shell) #root {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+/* The tabpanel wrapper carries the strip's ARIA pairing (#219). It repeats the
+   column layout so its children keep the spacing they had as direct children
+   of .charts-panel. */
+.charts-panel__body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
 }
 /* Provider selector: pill chips across the providers that report history. */
 .charts-provider-tabs {

--- a/apps/desktop-tauri/src/surfaces/ChartsPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/ChartsPanel.test.tsx
@@ -118,6 +118,46 @@ describe("ChartsPanel", () => {
     expect(getByTestId("charts-section").textContent).toBe("claude");
   });
 
+  it("is one tab stop and arrows across the strip without loading each provider", () => {
+    const { getByRole, getByTestId } = render(
+      <ChartsPanel
+        providers={[
+          provider({ providerId: "codex", displayName: "Codex" }),
+          provider({ providerId: "claude", displayName: "Claude" }),
+        ]}
+      />,
+    );
+    const compare = getByRole("tab", { name: /Compare/ });
+    const claude = getByRole("tab", { name: /Claude/ });
+    expect(compare.tabIndex).toBe(0);
+    expect(claude.tabIndex).toBe(-1);
+
+    // Manual activation: arrowing past Codex must not mount its charts.
+    fireEvent.keyDown(compare, { key: "End" });
+    expect(claude).toBe(document.activeElement);
+    expect(getByTestId("provider-comparison")).toBeTruthy();
+
+    fireEvent.click(claude);
+    expect(getByTestId("charts-section").textContent).toBe("claude");
+    expect(claude.tabIndex).toBe(0);
+    expect(compare.tabIndex).toBe(-1);
+  });
+
+  it("names the charts body as the panel of the selected provider tab", () => {
+    const { getByRole } = render(
+      <ChartsPanel
+        providers={[
+          provider({ providerId: "codex", displayName: "Codex" }),
+          provider({ providerId: "claude", displayName: "Claude" }),
+        ]}
+      />,
+    );
+    const panel = getByRole("tabpanel");
+    const compare = getByRole("tab", { name: /Compare/ });
+    expect(compare.getAttribute("aria-controls")).toBe(panel.id);
+    expect(panel.getAttribute("aria-labelledby")).toBe(compare.id);
+  });
+
   it("collapses a provider's accounts into a single tab, since local logs are machine-wide", () => {
     // Local activity is scanned from logs that carry no account identity, so
     // two Codex accounts must not present as two tabs of separable data.

--- a/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ProviderUsageSnapshot } from "../types/bridge";
 import { useLocale } from "../hooks/useLocale";
+import { useTabListKeyboard } from "../hooks/useTabListKeyboard";
 import { ProviderIcon } from "../components/providers/ProviderIcon";
 import { providerSupportsChartData } from "../lib/providerCharts";
 import { ChartsSection } from "./settings/providers/sections/charts/ChartsSection";
@@ -73,6 +74,31 @@ export default function ChartsPanel({
     );
   }, [supported, comparisonProviders]);
 
+  const tabIds = useMemo(
+    () => [
+      ...(comparisonProviders ? [COMPARE_ID] : []),
+      ...supported.map((p) => p.providerId),
+    ],
+    [comparisonProviders, supported],
+  );
+
+  const comparing = selectedId === COMPARE_ID && comparisonProviders !== null;
+  // The selection settles in an effect, so until it does the strip reports what
+  // the body actually renders: the first supported provider.
+  const activeTabId = comparing
+    ? COMPARE_ID
+    : (tabIds.includes(selectedId ?? "") ? selectedId : supported[0]?.providerId) ?? null;
+
+  // Manual activation: picking a provider remounts ChartsSection, which loads
+  // that provider's history. Arrowing across the strip should not fire a load
+  // per tab it passes over.
+  const { tabListProps, getTabProps, getPanelProps } = useTabListKeyboard({
+    tabIds,
+    selectedId: activeTabId,
+    onSelect: setSelectedId,
+    activation: "manual",
+  });
+
   if (supported.length === 0) {
     // The API-value card loads its own local totals, so keep it visible even
     // when no provider reports chart-series data (or a snapshot errored).
@@ -88,21 +114,19 @@ export default function ChartsPanel({
     );
   }
 
-  const comparing = selectedId === COMPARE_ID && comparisonProviders !== null;
   const selected =
     supported.find((p) => p.providerId === selectedId) ?? supported[0];
-  const tabCount = supported.length + (comparisonProviders ? 1 : 0);
+  const tabCount = tabIds.length;
 
   return (
     <div className="charts-panel">
       <TotalApiValueCard />
       {tabCount > 1 && (
-        <div className="charts-provider-tabs" role="tablist" aria-label="Provider">
+        <div className="charts-provider-tabs" {...tabListProps} aria-label="Provider">
           {comparisonProviders && (
             <button
               type="button"
-              role="tab"
-              aria-selected={comparing}
+              {...getTabProps(COMPARE_ID)}
               className="charts-provider-tab charts-provider-tab--compare"
               data-active={comparing ? "true" : "false"}
               onClick={() => setSelectedId(COMPARE_ID)}
@@ -112,13 +136,12 @@ export default function ChartsPanel({
             </button>
           )}
           {supported.map((p) => {
-            const isActive = !comparing && p.providerId === selected.providerId;
+            const isActive = p.providerId === activeTabId;
             return (
               <button
                 key={p.providerId}
                 type="button"
-                role="tab"
-                aria-selected={isActive}
+                {...getTabProps(p.providerId)}
                 className="charts-provider-tab"
                 data-active={isActive ? "true" : "false"}
                 onClick={() => setSelectedId(p.providerId)}
@@ -135,24 +158,29 @@ export default function ChartsPanel({
           })}
         </div>
       )}
-      {comparing ? (
-        <>
-          <p className="charts-compare-note">
-            Compares all Codex usage against all Claude usage on this machine,
-            across every account.
-          </p>
-          <ProviderComparison providers={[comparisonProviders[0], comparisonProviders[1]]} />
-        </>
-      ) : (
-        <ChartsSection
-          key={chartSectionKey(selected)}
-          providerId={selected.providerId}
-          accountEmail={selected.accountEmail}
-          accountId={selected.accountId}
-          providerSnapshot={selected}
-          t={t}
-        />
-      )}
+      <div
+        {...(tabCount > 1 ? getPanelProps() : {})}
+        className="charts-panel__body"
+      >
+        {comparing ? (
+          <>
+            <p className="charts-compare-note">
+              Compares all Codex usage against all Claude usage on this machine,
+              across every account.
+            </p>
+            <ProviderComparison providers={[comparisonProviders[0], comparisonProviders[1]]} />
+          </>
+        ) : (
+          <ChartsSection
+            key={chartSectionKey(selected)}
+            providerId={selected.providerId}
+            accountEmail={selected.accountEmail}
+            accountId={selected.accountId}
+            providerSnapshot={selected}
+            t={t}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/desktop-tauri/src/surfaces/Settings.tsx
+++ b/apps/desktop-tauri/src/surfaces/Settings.tsx
@@ -9,6 +9,7 @@ import type {
 import { useSettings } from "../hooks/useSettings";
 import { useSurfaceTarget } from "../hooks/useSurfaceMode";
 import { useLocale } from "../hooks/useLocale";
+import { useTabListKeyboard } from "../hooks/useTabListKeyboard";
 import type { LocaleKey } from "../i18n/keys";
 import { closeSettingsWindow, getWorkAreaRect, setSurfaceMode } from "../lib/tauri";
 import GeneralTab from "./settings/tabs/GeneralTab";
@@ -116,6 +117,8 @@ export const TAB_META: { id: SettingsTab; labelKey: LocaleKey }[] = [
   { id: "about", labelKey: "TabAbout" },
 ];
 
+const TAB_IDS: SettingsTab[] = TAB_META.map((t) => t.id);
+
 function isSettingsTab(value: string): value is SettingsTab {
   return TAB_META.some((t) => t.id === value);
 }
@@ -202,6 +205,12 @@ export default function Settings({ state, initialTab: propTab }: { state: Bootst
     }
   }, []);
 
+  const { tabListProps, getTabProps, getPanelProps } = useTabListKeyboard({
+    tabIds: TAB_IDS,
+    selectedId: activeTab,
+    onSelect: handleTabClick,
+  });
+
   return (
     <div
       className={`settings${activeTab === "providers" ? " settings--providers-active" : ""}`}
@@ -237,12 +246,11 @@ export default function Settings({ state, initialTab: propTab }: { state: Bootst
       </div>
 
       {/* tab bar */}
-      <nav className="settings-tabs" role="tablist">
+      <nav className="settings-tabs" {...tabListProps}>
         {TAB_META.map((tab) => (
           <button
             key={tab.id}
-            role="tab"
-            aria-selected={activeTab === tab.id}
+            {...getTabProps(tab.id)}
             className={`settings-tab ${activeTab === tab.id ? "settings-tab--active" : ""}`}
             onClick={() => handleTabClick(tab.id)}
           >
@@ -262,7 +270,10 @@ export default function Settings({ state, initialTab: propTab }: { state: Bootst
       )}
 
       {/* tab panels */}
-      <div className={`settings-body${activeTab === "providers" ? " settings-body--providers" : ""}`}>
+      <div
+        {...getPanelProps()}
+        className={`settings-body${activeTab === "providers" ? " settings-body--providers" : ""}`}
+      >
         {activeTab === "general" && (
           <GeneralTab mode="general" settings={settings} set={set} saving={saving} />
         )}

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
@@ -7,6 +7,7 @@ import type {
   SettingsUpdate,
 } from "../../../types/bridge";
 import { useLocale } from "../../../hooks/useLocale";
+import { useTabListKeyboard } from "../../../hooks/useTabListKeyboard";
 import {
   getCredentialStorageStatus,
   getProviderDetail,
@@ -218,6 +219,23 @@ export function ProviderDetailPane({
     };
   }, [providerId]);
 
+  const selectAccount = useCallback(
+    (accountId: string) => {
+      setSelectedAccountId(accountId);
+      if (providerId) void load(providerId, undefined, accountId);
+    },
+    [load, providerId],
+  );
+
+  // Manual activation: choosing an account refetches that account from the
+  // provider, so arrowing across the strip must not fire a request per tab.
+  const { tabListProps, getTabProps, getPanelProps } = useTabListKeyboard({
+    tabIds: (detail?.accounts ?? []).map((account) => account.accountId),
+    selectedId: detail?.accountId ?? null,
+    onSelect: selectAccount,
+    activation: "manual",
+  });
+
   if (!providerId) {
     return (
       <div className="provider-detail">
@@ -314,20 +332,22 @@ export function ProviderDetailPane({
     }
   };
 
+  // Only rendered with something to choose between. One account means this pane
+  // already describes it, and a selector would be noise. The body is only a
+  // tabpanel when the strip that labels it exists.
+  const hasAccountTabs = (detail.accounts?.length ?? 0) > 1;
+
   return (
     <div className="provider-detail">
-      {/* Only rendered with something to choose between. One account means this
-          pane already describes it, and a selector would be noise. */}
-      {(detail.accounts?.length ?? 0) > 1 && (
-        <div className="provider-detail__accounts" role="tablist">
+      {hasAccountTabs && (
+        <div className="provider-detail__accounts" aria-label={t("SectionAccounts")} {...tabListProps}>
           {detail.accounts?.map((account) => {
             const selected = account.accountId === detail.accountId;
             return (
               <button
                 key={account.accountId}
                 type="button"
-                role="tab"
-                aria-selected={selected}
+                {...getTabProps(account.accountId)}
                 className={`provider-detail__account${selected ? " provider-detail__account--selected" : ""}`}
                 style={
                   account.tint && selected
@@ -335,10 +355,7 @@ export function ProviderDetailPane({
                     : undefined
                 }
                 disabled={loading}
-                onClick={() => {
-                  setSelectedAccountId(account.accountId);
-                  void load(detail.id, undefined, account.accountId);
-                }}
+                onClick={() => selectAccount(account.accountId)}
               >
                 {account.label}
               </button>
@@ -347,107 +364,112 @@ export function ProviderDetailPane({
         </div>
       )}
 
-      <IdentitySection provider={detail} subtitle={subtitle} t={t} />
+      <div
+        {...(hasAccountTabs ? getPanelProps() : {})}
+        className="provider-detail__body"
+      >
+        <IdentitySection provider={detail} subtitle={subtitle} t={t} />
 
-      <DataSourceSection provider={detail} t={t} />
+        <DataSourceSection provider={detail} t={t} />
 
-      {detail.lastError && (
-        <ProviderIssueNotice
-          detail={detail}
-          message={detail.lastError}
-          onCopy={handleCopyError}
+        {detail.lastError && (
+          <ProviderIssueNotice
+            detail={detail}
+            message={detail.lastError}
+            onCopy={handleCopyError}
+            t={t}
+          />
+        )}
+
+        <UsageSection
+          provider={detail}
+          resetTimeRelative={resetTimeRelative}
           t={t}
         />
-      )}
-
-      <UsageSection
-        provider={detail}
-        resetTimeRelative={resetTimeRelative}
-        t={t}
-      />
-      {detail.id === "wayfinder" && (
-        <section className="provider-detail__section">
-          <h3>{t("WayfinderGatewayTitle")}</h3>
-          <label>
-            <span>{t("WayfinderGatewayLabel")}</span>
-            <input
-              type="url"
-              value={gatewayDraft}
-              disabled={settingsDisabled || busy}
-              onChange={(event) => setGatewayDraft(event.target.value)}
-              aria-describedby="wayfinder-gateway-help"
-            />
-          </label>
-          <p id="wayfinder-gateway-help">{t("WayfinderGatewayHelp")}</p>
-          {gatewayError && <p role="alert">{gatewayError}</p>}
-          <button type="button" disabled={settingsDisabled || busy} onClick={() => void saveGateway()}>
-            {t("Save")}
-          </button>
-        </section>
-      )}
-      <MenuBarMetricSection
-        provider={detail}
-        providerMetrics={providerMetrics}
-        disabled={settingsDisabled}
-        t={t}
-        onChange={onSettingsChange}
-      />
-      <PaceSection pace={detail.pace} t={t} />
-      <CostSection cost={detail.cost} t={t} />
-
-      {/* Per-provider sub-sections ported in Phases 6c–6f. */}
-      <RegionSection
-        providerId={detail.id}
-        currentValue={detail.region}
-        options={regionOptions}
-        t={t}
-        onChanged={() => void load(detail.id)}
-      />
-      <CredentialsDispatcher providerId={detail.id} t={t} />
-      {detail.id === "codex" && <CodexUsageOptions t={t} />}
-      <CredentialStorageSection
-        status={credentialStatus}
-        busy={busy}
-        onRevoke={handleRevokeCredentials}
-        t={t}
-      />
-      {tokenProviderIds.has(detail.id) && (
-        <TokenAccountsPanel
-          key={`token-${detail.id}-${credentialRevision}`}
-          providerId={detail.id}
-          compact
+        {detail.id === "wayfinder" && (
+          <section className="provider-detail__section">
+            <h3>{t("WayfinderGatewayTitle")}</h3>
+            <label>
+              <span>{t("WayfinderGatewayLabel")}</span>
+              <input
+                type="url"
+                value={gatewayDraft}
+                disabled={settingsDisabled || busy}
+                onChange={(event) => setGatewayDraft(event.target.value)}
+                aria-describedby="wayfinder-gateway-help"
+              />
+            </label>
+            <p id="wayfinder-gateway-help">{t("WayfinderGatewayHelp")}</p>
+            {gatewayError && <p role="alert">{gatewayError}</p>}
+            <button type="button" disabled={settingsDisabled || busy} onClick={() => void saveGateway()}>
+              {t("Save")}
+            </button>
+          </section>
+        )}
+        <MenuBarMetricSection
+          provider={detail}
+          providerMetrics={providerMetrics}
+          disabled={settingsDisabled}
+          t={t}
+          onChange={onSettingsChange}
         />
-      )}
-      <ApiKeySection
-        key={`api-${detail.id}-${credentialRevision}`}
-        providerId={detail.id}
-      />
-      <CookieSection
-        key={`cookie-${detail.id}-${credentialRevision}`}
-        providerId={detail.id}
-        cookieDomain={cookieDomain}
-      />
-      <ChartsSection
-        providerId={detail.id}
-        accountEmail={detail.email}
-        accountId={detail.accountId}
-        t={t}
-      />
+        <PaceSection pace={detail.pace} t={t} />
+        <CostSection cost={detail.cost} t={t} />
 
-      <QuickActionsSection
-        provider={detail}
-        busy={busy}
-        loginPhase={loginPhase}
-        loginCode={loginCode}
-        loginUrl={loginUrl}
-        onRefresh={handleRefresh}
-        onSwitchAccount={handleSwitchAccount}
-        onOpenDashboard={handleOpenDashboard}
-        onOpenStatusPage={handleOpenStatusPage}
-        onCopyError={handleCopyError}
-        onBuyCredits={handleBuyCredits}
-        t={t}
-      />
+        {/* Per-provider sub-sections ported in Phases 6c–6f. */}
+        <RegionSection
+          providerId={detail.id}
+          currentValue={detail.region}
+          options={regionOptions}
+          t={t}
+          onChanged={() => void load(detail.id)}
+        />
+        <CredentialsDispatcher providerId={detail.id} t={t} />
+        {detail.id === "codex" && <CodexUsageOptions t={t} />}
+        <CredentialStorageSection
+          status={credentialStatus}
+          busy={busy}
+          onRevoke={handleRevokeCredentials}
+          t={t}
+        />
+        {tokenProviderIds.has(detail.id) && (
+          <TokenAccountsPanel
+            key={`token-${detail.id}-${credentialRevision}`}
+            providerId={detail.id}
+            compact
+          />
+        )}
+        <ApiKeySection
+          key={`api-${detail.id}-${credentialRevision}`}
+          providerId={detail.id}
+        />
+        <CookieSection
+          key={`cookie-${detail.id}-${credentialRevision}`}
+          providerId={detail.id}
+          cookieDomain={cookieDomain}
+        />
+        <ChartsSection
+          providerId={detail.id}
+          accountEmail={detail.email}
+          accountId={detail.accountId}
+          t={t}
+        />
+
+        <QuickActionsSection
+          provider={detail}
+          busy={busy}
+          loginPhase={loginPhase}
+          loginCode={loginCode}
+          loginUrl={loginUrl}
+          onRefresh={handleRefresh}
+          onSwitchAccount={handleSwitchAccount}
+          onOpenDashboard={handleOpenDashboard}
+          onOpenStatusPage={handleOpenStatusPage}
+          onCopyError={handleCopyError}
+          onBuyCredits={handleBuyCredits}
+          t={t}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
@@ -234,6 +234,7 @@ export function ProviderDetailPane({
     selectedId: detail?.accountId ?? null,
     onSelect: selectAccount,
     activation: "manual",
+    isTabDisabled: () => loading,
   });
 
   if (!providerId) {

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -24,6 +24,7 @@ import type {
   SettingsSnapshot,
 } from "../../../../../types/bridge";
 import type { useLocale } from "../../../../../hooks/useLocale";
+import { useTabListKeyboard } from "../../../../../hooks/useTabListKeyboard";
 import { CreditsHistoryChart } from "./CreditsHistoryChart";
 import { UsageBreakdownChart } from "./UsageBreakdownChart";
 import { QuotaHistoryChart } from "./QuotaHistoryChart";
@@ -681,6 +682,23 @@ export function ChartsSection({ providerId, accountEmail, accountId, providerSna
   const cursorRows = isCursor ? cursorActivity ?? [] : [];
   const hasCursorActivity = cursorRows.length > 0;
 
+  // Derived above the empty and loading states below because the tab-strip hook
+  // has to run on every render.
+  const available: TabKey[] = [];
+  if ((data?.quotaHistory.length ?? 0) > 0) available.push("limits");
+  if ((data?.creditsHistory.length ?? 0) > 0) available.push("credits");
+  if ((data?.usageBreakdown.length ?? 0) > 0) available.push("usage");
+  const current: TabKey | null =
+    active && available.includes(active) ? active : available[0] ?? null;
+
+  // Automatic activation: the series are already loaded, so switching tabs only
+  // swaps which chart is drawn.
+  const { tabListProps, getTabProps, getPanelProps } = useTabListKeyboard({
+    tabIds: available,
+    selectedId: current,
+    onSelect: setActive,
+  });
+
   if (loading) {
     return (
       <section className="provider-detail-section provider-detail-charts provider-detail-charts--loading">
@@ -711,12 +729,9 @@ export function ChartsSection({ providerId, accountEmail, accountId, providerSna
     );
   }
 
-  const hasCredits = data.creditsHistory.length > 0;
-  const hasUsage = data.usageBreakdown.length > 0;
-  const hasLimits = data.quotaHistory.length > 0;
   const hasLocalSummary = data.localUsage !== null;
 
-  if (!hasCredits && !hasUsage && !hasLimits && !hasLocalSummary && !hasCursorActivity
+  if (available.length === 0 && !hasLocalSummary && !hasCursorActivity
     && !resetBoundaryUnavailable) {
     return (
       <section className="provider-detail-section provider-detail-charts charts-data-empty">
@@ -726,12 +741,6 @@ export function ChartsSection({ providerId, accountEmail, accountId, providerSna
     );
   }
 
-  const available: TabKey[] = [];
-  if (hasLimits) available.push("limits");
-  if (hasCredits) available.push("credits");
-  if (hasUsage) available.push("usage");
-
-  const current: TabKey | null = active && available.includes(active) ? active : available[0] ?? null;
   const emptyMsg = t("DetailChartEmpty");
 
   const tabLabel = (k: TabKey): string => {
@@ -858,13 +867,12 @@ export function ChartsSection({ providerId, accountEmail, accountId, providerSna
         </div>
       )}
       {available.length > 1 && (
-        <div className="provider-detail-charts__tabs" role="tablist">
+        <div className="provider-detail-charts__tabs" {...tabListProps}>
           {available.map((k) => (
             <button
               key={k}
               type="button"
-              role="tab"
-              aria-selected={k === current}
+              {...getTabProps(k)}
               className="provider-detail-charts__tab"
               data-active={k === current ? "true" : "false"}
               onClick={() => setActive(k)}
@@ -874,7 +882,10 @@ export function ChartsSection({ providerId, accountEmail, accountId, providerSna
           ))}
         </div>
       )}
-      {current && <div className="provider-detail-charts__body" role="tabpanel">
+      {current && <div
+        className="provider-detail-charts__body"
+        {...(available.length > 1 ? getPanelProps() : {})}
+      >
         {current === "limits" && (
           <QuotaHistoryChart
             data={data.quotaHistory}


### PR DESCRIPTION
## Summary
- add a shared `useTabListKeyboard` hook implementing the ARIA tabs model: Left/Right, Home/End, wrapping, and roving `tabindex` so each strip is one tab stop
- apply it to all four `role="tablist"` strips: Settings, the Charts provider selector, provider-detail accounts, and the chart-type tabs
- wire panels to tabs with `aria-controls` / `aria-labelledby`, derived from the selection in one place so the two ends cannot drift
- make panels focusable, which also makes the two that are scroll containers reachable by keyboard

## Notes
Activation mode follows the APG rule rather than one blanket choice. Settings and the chart-type tabs activate on arrow (panel already loaded). The Charts provider strip and the account strip activate manually — arrowing past a tab there would otherwise fire a history load or a provider refetch per tab crossed.

Where a strip is hidden for having only one tab, the panel stays a plain container rather than naming a tab that is not in the document. `ChartsSection` previously rendered `role="tabpanel"` unconditionally, including in that case.

Two containers gained a wrapper element to host the panel role: `.charts-panel__body` (repeats the parent's column layout, so spacing is unchanged) and `.provider-detail__body` (plain block wrapper in a block container). Neither parent has direct-child selectors.

## Validation
- `npm test -- --run` (479 tests, 66 files; +14 covering the hook and the Charts strip)
- `npm run build` (TypeScript, locale drift check, Vite production build)

Not visually checked in the running app — worth a look at the Charts tab and a multi-account provider detail pane during the pre-publish installer test.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)