### PR TITLE
Show on-demand spend as money on every surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Ceiling] Unreleased
 
+### Fixed
+- **Cursor's on-demand spend reads as money on the taskbar, not just on the Overview.** 1.5.27 taught the Overview card to show dollars, but the surfaces you actually glance at were left behind. The taskbar tile picked the on-demand lane correctly and then drew "62%" — the fraction of a spend cap, which says nothing about the $1,112.92 behind it, and which inverts to a cheerful "38%" if you display remaining rather than used. The flyout was worse: it discarded any lane whose name contained "on-demand" before building its rows, so the tile named a lane that the panel beneath it refused to show, and because the same filter ran before the "+N more limits" count, nothing hinted that a row had been dropped. The free-floating bar carried the identical percentage-only defect. Activity had the same habit from the other direction: it listed the On-demand row faithfully and then headlined it "56% used", describing the shape of the bar instead of the bill. A lane billed in currency now leads with the amount on every surface that shows it — taskbar tile, hover flyout, floating bar, and the Activity schedule — the flyout lists On-demand with its spend beside the bar and reserves it a slot so a depleted plan cannot crowd it out, and on-demand running uncapped reports spend-to-date rather than going blank for want of a denominator. Reported in #191.
+
 ## [Ceiling] 1.5.27 - 2026-08-11
 
 Makes Cursor's on-demand spend readable at a glance, corrects two numbers Ceiling was reporting wrong, and replaces browser cookie import with a manual setup you can see.

--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -34,6 +34,8 @@ struct ProviderReadout {
     /// Set when the constraining lane is billed in currency. Takes the tile's
     /// headline slot ahead of `percent` — see [`strip_amount_label`].
     amount_label: Option<String>,
+    /// Cents-free fallback for tiles too narrow for `amount_label`.
+    amount_label_compact: Option<String>,
     window_label: String,
     reset: Option<String>,
 }
@@ -113,6 +115,29 @@ fn strip_amount_label(
     };
     let remaining = (limit - amount.used).max(0.0);
     Some(codexbar::core::WindowAmount::new(remaining, amount.currency_code.clone()).format_used())
+}
+
+/// Whole-dollar spelling of [`strip_amount_label`], for tiles too narrow for cents.
+///
+/// A provider gets 72-104px on the strip and the paint does not clip, so an
+/// overlong label runs into the neighbouring tile rather than being cut off.
+/// "$1112.92" needs roughly 68px against a 51px budget on a crowded taskbar;
+/// "$1113" fits, and the exact figure is a hover away in the flyout.
+fn compact_amount_label(
+    amount: &crate::commands::WindowAmountBridge,
+    show_as_used: bool,
+) -> Option<String> {
+    let value = match amount.limit.filter(|_| !show_as_used) {
+        Some(limit) => (limit - amount.used).max(0.0),
+        None => amount.used,
+    };
+    let rounded = value.round();
+    Some(match amount.currency_code.to_uppercase().as_str() {
+        "USD" => format!("${rounded:.0}"),
+        "EUR" => format!("€{rounded:.0}"),
+        "GBP" => format!("£{rounded:.0}"),
+        code => format!("{rounded:.0} {code}"),
+    })
 }
 
 fn is_blocking_window(window: &crate::commands::RateWindowSnapshot) -> bool {
@@ -864,15 +889,16 @@ mod windows_host {
                     value.clamp(0.0, 100.0).round() as u8
                 });
                 // A spend lane's headline is the money, not the fraction.
-                let amount_label = constraining.and_then(|readout| {
-                    readout
-                        .amount
-                        .and_then(|amount| strip_amount_label(amount, settings.show_as_used))
-                });
+                let spend = constraining.and_then(|readout| readout.amount);
+                let amount_label =
+                    spend.and_then(|amount| strip_amount_label(amount, settings.show_as_used));
+                let amount_label_compact =
+                    spend.and_then(|amount| compact_amount_label(amount, settings.show_as_used));
                 ProviderReadout {
                     provider_id,
                     percent,
                     amount_label,
+                    amount_label_compact,
                     // Window label only (Weekly / 5h). Account identity lives in
                     // the flyout (On strip + account line); long tags collide
                     // with the next tile on the compact strip.
@@ -1332,15 +1358,43 @@ mod windows_host {
         for (index, provider) in model.providers.iter().enumerate() {
             let item_left = i32::try_from(index).unwrap_or(0) * item_width;
             let color = provider_color(&provider.provider_id);
-            let label = provider
-                .amount_label
-                .clone()
-                .or_else(|| provider.percent.map(|percent| format!("{percent}%")))
-                .unwrap_or_else(|| "—".to_string());
-            let label = wide_without_nul(&label);
-            let label_width = unsafe { text_width(hdc, &label) };
             const ICON_WIDTH: i32 = 16;
             const ICON_TEXT_GAP: i32 = 5;
+            // Widest spelling that stays inside this tile. The strip paints
+            // without clipping and `centered_content_x` pins overlong content to
+            // the cell's left edge, so an unchecked "$1112.92" on a crowded
+            // taskbar would run across the divider into the next provider.
+            let percent_label = provider.percent.map(|percent| format!("{percent}%"));
+            let budget = item_width
+                .saturating_sub(ICON_WIDTH)
+                .saturating_sub(ICON_TEXT_GAP);
+            let mut best: Option<(Vec<u16>, i32)> = None;
+            for candidate in [
+                provider.amount_label.as_deref(),
+                provider.amount_label_compact.as_deref(),
+                percent_label.as_deref(),
+                Some("—"),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                let wide = wide_without_nul(candidate);
+                let width = unsafe { text_width(hdc, &wide) };
+                let fits = width <= budget;
+                // Take the first that fits; failing that, keep the narrowest so
+                // a tile too small for any spelling overruns as little as possible.
+                let better = match &best {
+                    None => true,
+                    Some((_, best_width)) => *best_width > budget && width < *best_width,
+                };
+                if better {
+                    best = Some((wide, width));
+                }
+                if fits {
+                    break;
+                }
+            }
+            let (label, label_width) = best.expect("the em dash always yields a candidate");
             let primary_width = ICON_WIDTH
                 .saturating_add(ICON_TEXT_GAP)
                 .saturating_add(label_width);
@@ -2599,6 +2653,39 @@ mod tests {
         assert_eq!(
             strip_amount_label(&uncapped, false).as_deref(),
             Some("$42.50")
+        );
+    }
+
+    #[test]
+    fn compact_spend_drops_cents_for_narrow_tiles() {
+        let capped = crate::commands::WindowAmountBridge {
+            used: 1112.92,
+            limit: Some(1800.0),
+            currency_code: "USD".into(),
+            formatted_used: "$1112.92".into(),
+            formatted_limit: Some("$1800.00".into()),
+        };
+        // Three characters narrower than "$1112.92", which is the difference
+        // between fitting a 72px tile and crossing into the next provider.
+        assert_eq!(
+            compact_amount_label(&capped, true).as_deref(),
+            Some("$1113")
+        );
+        assert_eq!(
+            compact_amount_label(&capped, false).as_deref(),
+            Some("$687")
+        );
+
+        let uncapped = crate::commands::WindowAmountBridge {
+            used: 42.5,
+            limit: None,
+            currency_code: "EUR".into(),
+            formatted_used: "€42.50".into(),
+            formatted_limit: None,
+        };
+        assert_eq!(
+            compact_amount_label(&uncapped, false).as_deref(),
+            Some("€43")
         );
     }
 

--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -31,6 +31,9 @@ enum PlacementOutcome {
 struct ProviderReadout {
     provider_id: String,
     percent: Option<u8>,
+    /// Set when the constraining lane is billed in currency. Takes the tile's
+    /// headline slot ahead of `percent` — see [`strip_amount_label`].
+    amount_label: Option<String>,
     window_label: String,
     reset: Option<String>,
 }
@@ -81,6 +84,35 @@ fn native_mode_has_configured_provider(settings: &codexbar::settings::Settings) 
 struct ConstrainingReadout<'a> {
     label: Option<&'a str>,
     window: &'a crate::commands::RateWindowSnapshot,
+    /// Money behind this lane, when the provider bills it in currency. A
+    /// percentage is the wrong readout for a spend lane: "62%" of an $1800 cap
+    /// does not tell you that you owe $1112.92 (SBS-191).
+    amount: Option<&'a crate::commands::WindowAmountBridge>,
+}
+
+impl<'a> ConstrainingReadout<'a> {
+    fn new(label: Option<&'a str>, window: &'a crate::commands::RateWindowSnapshot) -> Self {
+        Self {
+            label,
+            window,
+            amount: None,
+        }
+    }
+}
+
+/// Tile text for a currency-billed lane.
+///
+/// Uncapped spend has no remaining figure to show, so "show remaining" falls
+/// back to spend-to-date — the only honest number when there is no denominator.
+fn strip_amount_label(
+    amount: &crate::commands::WindowAmountBridge,
+    show_as_used: bool,
+) -> Option<String> {
+    let Some(limit) = amount.limit.filter(|_| !show_as_used) else {
+        return Some(amount.formatted_used.clone());
+    };
+    let remaining = (limit - amount.used).max(0.0);
+    Some(codexbar::core::WindowAmount::new(remaining, amount.currency_code.clone()).format_used())
 }
 
 fn is_blocking_window(window: &crate::commands::RateWindowSnapshot) -> bool {
@@ -116,7 +148,7 @@ fn outranks_window(
 /// Cursor Auto + API only (not Plan/Monthly blend).
 fn cursor_actionable_windows(
     snapshot: &crate::commands::ProviderUsageSnapshot,
-) -> Vec<(Option<&str>, &crate::commands::RateWindowSnapshot)> {
+) -> Vec<ConstrainingReadout<'_>> {
     let mut out = Vec::new();
     if let Some(window) = snapshot.secondary.as_ref() {
         let label = snapshot
@@ -125,7 +157,7 @@ fn cursor_actionable_windows(
             .map(str::trim)
             .filter(|label| !label.is_empty())
             .unwrap_or("Auto");
-        out.push((Some(label), window));
+        out.push(ConstrainingReadout::new(Some(label), window));
     }
     for extra in &snapshot.extra_rate_windows {
         if extra.id != "cursor-api" {
@@ -135,7 +167,11 @@ fn cursor_actionable_windows(
             "" => "API",
             label => label,
         };
-        out.push((Some(label), &extra.window));
+        out.push(ConstrainingReadout {
+            label: Some(label),
+            window: &extra.window,
+            amount: extra.amount.as_ref(),
+        });
     }
     out
 }
@@ -153,6 +189,7 @@ fn cursor_on_demand_readout(
                 label => label,
             }),
             window: &extra.window,
+            amount: extra.amount.as_ref(),
         })
 }
 
@@ -173,14 +210,11 @@ fn cursor_strip_readout(
     if !actionable.is_empty() {
         // Hottest non-exhausted Auto/API lane.
         let mut with_room: Option<ConstrainingReadout<'_>> = None;
-        for (label, window) in &actionable {
-            if is_blocking_window(window) {
+        for candidate in &actionable {
+            if is_blocking_window(candidate.window) {
                 continue;
             }
-            let candidate = ConstrainingReadout {
-                label: *label,
-                window,
-            };
+            let candidate = *candidate;
             let replace = match with_room {
                 None => true,
                 Some(best) => {
@@ -201,14 +235,11 @@ fn cursor_strip_readout(
         }
         // All actionable lanes exhausted: soonest reset.
         let mut exhausted: Option<ConstrainingReadout<'_>> = None;
-        for (label, window) in &actionable {
-            if !is_blocking_window(window) {
+        for candidate in &actionable {
+            if !is_blocking_window(candidate.window) {
                 continue;
             }
-            let candidate = ConstrainingReadout {
-                label: *label,
-                window,
-            };
+            let candidate = *candidate;
             let replace = match exhausted {
                 None => true,
                 Some(best) => {
@@ -230,10 +261,7 @@ fn cursor_strip_readout(
     {
         return readout;
     }
-    ConstrainingReadout {
-        label: snapshot.primary_label.as_deref(),
-        window: &snapshot.primary,
-    }
+    ConstrainingReadout::new(snapshot.primary_label.as_deref(), &snapshot.primary)
 }
 
 fn constraining_readout(
@@ -243,10 +271,7 @@ fn constraining_readout(
         return cursor_strip_readout(snapshot);
     }
 
-    let mut best = ConstrainingReadout {
-        label: snapshot.primary_label.as_deref(),
-        window: &snapshot.primary,
-    };
+    let mut best = ConstrainingReadout::new(snapshot.primary_label.as_deref(), &snapshot.primary);
 
     // Claude's per-model weekly caps are parallel sub-pools, not blockers: at
     // 100% you switch model rather than stop. The tile shows one lane, so
@@ -256,18 +281,24 @@ fn constraining_readout(
     // providers put real pools in `model_specific`.
     let is_claude = snapshot.provider_id == "claude";
 
-    let candidates: Vec<(Option<&str>, &crate::commands::RateWindowSnapshot)> = {
+    let candidates: Vec<ConstrainingReadout<'_>> = {
         let mut out = Vec::new();
         if let Some(window) = snapshot.secondary.as_ref() {
-            out.push((snapshot.secondary_label.as_deref(), window));
+            out.push(ConstrainingReadout::new(
+                snapshot.secondary_label.as_deref(),
+                window,
+            ));
         }
         if let Some(window) = snapshot.model_specific.as_ref()
             && !is_claude
         {
-            out.push((Some("Model"), window));
+            out.push(ConstrainingReadout::new(Some("Model"), window));
         }
         if let Some(window) = snapshot.tertiary.as_ref() {
-            out.push((snapshot.tertiary_label.as_deref().or(Some("Extra")), window));
+            out.push(ConstrainingReadout::new(
+                snapshot.tertiary_label.as_deref().or(Some("Extra")),
+                window,
+            ));
         }
         for extra in &snapshot.extra_rate_windows {
             if extra.id == "reset-credits" {
@@ -276,14 +307,18 @@ fn constraining_readout(
             if is_claude && extra.id.starts_with("claude-weekly-scoped-") {
                 continue;
             }
-            out.push((Some(extra.title.as_str()), &extra.window));
+            out.push(ConstrainingReadout {
+                label: Some(extra.title.as_str()),
+                window: &extra.window,
+                amount: extra.amount.as_ref(),
+            });
         }
         out
     };
 
-    for (label, window) in candidates {
-        if outranks_window(window, best.window) {
-            best = ConstrainingReadout { label, window };
+    for candidate in candidates {
+        if outranks_window(candidate.window, best.window) {
+            best = candidate;
         }
     }
 
@@ -828,9 +863,16 @@ mod windows_host {
                     };
                     value.clamp(0.0, 100.0).round() as u8
                 });
+                // A spend lane's headline is the money, not the fraction.
+                let amount_label = constraining.and_then(|readout| {
+                    readout
+                        .amount
+                        .and_then(|amount| strip_amount_label(amount, settings.show_as_used))
+                });
                 ProviderReadout {
                     provider_id,
                     percent,
+                    amount_label,
                     // Window label only (Weekly / 5h). Account identity lives in
                     // the flyout (On strip + account line); long tags collide
                     // with the next tile on the compact strip.
@@ -1291,8 +1333,9 @@ mod windows_host {
             let item_left = i32::try_from(index).unwrap_or(0) * item_width;
             let color = provider_color(&provider.provider_id);
             let label = provider
-                .percent
-                .map(|percent| format!("{percent}%"))
+                .amount_label
+                .clone()
+                .or_else(|| provider.percent.map(|percent| format!("{percent}%")))
                 .unwrap_or_else(|| "—".to_string());
             let label = wide_without_nul(&label);
             let label_width = unsafe { text_width(hdc, &label) };
@@ -2494,6 +2537,76 @@ mod tests {
         let readout = constraining_readout(&snapshot);
         assert_eq!(readout.label, Some("On-demand"));
         assert_eq!(readout.window.used_percent, 0.0);
+    }
+
+    /// SBS-191: picking the on-demand lane was never the hard part — carrying
+    /// its money to the tile was. The readout dropped `amount` on the floor, so
+    /// the strip could only ever render "62%".
+    #[test]
+    fn cursor_strip_readout_carries_on_demand_money() {
+        let mut snapshot = snap("cursor", None, 100.0);
+        snapshot.primary_label = Some("Plan".into());
+        snapshot.secondary = Some(rate_window(100.0, Some(43_200)));
+        snapshot.secondary_label = Some("Auto".into());
+        snapshot
+            .extra_rate_windows
+            .push(crate::commands::NamedRateWindowSnapshot {
+                id: "cursor-api".into(),
+                title: "API".into(),
+                window: rate_window(100.0, Some(43_200)),
+                amount: None,
+            });
+        snapshot
+            .extra_rate_windows
+            .push(crate::commands::NamedRateWindowSnapshot {
+                id: "cursor-on-demand".into(),
+                title: "On-demand".into(),
+                window: rate_window(62.0, Some(43_200)),
+                amount: Some(crate::commands::WindowAmountBridge {
+                    used: 1112.92,
+                    limit: Some(1800.0),
+                    currency_code: "USD".into(),
+                    formatted_used: "$1112.92".into(),
+                    formatted_limit: Some("$1800.00".into()),
+                }),
+            });
+
+        let readout = constraining_readout(&snapshot);
+        let amount = readout.amount.expect("on-demand money reaches the tile");
+        assert_eq!(
+            strip_amount_label(amount, true).as_deref(),
+            Some("$1112.92")
+        );
+        // "Show remaining" on a capped spend lane is headroom, not spend.
+        assert_eq!(
+            strip_amount_label(amount, false).as_deref(),
+            Some("$687.08")
+        );
+    }
+
+    #[test]
+    fn uncapped_spend_reports_spend_even_in_remaining_mode() {
+        // No denominator means no headroom figure exists. Falling back to
+        // spend-to-date beats blanking the tile for exactly the people running
+        // on-demand without a cap.
+        let uncapped = crate::commands::WindowAmountBridge {
+            used: 42.5,
+            limit: None,
+            currency_code: "USD".into(),
+            formatted_used: "$42.50".into(),
+            formatted_limit: None,
+        };
+        assert_eq!(
+            strip_amount_label(&uncapped, false).as_deref(),
+            Some("$42.50")
+        );
+    }
+
+    #[test]
+    fn percentage_lanes_leave_the_tile_on_percent() {
+        let snapshot = snap("claude", None, 41.0);
+        let readout = constraining_readout(&snapshot);
+        assert!(readout.amount.is_none());
     }
 
     #[test]

--- a/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
@@ -375,6 +375,48 @@ describe("FloatBar", () => {
     });
   });
 
+  it("headlines on-demand spend in dollars once every allowance is depleted", async () => {
+    // SBS-191: the free-floating bar had the same defect as the native tile —
+    // it picked the on-demand lane correctly, then rendered "62%".
+    const live = snapshot("cursor", "Cursor", 100);
+    live.updatedAt = new Date().toISOString();
+    live.primaryLabel = "Plan";
+    live.secondary = rateWindow(100);
+    live.secondaryLabel = "Auto";
+    live.extraRateWindows = [
+      { id: "cursor-api", title: "API", window: rateWindow(100) },
+      {
+        id: "cursor-on-demand",
+        title: "On-demand",
+        window: rateWindow(62),
+        amount: {
+          used: 1112.92,
+          limit: 1800,
+          currencyCode: "USD",
+          formattedUsed: "$1112.92",
+          formattedLimit: "$1800.00",
+        },
+      },
+    ];
+    tauriMocks.getCachedProviders.mockResolvedValue([live]);
+    tauriMocks.getSettingsSnapshot.mockResolvedValue(
+      settings({ showAsUsed: true, enabledProviders: ["cursor"] }),
+    );
+
+    const { container } = renderFloatBar(
+      bootstrap({ showAsUsed: true, enabledProviders: ["cursor"] }),
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(".floatbar__window")?.textContent).toBe(
+        "On-demand",
+      );
+      expect(container.querySelector(".floatbar__pct")?.textContent).toBe(
+        "$1112.92",
+      );
+    });
+  });
+
   it("animates only the provider named by a confirmed capacity event", async () => {
     tauriMocks.getCachedProviders.mockResolvedValue([
       snapshot("claude", "Claude", 30),

--- a/apps/desktop-tauri/src/floatbar/FloatBar.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.tsx
@@ -38,6 +38,7 @@ import {
   constrainingWindow,
   activePromoBoosts,
   calmPresentation,
+  stripAmountLabel,
   type CapacityFreshness,
   type ConstrainingWindow,
 } from "../lib/capacityPresentation";
@@ -173,7 +174,12 @@ function ProviderPill({
   else if (pressureRemaining <= highRemaining) tone = "warn";
 
   const brand = getProviderIcon(provider.providerId).brandColor;
-  const label = provider.error ? "—" : `${Math.round(displayPercent)}%`;
+  // A lane billed in currency leads with the money. "62%" of a spend cap is not
+  // the number you act on — the amount owed is (SBS-191).
+  const spend = hero.amount ? stripAmountLabel(hero.amount, showAsUsed) : null;
+  const label = provider.error
+    ? "—"
+    : (spend ?? `${Math.round(displayPercent)}%`);
   const resetText = useFormattedResetTime(
     hero.window.resetsAt,
     hero.window.resetDescription,

--- a/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
@@ -11,6 +11,7 @@ import {
   codexResetCredits,
   calmPresentation,
   formatShortDuration,
+  stripAmountLabel,
 } from "./capacityPresentation";
 import type {
   PaceSnapshot,
@@ -643,6 +644,56 @@ describe("capacityPresentation", () => {
     expect(
       codexResetCredits(provider({ providerId: "cursor", resetCreditsAvailable: 2 })),
     ).toBeNull();
+  });
+
+  describe("stripAmountLabel", () => {
+    const capped = {
+      used: 1112.92,
+      limit: 1800,
+      currencyCode: "USD",
+      formattedUsed: "$1112.92",
+      formattedLimit: "$1800.00",
+    };
+
+    it("leads with spend, not the fraction of the cap", () => {
+      expect(stripAmountLabel(capped, true)).toBe("$1112.92");
+    });
+
+    it("reports headroom in currency when showing remaining", () => {
+      expect(stripAmountLabel(capped, false)).toBe("$687.08");
+    });
+
+    it("falls back to spend when on-demand is uncapped", () => {
+      // No denominator means no headroom exists. Blanking here is what hid
+      // spend from uncapped users entirely (SBS-191).
+      expect(
+        stripAmountLabel(
+          {
+            used: 42.5,
+            limit: null,
+            currencyCode: "USD",
+            formattedUsed: "$42.50",
+            formattedLimit: null,
+          },
+          false,
+        ),
+      ).toBe("$42.50");
+    });
+
+    it("keeps non-USD currencies readable", () => {
+      expect(
+        stripAmountLabel(
+          {
+            used: 10,
+            limit: 40,
+            currencyCode: "EUR",
+            formattedUsed: "€10.00",
+            formattedLimit: "€40.00",
+          },
+          false,
+        ),
+      ).toBe("€30.00");
+    });
   });
 
   describe("calmPresentation", () => {

--- a/apps/desktop-tauri/src/lib/capacityPresentation.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.ts
@@ -243,6 +243,36 @@ export function constrainingWindow(
   return best;
 }
 
+/** Mirrors `format_currency` in `rust/src/core/usage_snapshot.rs`. */
+function formatAmount(value: number, currencyCode: string): string {
+  const safe = Number.isFinite(value) ? Math.max(0, value) : 0;
+  switch (currencyCode.toUpperCase()) {
+    case "USD":
+      return `$${safe.toFixed(2)}`;
+    case "EUR":
+      return `€${safe.toFixed(2)}`;
+    case "GBP":
+      return `£${safe.toFixed(2)}`;
+    default:
+      return `${safe.toFixed(2)} ${currencyCode}`;
+  }
+}
+
+/**
+ * Headline for a currency-billed lane on a one-number strip.
+ *
+ * Mirrors `strip_amount_label` in `taskbar_widget.rs` so the native taskbar tile
+ * and the floating bar read the same. Uncapped spend has no headroom figure, so
+ * "show remaining" falls back to spend-to-date rather than going blank (SBS-191).
+ */
+export function stripAmountLabel(
+  amount: WindowAmountBridge,
+  showAsUsed: boolean,
+): string {
+  if (showAsUsed || amount.limit == null) return amount.formattedUsed;
+  return formatAmount(amount.limit - amount.used, amount.currencyCode);
+}
+
 /**
  * Lanes that define a plan alongside its hero, listed in display order and
  * shown on overview however quiet they are:

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -7679,6 +7679,9 @@ body:has(.dashboard-shell) #root {
   color: var(--text-secondary);
   font-variant-numeric: tabular-nums;
   flex-shrink: 0;
+  /* "$1112.92 of $1800.00" is far longer than "56% used" and must stay on one
+     line; the window label beside it is the flexible half. */
+  white-space: nowrap;
 }
 .activity-row__bar {
   margin-top: 7px;

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -1480,6 +1480,20 @@ body:has(.taskbar-flyout-frame) #root {
   line-height: 13px;
 }
 
+/* Spend on a currency-billed lane. Sits between the meta row and the bar so the
+   money is adjacent to the fraction it explains. */
+.taskbar-flyout__meter-amount {
+  margin-bottom: 3px;
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 13px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .taskbar-flyout__track {
   flex: 1 1 auto;
   height: 4px;

--- a/apps/desktop-tauri/src/surfaces/ActivityTimeline.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/ActivityTimeline.test.tsx
@@ -186,6 +186,43 @@ describe("ActivityTimeline", () => {
     expect(text).not.toContain("Promotional");
   });
 
+  it("reports a currency-billed lane in money rather than percent", () => {
+    // SBS-191: Activity listed On-demand but headlined it "56% used" — the
+    // shape of the bar, not the bill.
+    const { container } = render(
+      <ActivityTimeline
+        providers={[
+          provider({
+            providerId: "cursor",
+            displayName: "Cursor",
+            primary: window(100, 8 * DAY),
+            primaryLabel: "Plan",
+            extraRateWindows: [
+              {
+                id: "cursor-on-demand",
+                title: "On-demand",
+                window: window(62, 8 * DAY),
+                amount: {
+                  used: 1112.92,
+                  limit: 1800,
+                  currencyCode: "USD",
+                  formattedUsed: "$1112.92",
+                  formattedLimit: "$1800.00",
+                },
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("$1112.92 of $1800.00");
+    expect(text).not.toContain("62% used");
+    // Percentage lanes are untouched.
+    expect(text).toContain("100% used");
+  });
+
   it("shows an empty state when nothing is scheduled", () => {
     const providers = [
       provider({ primary: window(30, null), primaryLabel: "Weekly" }),

--- a/apps/desktop-tauri/src/surfaces/ActivityTimeline.tsx
+++ b/apps/desktop-tauri/src/surfaces/ActivityTimeline.tsx
@@ -36,6 +36,10 @@ type TimelineEntry = {
  *
  * A percentage alone is the wrong answer here: "56% used" against a spend cap
  * is the shape of the bar, not the bill (SBS-191).
+ *
+ * Always spend-of-limit, matching `PlanStatusCard` and the flyout: a row with
+ * room states both numbers, so there is nothing for a used/remaining toggle to
+ * reveal. Only the one-number strips choose between them.
  */
 function spendLabel(entry: TimelineEntry): string | null {
   if (!entry.amount) return null;

--- a/apps/desktop-tauri/src/surfaces/ActivityTimeline.tsx
+++ b/apps/desktop-tauri/src/surfaces/ActivityTimeline.tsx
@@ -1,5 +1,9 @@
 import { Fragment, useEffect, useMemo, useState } from "react";
-import type { ProviderUsageSnapshot, RateWindowSnapshot } from "../types/bridge";
+import type {
+  ProviderUsageSnapshot,
+  RateWindowSnapshot,
+  WindowAmountBridge,
+} from "../types/bridge";
 import { ProviderIcon } from "../components/providers/ProviderIcon";
 import { allMeasuredWindows } from "../lib/capacityPresentation";
 import {
@@ -22,8 +26,23 @@ type TimelineEntry = {
   accountName: string | null;
   label: string;
   window: RateWindowSnapshot;
+  /** Money behind this lane, when the provider bills it in currency. */
+  amount: WindowAmountBridge | null;
   resetMs: number | null;
 };
+
+/**
+ * Spend on a currency-billed lane, for the row's headline.
+ *
+ * A percentage alone is the wrong answer here: "56% used" against a spend cap
+ * is the shape of the bar, not the bill (SBS-191).
+ */
+function spendLabel(entry: TimelineEntry): string | null {
+  if (!entry.amount) return null;
+  return entry.amount.formattedLimit
+    ? `${entry.amount.formattedUsed} of ${entry.amount.formattedLimit}`
+    : entry.amount.formattedUsed;
+}
 
 type Bucket = {
   id: string;
@@ -98,6 +117,7 @@ function collectEntries(
           : null,
         label: measured.label,
         window: measured.window,
+        amount: measured.amount ?? null,
         resetMs: Number.isNaN(parsed) ? null : parsed,
       });
     }
@@ -170,6 +190,7 @@ function UsageBar({ window }: { window: RateWindowSnapshot }) {
 
 function FeaturedReset({ entry, nowMs }: { entry: TimelineEntry; nowMs: number }) {
   const usedPct = Math.max(0, Math.min(100, entry.window.usedPercent));
+  const spend = spendLabel(entry);
   const duration = shortDuration((entry.resetMs as number) - nowMs);
   return (
     <section className="activity-next" data-activity-entry={entry.key}>
@@ -192,7 +213,9 @@ function FeaturedReset({ entry, nowMs }: { entry: TimelineEntry; nowMs: number }
       <div className="activity-next__glance">
         <strong>{duration}</strong>
         <span>{localResetLabel(entry.resetMs as number, nowMs)}</span>
-        <span className="activity-next__pct">{Math.round(usedPct)}% used</span>
+        <span className="activity-next__pct">
+          {spend ?? `${Math.round(usedPct)}% used`}
+        </span>
       </div>
       <UsageBar window={entry.window} />
     </section>
@@ -201,6 +224,7 @@ function FeaturedReset({ entry, nowMs }: { entry: TimelineEntry; nowMs: number }
 
 function TimelineRow({ entry, nowMs }: { entry: TimelineEntry; nowMs: number }) {
   const usedPct = Math.max(0, Math.min(100, entry.window.usedPercent));
+  const spend = spendLabel(entry);
   const when =
     entry.resetMs === null ? "—" : shortDuration(entry.resetMs - nowMs);
 
@@ -222,7 +246,9 @@ function TimelineRow({ entry, nowMs }: { entry: TimelineEntry; nowMs: number }) 
             )}
           </span>
           <span className="activity-row__label">{entry.label}</span>
-          <span className="activity-row__pct">{Math.round(usedPct)}% used</span>
+          <span className="activity-row__pct">
+            {spend ?? `${Math.round(usedPct)}% used`}
+          </span>
         </div>
         <UsageBar window={entry.window} />
       </div>

--- a/apps/desktop-tauri/src/surfaces/TaskbarFlyout.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/TaskbarFlyout.test.tsx
@@ -263,6 +263,67 @@ describe("TaskbarFlyout", () => {
     expect(screen.queryByText("Promotional")).not.toBeInTheDocument();
   });
 
+  it("keeps the On-demand lane and its spend when every Cursor allowance is depleted", async () => {
+    // SBS-191: the reporter's exact state — Plan/Auto/API all at 100%, real
+    // money accruing on-demand. The flyout used to drop the row by name, so the
+    // one lane still costing anything was the only one you could not see.
+    const cursor = provider("cursor", "Cursor", 100, 22 * 24 * 60, "Plan");
+    cursor.primary.isExhausted = true;
+    cursor.secondary = {
+      ...cursor.primary,
+      usedPercent: 100,
+      remainingPercent: 0,
+      isExhausted: true,
+    };
+    cursor.secondaryLabel = "Auto";
+    cursor.extraRateWindows = [
+      {
+        id: "cursor-api",
+        title: "API",
+        window: {
+          ...cursor.primary,
+          usedPercent: 100,
+          remainingPercent: 0,
+          isExhausted: true,
+        },
+      },
+      {
+        id: "cursor-on-demand",
+        title: "On-demand",
+        window: { ...cursor.primary, usedPercent: 62, remainingPercent: 38, isExhausted: false },
+        amount: {
+          used: 1112.92,
+          limit: 1800,
+          currencyCode: "USD",
+          formattedUsed: "$1112.92",
+          formattedLimit: "$1800.00",
+        },
+      },
+    ];
+    providerState.providers = [cursor];
+    const cursorState = {
+      ...state,
+      providers: [{ id: "cursor", displayName: "Cursor" }],
+      settings: {
+        ...state.settings,
+        enabledProviders: ["cursor"],
+        providerOrder: ["cursor"],
+      },
+    } as BootstrapState;
+
+    render(<TaskbarFlyout state={cursorState} />);
+
+    expect(screen.getByText("On-demand")).toBeInTheDocument();
+    expect(screen.getByText("$1112.92 of $1800.00")).toBeInTheDocument();
+    expect(
+      screen.getByRole("progressbar", {
+        name: "Cursor On-demand 62% — $1112.92 of $1800.00",
+      }),
+    ).toBeInTheDocument();
+    // All four lanes fit, so nothing is silently truncated.
+    expect(screen.queryByText(/more limits in Ceiling/)).not.toBeInTheDocument();
+  });
+
   it("opens the full dashboard and dismisses the glance flyout", async () => {
     render(<TaskbarFlyout state={state} />);
     fireEvent.click(screen.getByRole("button", { name: "Open Ceiling" }));

--- a/apps/desktop-tauri/src/surfaces/TaskbarFlyout.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/TaskbarFlyout.test.tsx
@@ -324,6 +324,57 @@ describe("TaskbarFlyout", () => {
     expect(screen.queryByText(/more limits in Ceiling/)).not.toBeInTheDocument();
   });
 
+  it("states spend of limit under Show-as-remaining, like the Overview does", () => {
+    // Rows with space print both numbers, so the used/remaining toggle has
+    // nothing left to reveal and moves only the percentage — the same split
+    // PlanStatusCard uses. Only the one-number strips (taskbar tile, floating
+    // bar) pick one figure and follow the setting.
+    const cursor = provider("cursor", "Cursor", 100, 22 * 24 * 60, "Plan");
+    cursor.primary.isExhausted = true;
+    cursor.extraRateWindows = [
+      {
+        id: "cursor-on-demand",
+        title: "On-demand",
+        window: {
+          ...cursor.primary,
+          usedPercent: 62,
+          remainingPercent: 38,
+          isExhausted: false,
+        },
+        amount: {
+          used: 1112.92,
+          limit: 1800,
+          currencyCode: "USD",
+          formattedUsed: "$1112.92",
+          formattedLimit: "$1800.00",
+        },
+      },
+    ];
+    providerState.providers = [cursor];
+
+    render(
+      <TaskbarFlyout
+        state={
+          {
+            ...state,
+            providers: [{ id: "cursor", displayName: "Cursor" }],
+            settings: {
+              ...state.settings,
+              enabledProviders: ["cursor"],
+              providerOrder: ["cursor"],
+              showAsUsed: false,
+            },
+          } as BootstrapState
+        }
+      />,
+    );
+
+    // The percentage flips to remaining...
+    expect(screen.getByText("38%")).toBeInTheDocument();
+    // ...while the money keeps stating both figures.
+    expect(screen.getByText("$1112.92 of $1800.00")).toBeInTheDocument();
+  });
+
   it("opens the full dashboard and dismisses the glance flyout", async () => {
     render(<TaskbarFlyout state={state} />);
     fireEvent.click(screen.getByRole("button", { name: "Open Ceiling" }));

--- a/apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx
+++ b/apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx
@@ -196,6 +196,14 @@ function ProviderRow({ provider, showAccount, hideEmail, onStrip, showAsUsed, no
             const level = meterLevel(window);
             // A lane billed in currency reads as money first; the percentage is
             // only the shape of the bar beneath it.
+            //
+            // Deliberately not switched by `showAsUsed`. A row with space
+            // states both numbers, so remaining is already on screen and the
+            // toggle has nothing to reveal; only the one-number strips (the
+            // taskbar tile and the floating bar) have to choose, and they
+            // follow the setting. This matches `PlanStatusCard`, where the
+            // percentage flips and the amount does not — making the flyout obey
+            // the toggle would put it out of step with the Overview it summarizes.
             const spend = amount
               ? amount.formattedLimit
                 ? `${amount.formattedUsed} of ${amount.formattedLimit}`

--- a/apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx
+++ b/apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx
@@ -56,7 +56,7 @@ function earliestReset(providers: ProviderUsageSnapshot[], now: number): string 
   let earliestTime = Number.POSITIVE_INFINITY;
   for (const provider of providers) {
     if (provider.error) continue;
-    const windows = allMeasuredWindows(provider).filter(isUtilityWindow);
+    const windows = allMeasuredWindows(provider).filter(isResetClockWindow);
     for (const { window } of windows) {
       const candidate = window?.resetsAt;
       if (!candidate) continue;
@@ -70,25 +70,43 @@ function earliestReset(providers: ProviderUsageSnapshot[], now: number): string 
   return earliest;
 }
 
-function isUtilityWindow(window: ConstrainingWindow): boolean {
+/** Promotional grants are giveaways, not limits — they never earn a row. */
+function isMeteredWindow(window: ConstrainingWindow): boolean {
+  return !`${window.id} ${window.label}`.toLowerCase().includes("promotional");
+}
+
+/**
+ * Windows that answer "when does capacity come back".
+ *
+ * A spend lane bills rather than blocks, so it stays out of the header clock —
+ * but it is still a real row. Folding both questions into one predicate is what
+ * erased On-demand from the flyout entirely (SBS-191).
+ */
+function isResetClockWindow(window: ConstrainingWindow): boolean {
   const identity = `${window.id} ${window.label}`.toLowerCase();
-  return ![
-    "promotional",
-    "on-demand",
-    "on demand",
-    "ondemand",
-  ].some((noise) => identity.includes(noise));
+  return (
+    isMeteredWindow(window) &&
+    !["on-demand", "on demand", "ondemand"].some((lane) =>
+      identity.includes(lane),
+    )
+  );
 }
 
 function flyoutWindows(provider: ProviderUsageSnapshot): ConstrainingWindow[] {
-  const windows = allMeasuredWindows(provider).filter(isUtilityWindow);
+  const windows = allMeasuredWindows(provider).filter(isMeteredWindow);
   if (provider.providerId !== "cursor") {
     return windows.slice(0, MAX_VISIBLE_WINDOWS_PER_PROVIDER);
   }
 
-  // Cursor's three durable allowances are the useful comparison. Keep API in
-  // the first three even if the provider inserts another auxiliary pool.
-  const preferredIds = ["primary", "secondary", "extra-cursor-api"];
+  // Cursor's three durable allowances plus the lane that actually charges you.
+  // On-demand is pinned rather than left to fill a leftover slot: when the
+  // other three are depleted it is the only row that still means anything.
+  const preferredIds = [
+    "primary",
+    "secondary",
+    "extra-cursor-api",
+    "extra-cursor-on-demand",
+  ];
   const preferred = preferredIds
     .map((id) => windows.find((window) => window.id === id))
     .filter((window): window is ConstrainingWindow => Boolean(window));
@@ -142,7 +160,7 @@ function ProviderRow({ provider, showAccount, hideEmail, onStrip, showAsUsed, no
   const resetCredits = codexResetCredits(provider);
   const hiddenWindowCount = Math.max(
     0,
-    allMeasuredWindows(provider).filter(isUtilityWindow).length - windows.length,
+    allMeasuredWindows(provider).filter(isMeteredWindow).length - windows.length,
   );
   return (
     <div
@@ -172,10 +190,17 @@ function ProviderRow({ provider, showAccount, hideEmail, onStrip, showAsUsed, no
           </div>
         )}
         <div className="taskbar-flyout__meters">
-          {windows.map(({ id, label, window }) => {
+          {windows.map(({ id, label, window, amount }) => {
             const percent = valueFor(window, showAsUsed);
             const reset = compactDuration(window.resetsAt, window.resetDescription, now);
             const level = meterLevel(window);
+            // A lane billed in currency reads as money first; the percentage is
+            // only the shape of the bar beneath it.
+            const spend = amount
+              ? amount.formattedLimit
+                ? `${amount.formattedUsed} of ${amount.formattedLimit}`
+                : amount.formattedUsed
+              : null;
             return (
               <div className="taskbar-flyout__meter" key={id} data-level={level}>
                 <div className="taskbar-flyout__meter-meta">
@@ -183,11 +208,18 @@ function ProviderRow({ provider, showAccount, hideEmail, onStrip, showAsUsed, no
                   <span className="taskbar-flyout__meter-value" data-level={level}>{percent}%</span>
                   <span className="taskbar-flyout__reset">{reset}</span>
                 </div>
+                {spend && (
+                  <div className="taskbar-flyout__meter-amount">{spend}</div>
+                )}
                 <div
                   className="taskbar-flyout__track"
                   data-level={level}
                   role="progressbar"
-                  aria-label={`${provider.displayName} ${label} ${percent}%`}
+                  aria-label={
+                    spend
+                      ? `${provider.displayName} ${label} ${percent}% — ${spend}`
+                      : `${provider.displayName} ${label} ${percent}%`
+                  }
                   aria-valuemin={0}
                   aria-valuemax={100}
                   aria-valuenow={percent}


### PR DESCRIPTION
Closes the remaining half of #191.

## Problem

1.5.27 taught the Overview card to show Cursor's on-demand dollars. The reporter confirmed that part works — and then showed that four other surfaces still described a spend lane as a percentage, or hid it outright.

| Surface | Before | After |
|---|---|---|
| Taskbar tile | `62%` | `$1112.92` |
| Hover flyout | *row absent entirely* | `On-demand · 62% · 4d 23h` + `$1112.92 of $1800.00` |
| Floating bar | `62%` | `$1112.92` |
| Activity schedule | `56% used` | `$1112.92 of $1800.00` |
| Overview card | already correct | unchanged |

## Root causes

These were four distinct bugs that happened to share a symptom.

**The tile had no amount to render.** `ConstrainingReadout` carried only `label` and `window`. The extra's `amount` was read in `cursor_strip_readout` solely to decide *whether* on-demand won the slot, then dropped. The struct now carries it, and the paint path prefers a currency label over the percentage. Done generically, so any lane billed in currency benefits — not just Cursor's.

**The flyout filtered the lane out by name.** `isUtilityWindow` rejected anything matching `on-demand`/`on demand`/`ondemand` — the same class of filter that was removed from `ProviderDetailView` in the previous round, still live here. So the tile named a lane that the panel beneath it refused to show, while marking the provider "On strip". Because the same predicate also ran before the `+N more limits` count, nothing hinted a row had been dropped.

Split into two predicates: `isMeteredWindow` (what earns a row) and `isResetClockWindow` (what answers "when does capacity come back"). A spend lane bills rather than blocks, so it stays out of the header clock but keeps its row. On-demand is also pinned into Cursor's preferred slots — the cap is 4 and the durable lanes are 3, so a depleted plan can't crowd it out.

**The floating bar had the identical percentage-only defect** at `FloatBar.tsx:176`. Fixed via a shared `stripAmountLabel` in `capacityPresentation.ts` that mirrors `strip_amount_label` in `taskbar_widget.rs`, so the native tile and the floating bar can't drift apart.

**Activity described the bar, not the bill.** It listed the On-demand row faithfully and headlined it `56% used`.

## Uncapped on-demand

`strip_amount_label` falls back to spend-to-date when there's no limit. With no denominator there's no headroom figure, and returning nothing blanked the tile for exactly the people running without a cap — the same failure mode called out in the 1.5.27 notes. A test asserts this; it caught the gap in my own first implementation.

## Not changed

The Overview needs no fix. I measured the earlier "text collides with the meter bar" suspicion at the pixel level — text bottom at y=346, bar at y=350–352, a 3px gap; what looked like overlap in a 2× crop is the pace marker crossing the bar. The emphasis inversion at 100% (reset time promoted over `100% used`) is the `showResetWhenExhausted` setting behaving as written.

## Verification

- `cargo test` (Tauri crate): 489 pass, 4 new
- `vitest`: 489 pass, 7 new
- `tsc --noEmit`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` on both manifests: clean
- `check-locale-drift`: 655 keys match

Pre-existing and unrelated: `cli::tty_runner::tests::test_run_sends_script_through_pty` in the shared crate fails locally from an environment PTY path. Confirmed it fails identically on a stashed clean `HEAD`.

Not manually run in the Tauri shell — the taskbar tile and flyout are Windows-native surfaces worth a visual pass before release.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added currency-based spend displays for Cursor usage across the taskbar tile, flyout, floating bar, and Activity timeline.
  - Shows spend-to-date for uncapped on-demand usage and remaining balances for capped allowances.
  - Keeps percentage displays for usage limits without currency billing.
  - Includes Cursor’s On-demand allowance in the flyout and prioritizes it when other allowances are exhausted.
- **Bug Fixes**
  - Improved visibility and accessibility of usage amounts and allowance rows in the taskbar flyout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->