### PR TITLE
Surface the taskbar widget's hidden state in Settings

### DIFF
--- a/apps/desktop-tauri/src-tauri/permissions/commands.toml
+++ b/apps/desktop-tauri/src-tauri/permissions/commands.toml
@@ -11,6 +11,7 @@ commands.allow = [
   "set_surface_mode",
   "dismiss_tray_panel",
   "get_taskbar_surface_color",
+  "get_taskbar_widget_status",
   "hide_dashboard_to_tray",
   "begin_flyout_gesture",
   "end_flyout_gesture",

--- a/apps/desktop-tauri/src-tauri/src/events.rs
+++ b/apps/desktop-tauri/src-tauri/src/events.rs
@@ -22,6 +22,7 @@ pub const PROOF_STATE_CHANGED: &str = "proof-state-changed";
 pub const LOCALE_CHANGED: &str = "locale-changed";
 pub const SETTINGS_CHANGED: &str = "settings-changed";
 pub const CAPACITY_EVENT: &str = "capacity-event";
+pub const TASKBAR_WIDGET_STATUS_CHANGED: &str = "taskbar-widget-status-changed";
 
 // ── Payloads ─────────────────────────────────────────────────────────
 
@@ -151,6 +152,13 @@ pub fn emit_proof_state_changed(app: &AppHandle, payload: &ProofStatePayload) {
 /// do not share React state. Payload-less; listeners re-fetch the snapshot.
 pub fn emit_settings_changed(app: &AppHandle) {
     let _ = app.emit(SETTINGS_CHANGED, ());
+}
+
+/// Broadcast when the native taskbar widget's visibility status changes
+/// (shown, or hidden and why), so the Settings row updates live instead of
+/// polling. Payload-less; listeners re-fetch via `get_taskbar_widget_status`.
+pub fn emit_taskbar_widget_status_changed(app: &AppHandle) {
+    let _ = app.emit(TASKBAR_WIDGET_STATUS_CHANGED, ());
 }
 
 pub fn emit_capacity_event(

--- a/apps/desktop-tauri/src-tauri/src/main.rs
+++ b/apps/desktop-tauri/src-tauri/src/main.rs
@@ -147,6 +147,7 @@ fn main() {
             commands::set_surface_mode,
             commands::dismiss_tray_panel,
             taskbar_widget::get_taskbar_surface_color,
+            taskbar_widget::get_taskbar_widget_status,
             commands::hide_dashboard_to_tray,
             commands::begin_flyout_gesture,
             commands::end_flyout_gesture,

--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -12,6 +12,13 @@ const WATCHDOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5)
 /// order come from `float_bar_provider_ids` (or enabled providers in display order).
 const MAX_TASKBAR_WIDGET_PROVIDERS: usize = 5;
 
+/// Consecutive transient-landmark misses before the Settings row reports
+/// `WaitingLandmarks`. The watchdog runs every `WATCHDOG_INTERVAL`, so this
+/// is roughly 30s of persistent misses — long enough to ride out Explorer
+/// surfaces (Start, Search, Widgets) opening and closing, short enough to
+/// still feel responsive.
+const TRANSIENT_LANDMARKS_DEBOUNCE: u32 = 6;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ChildPlacement {
     x: i32,
@@ -527,6 +534,90 @@ fn placement_outcome(
     })
 }
 
+/// Reported native taskbar widget visibility, mirrored to the Settings UI so
+/// a hidden widget is never silent. Declared outside `windows_host` so
+/// `get_taskbar_widget_status` compiles (and returns `Unavailable`) on
+/// non-Windows targets.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum TaskbarWidgetStatus {
+    /// Not Windows; the native widget does not exist on this platform.
+    #[cfg_attr(windows, allow(dead_code))]
+    Unavailable,
+    /// Native taskbar mode is turned off in Settings.
+    Disabled,
+    NoProviders,
+    WaitingLandmarks,
+    NoFit,
+    Active {
+        taskbars: usize,
+    },
+}
+
+/// Why [`prepare_widgets`] could not produce placements this pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrepareFailure {
+    Disabled,
+    NoProviders,
+    /// No taskbar produced a placement, but none was conclusively rejected
+    /// either — Start/Widgets/Search were transiently unavailable to UI
+    /// Automation. Distinct from [`PlacementOutcome::VerifiedNoFit`], which
+    /// is conclusive.
+    TransientLandmarks,
+}
+
+impl std::fmt::Display for PrepareFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            PrepareFailure::Disabled => "Native taskbar mode is disabled",
+            PrepareFailure::NoProviders => {
+                "No enabled providers are available for the taskbar widget"
+            }
+            PrepareFailure::TransientLandmarks => {
+                "No verified taskbar lane can fit the native widget"
+            }
+        })
+    }
+}
+
+struct PreparedWidget {
+    taskbar: isize,
+    placement: ChildPlacement,
+}
+
+struct PreparedWidgets {
+    widgets: Vec<PreparedWidget>,
+    rejected_taskbars: Vec<isize>,
+    all_monitors: bool,
+    model: WidgetModel,
+}
+
+/// Pure mapping from a preparation attempt to the status it implies, absent
+/// debounce. `None` for [`PrepareFailure::TransientLandmarks`]: the caller
+/// must consult the debounce counter (see [`should_report_waiting_landmarks`])
+/// to decide whether to keep the previous status or surface
+/// `WaitingLandmarks`.
+fn status_from_preparation(
+    prepared: &Result<PreparedWidgets, PrepareFailure>,
+) -> Option<TaskbarWidgetStatus> {
+    match prepared {
+        Ok(prepared) if !prepared.widgets.is_empty() => Some(TaskbarWidgetStatus::Active {
+            taskbars: prepared.widgets.len(),
+        }),
+        Ok(_) => Some(TaskbarWidgetStatus::NoFit),
+        Err(PrepareFailure::Disabled) => Some(TaskbarWidgetStatus::Disabled),
+        Err(PrepareFailure::NoProviders) => Some(TaskbarWidgetStatus::NoProviders),
+        Err(PrepareFailure::TransientLandmarks) => None,
+    }
+}
+
+/// Whether `streak` consecutive transient-landmark misses should flip the
+/// status to `WaitingLandmarks`. Pure so the debounce threshold is testable
+/// without touching the watchdog's global counter.
+fn should_report_waiting_landmarks(streak: u32) -> bool {
+    streak >= TRANSIENT_LANDMARKS_DEBOUNCE
+}
+
 pub fn install(app: &tauri::AppHandle) {
     #[cfg(windows)]
     windows_host::install(app);
@@ -552,12 +643,23 @@ pub fn get_taskbar_surface_color() -> Option<String> {
     None
 }
 
+/// Current native taskbar widget visibility, mirrored from the same
+/// watchdog pass that shows or hides the strip, so the Settings row and the
+/// strip never disagree.
+#[tauri::command]
+pub fn get_taskbar_widget_status() -> TaskbarWidgetStatus {
+    #[cfg(windows)]
+    return windows_host::current_status();
+    #[cfg(not(windows))]
+    TaskbarWidgetStatus::Unavailable
+}
+
 #[cfg(windows)]
 mod windows_host {
     use super::*;
     use std::sync::{
         Mutex, OnceLock,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
     };
     use tauri::Manager;
 
@@ -612,24 +714,14 @@ mod windows_host {
         model: WidgetModel,
     }
 
-    struct PreparedWidget {
-        taskbar: isize,
-        placement: ChildPlacement,
-    }
-
-    struct PreparedWidgets {
-        widgets: Vec<PreparedWidget>,
-        rejected_taskbars: Vec<isize>,
-        all_monitors: bool,
-        model: WidgetModel,
-    }
-
     static APP: OnceLock<tauri::AppHandle> = OnceLock::new();
     static HOST: OnceLock<Mutex<HostState>> = OnceLock::new();
     static CLASS_REGISTERED: OnceLock<bool> = OnceLock::new();
     static RECOVERY_PENDING: AtomicBool = AtomicBool::new(false);
     static HOVER_TRACKING: AtomicBool = AtomicBool::new(false);
     static HOVER_FLYOUT_OPEN: AtomicBool = AtomicBool::new(false);
+    static STATUS: Mutex<TaskbarWidgetStatus> = Mutex::new(TaskbarWidgetStatus::Disabled);
+    static TRANSIENT_STREAK: AtomicU32 = AtomicU32::new(0);
 
     pub(super) fn install(app: &tauri::AppHandle) {
         let _ = APP.set(app.clone());
@@ -659,6 +751,31 @@ mod windows_host {
             schedule_recovery(app);
         } else {
             hide_existing();
+            TRANSIENT_STREAK.store(0, Ordering::Release);
+            set_status(app, TaskbarWidgetStatus::Disabled);
+        }
+    }
+
+    pub(super) fn current_status() -> TaskbarWidgetStatus {
+        STATUS
+            .lock()
+            .map(|guard| guard.clone())
+            .unwrap_or(TaskbarWidgetStatus::Disabled)
+    }
+
+    /// Persist the widget status and emit `taskbar-widget-status-changed`
+    /// only when it actually changes, so Settings doesn't re-fetch on every
+    /// watchdog tick.
+    fn set_status(app: &tauri::AppHandle, status: TaskbarWidgetStatus) {
+        let changed = match STATUS.lock() {
+            Ok(mut guard) if *guard != status => {
+                *guard = status;
+                true
+            }
+            _ => false,
+        };
+        if changed {
+            crate::events::emit_taskbar_widget_status_changed(app);
         }
     }
 
@@ -716,20 +833,43 @@ mod windows_host {
         let app = app.clone();
         tauri::async_runtime::spawn(async move {
             let prepared = tauri::async_runtime::spawn_blocking(prepare_widgets).await;
+            let status_app = app.clone();
             let dispatched = app.run_on_main_thread(move || {
                 match prepared {
-                    Ok(Ok(prepared)) => {
-                        if let Err(error) = apply_prepared(prepared) {
-                            tracing::warn!(%error, "Native taskbar widget proof update failed");
+                    Ok(outcome) => {
+                        let status = status_from_preparation(&outcome);
+                        match outcome {
+                            Ok(prepared) => {
+                                TRANSIENT_STREAK.store(0, Ordering::Release);
+                                if let Err(error) = apply_prepared(prepared) {
+                                    tracing::warn!(%error, "Native taskbar widget proof update failed");
+                                } else if let Some(status) = status {
+                                    set_status(&status_app, status);
+                                }
+                            }
+                            Err(error @ PrepareFailure::TransientLandmarks) => {
+                                // Start, Search, Widgets, and other Explorer surfaces
+                                // can temporarily make UI Automation landmarks
+                                // unavailable. Keep the last known healthy child
+                                // visible rather than turning a transient discovery
+                                // miss into user-visible flicker and a slow
+                                // rediscovery cycle; only report `WaitingLandmarks`
+                                // after several consecutive misses so a single
+                                // missed watchdog tick doesn't flash the Settings row.
+                                let streak = TRANSIENT_STREAK.fetch_add(1, Ordering::AcqRel) + 1;
+                                tracing::debug!(%error, streak, "Native taskbar widget recovery deferred; preserving the current widget");
+                                if should_report_waiting_landmarks(streak) {
+                                    set_status(&status_app, TaskbarWidgetStatus::WaitingLandmarks);
+                                }
+                            }
+                            Err(error) => {
+                                TRANSIENT_STREAK.store(0, Ordering::Release);
+                                tracing::debug!(%error, "Native taskbar widget recovery deferred; preserving the current widget");
+                                if let Some(status) = status {
+                                    set_status(&status_app, status);
+                                }
+                            }
                         }
-                    }
-                    Ok(Err(error)) => {
-                        // Start, Search, Widgets, and other Explorer surfaces can
-                        // temporarily make UI Automation landmarks unavailable.
-                        // Keep the last known healthy child visible rather than
-                        // turning a transient discovery miss into user-visible
-                        // flicker and a slow rediscovery cycle.
-                        tracing::debug!(%error, "Native taskbar widget recovery deferred; preserving the current widget");
                     }
                     Err(error) => {
                         tracing::warn!(%error, "Native taskbar discovery worker failed; preserving the current widget");
@@ -743,14 +883,23 @@ mod windows_host {
         });
     }
 
-    fn prepare_widgets() -> Result<PreparedWidgets, String> {
+    fn prepare_widgets() -> Result<PreparedWidgets, PrepareFailure> {
         let settings = codexbar::settings::Settings::load();
         if !native_mode_enabled(&settings) {
-            return Err("Native taskbar mode is disabled".to_string());
+            return Err(PrepareFailure::Disabled);
         }
-        let model = widget_model()?;
+        let model = match widget_model() {
+            Ok(model) => model,
+            Err(error) => {
+                // App-handle/state-poisoning failures are internal and rare;
+                // fold them into the transient-landmarks bucket rather than
+                // adding a fourth status the UI cannot act on differently.
+                tracing::debug!(%error, "Native taskbar widget model unavailable this pass");
+                return Err(PrepareFailure::TransientLandmarks);
+            }
+        };
         if model.providers.is_empty() {
-            return Err("No enabled providers are available for the taskbar widget".to_string());
+            return Err(PrepareFailure::NoProviders);
         }
         let layouts = crate::floatbar::taskbar::discover_all();
         let (_, rejected_taskbars, placements) = taskbar_placements(
@@ -763,7 +912,7 @@ mod windows_host {
             .map(|(taskbar, placement)| PreparedWidget { taskbar, placement })
             .collect::<Vec<_>>();
         if widgets.is_empty() && rejected_taskbars.is_empty() {
-            return Err("No verified taskbar lane can fit the native widget".to_string());
+            return Err(PrepareFailure::TransientLandmarks);
         }
 
         Ok(PreparedWidgets {
@@ -2711,5 +2860,80 @@ mod tests {
         let cache = [calm_session, busy_session];
         let picked = select_strip_snapshot(cache.iter(), "claude", None).unwrap();
         assert_eq!(picked.account_id.as_deref(), Some("a"));
+    }
+
+    fn prepared_widgets(taskbar_count: usize, rejected_count: usize) -> PreparedWidgets {
+        PreparedWidgets {
+            widgets: (0..taskbar_count)
+                .map(|index| PreparedWidget {
+                    taskbar: index as isize + 1,
+                    placement: ChildPlacement {
+                        x: 0,
+                        y: 0,
+                        width: 104,
+                        height: 48,
+                    },
+                })
+                .collect(),
+            rejected_taskbars: (0..rejected_count)
+                .map(|index| index as isize + 100)
+                .collect(),
+            all_monitors: false,
+            model: WidgetModel::default(),
+        }
+    }
+
+    #[test]
+    fn status_from_preparation_reports_active_with_the_taskbar_count() {
+        let result: Result<PreparedWidgets, PrepareFailure> = Ok(prepared_widgets(2, 0));
+        assert_eq!(
+            status_from_preparation(&result),
+            Some(TaskbarWidgetStatus::Active { taskbars: 2 })
+        );
+    }
+
+    #[test]
+    fn status_from_preparation_reports_no_fit_when_every_taskbar_is_rejected() {
+        let result: Result<PreparedWidgets, PrepareFailure> = Ok(prepared_widgets(0, 1));
+        assert_eq!(
+            status_from_preparation(&result),
+            Some(TaskbarWidgetStatus::NoFit)
+        );
+    }
+
+    #[test]
+    fn status_from_preparation_maps_disabled_and_no_providers() {
+        assert_eq!(
+            status_from_preparation(&Err(PrepareFailure::Disabled)),
+            Some(TaskbarWidgetStatus::Disabled)
+        );
+        assert_eq!(
+            status_from_preparation(&Err(PrepareFailure::NoProviders)),
+            Some(TaskbarWidgetStatus::NoProviders)
+        );
+    }
+
+    #[test]
+    fn status_from_preparation_defers_transient_landmarks_to_the_debounce() {
+        assert_eq!(
+            status_from_preparation(&Err(PrepareFailure::TransientLandmarks)),
+            None
+        );
+    }
+
+    #[test]
+    fn debounce_waits_for_six_consecutive_transient_misses() {
+        for streak in 1..TRANSIENT_LANDMARKS_DEBOUNCE {
+            assert!(
+                !should_report_waiting_landmarks(streak),
+                "streak {streak} should not yet report WaitingLandmarks"
+            );
+        }
+        assert!(should_report_waiting_landmarks(
+            TRANSIENT_LANDMARKS_DEBOUNCE
+        ));
+        assert!(should_report_waiting_landmarks(
+            TRANSIENT_LANDMARKS_DEBOUNCE + 1
+        ));
     }
 }

--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -618,6 +618,19 @@ fn should_report_waiting_landmarks(streak: u32) -> bool {
     streak >= TRANSIENT_LANDMARKS_DEBOUNCE
 }
 
+/// Status to report while `apply_state` keeps the widget hidden. Native mode
+/// on without a configured provider must surface as `NoProviders`: the
+/// Settings row hides `Disabled`, which would leave that misconfiguration
+/// silent — the exact failure mode this status exists to prevent.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn status_when_hidden(native_mode_enabled: bool) -> TaskbarWidgetStatus {
+    if native_mode_enabled {
+        TaskbarWidgetStatus::NoProviders
+    } else {
+        TaskbarWidgetStatus::Disabled
+    }
+}
+
 pub fn install(app: &tauri::AppHandle) {
     #[cfg(windows)]
     windows_host::install(app);
@@ -752,7 +765,7 @@ mod windows_host {
         } else {
             hide_existing();
             TRANSIENT_STREAK.store(0, Ordering::Release);
-            set_status(app, TaskbarWidgetStatus::Disabled);
+            set_status(app, status_when_hidden(native_mode_enabled(settings)));
         }
     }
 
@@ -2919,6 +2932,12 @@ mod tests {
             status_from_preparation(&Err(PrepareFailure::TransientLandmarks)),
             None
         );
+    }
+
+    #[test]
+    fn hidden_state_reports_no_providers_while_native_mode_is_still_enabled() {
+        assert_eq!(status_when_hidden(true), TaskbarWidgetStatus::NoProviders);
+        assert_eq!(status_when_hidden(false), TaskbarWidgetStatus::Disabled);
     }
 
     #[test]

--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -770,25 +770,54 @@ mod windows_host {
     }
 
     pub(super) fn current_status() -> TaskbarWidgetStatus {
+        // A poisoned lock still holds the last stored status. Recover it: a
+        // possibly-stale reading beats reporting `Disabled`, which would hide
+        // the status row — the silent failure this feature exists to prevent.
         STATUS
             .lock()
-            .map(|guard| guard.clone())
-            .unwrap_or(TaskbarWidgetStatus::Disabled)
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
     }
 
     /// Persist the widget status and emit `taskbar-widget-status-changed`
     /// only when it actually changes, so Settings doesn't re-fetch on every
     /// watchdog tick.
     fn set_status(app: &tauri::AppHandle, status: TaskbarWidgetStatus) {
-        let changed = match STATUS.lock() {
-            Ok(mut guard) if *guard != status => {
+        let changed = {
+            let mut guard = STATUS
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if *guard != status {
                 *guard = status;
                 true
+            } else {
+                false
             }
-            _ => false,
         };
         if changed {
             crate::events::emit_taskbar_widget_status_changed(app);
+        }
+    }
+
+    #[cfg(test)]
+    mod status_lock_tests {
+        use super::*;
+
+        #[test]
+        fn current_status_survives_a_poisoned_lock() {
+            *STATUS
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+                TaskbarWidgetStatus::Active { taskbars: 2 };
+            let poisoner = std::thread::spawn(|| {
+                let _guard = STATUS.lock();
+                panic!("poison the status lock");
+            });
+            assert!(poisoner.join().is_err());
+            assert_eq!(
+                current_status(),
+                TaskbarWidgetStatus::Active { taskbars: 2 }
+            );
         }
     }
 

--- a/apps/desktop-tauri/src/floatbar/SettingsSection.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/SettingsSection.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SettingsSnapshot, TaskbarWidgetStatus } from "../types/bridge";
 import FloatBarSettingsSection from "./SettingsSection";
@@ -14,8 +14,12 @@ vi.mock("../lib/tauri", () => ({
   getTaskbarWidgetStatus: () => getTaskbarWidgetStatus(),
 }));
 
+const statusListeners = vi.hoisted(() => [] as Array<() => void>);
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
+  listen: vi.fn((event: string, handler: () => void) => {
+    if (event === "taskbar-widget-status-changed") statusListeners.push(handler);
+    return Promise.resolve(() => {});
+  }),
 }));
 
 const settings = {
@@ -44,6 +48,7 @@ describe("FloatBar settings", () => {
   beforeEach(() => {
     getDirectoryAccounts.mockResolvedValue([]);
     getTaskbarWidgetStatus.mockResolvedValue({ kind: "active", taskbars: 1 });
+    statusListeners.length = 0;
   });
 
   it("does not offer the legacy API-equivalent cost toggle", () => {
@@ -265,6 +270,41 @@ describe("FloatBar settings", () => {
     );
 
     expect(await screen.findByRole("status")).toHaveTextContent(text);
+  });
+
+  it("ignores a stale status read that resolves after a newer one", async () => {
+    let resolveFirst!: (status: TaskbarWidgetStatus) => void;
+    let resolveSecond!: (status: TaskbarWidgetStatus) => void;
+    getTaskbarWidgetStatus.mockClear();
+    getTaskbarWidgetStatus
+      .mockReturnValueOnce(
+        new Promise<TaskbarWidgetStatus>((resolve) => {
+          resolveFirst = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise<TaskbarWidgetStatus>((resolve) => {
+          resolveSecond = resolve;
+        }),
+      );
+    render(
+      <FloatBarSettingsSection settings={settings} saving={false} set={vi.fn()} />,
+    );
+
+    await waitFor(() => expect(statusListeners.length).toBeGreaterThan(0));
+    statusListeners[0]();
+    await waitFor(() => expect(getTaskbarWidgetStatus).toHaveBeenCalledTimes(2));
+
+    resolveSecond({ kind: "noFit" });
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Hidden: no free space on the taskbar between Widgets and Start.",
+    );
+
+    resolveFirst({ kind: "active", taskbars: 3 });
+    await act(async () => {});
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Hidden: no free space on the taskbar between Widgets and Start.",
+    );
   });
 
   it("hides the status row when the native widget is disabled or unavailable", async () => {

--- a/apps/desktop-tauri/src/floatbar/SettingsSection.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/SettingsSection.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { SettingsSnapshot } from "../types/bridge";
+import type { SettingsSnapshot, TaskbarWidgetStatus } from "../types/bridge";
 import FloatBarSettingsSection from "./SettingsSection";
 
 vi.mock("../hooks/useLocale", () => ({
@@ -8,8 +8,14 @@ vi.mock("../hooks/useLocale", () => ({
 }));
 
 const getDirectoryAccounts = vi.fn();
+const getTaskbarWidgetStatus = vi.fn();
 vi.mock("../lib/tauri", () => ({
   getDirectoryAccounts: () => getDirectoryAccounts(),
+  getTaskbarWidgetStatus: () => getTaskbarWidgetStatus(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
 }));
 
 const settings = {
@@ -37,6 +43,7 @@ const settings = {
 describe("FloatBar settings", () => {
   beforeEach(() => {
     getDirectoryAccounts.mockResolvedValue([]);
+    getTaskbarWidgetStatus.mockResolvedValue({ kind: "active", taskbars: 1 });
   });
 
   it("does not offer the legacy API-equivalent cost toggle", () => {
@@ -228,5 +235,62 @@ describe("FloatBar settings", () => {
     expect(
       screen.queryByRole("combobox", { name: /Taskbar account/ }),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows how many taskbars the widget is active on", async () => {
+    getTaskbarWidgetStatus.mockResolvedValue({ kind: "active", taskbars: 2 });
+    render(
+      <FloatBarSettingsSection settings={settings} saving={false} set={vi.fn()} />,
+    );
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Shown on 2 taskbars.",
+    );
+  });
+
+  it.each<[TaskbarWidgetStatus, string]>([
+    [
+      { kind: "noFit" },
+      "Hidden: no free space on the taskbar between Widgets and Start.",
+    ],
+    [
+      { kind: "waitingLandmarks" },
+      "Waiting for taskbar landmarks (Start button not found). A taskbar mod may be interfering.",
+    ],
+    [{ kind: "noProviders" }, "No enabled providers to show."],
+  ])("surfaces the %o status as a status row", async (status, text) => {
+    getTaskbarWidgetStatus.mockResolvedValue(status);
+    render(
+      <FloatBarSettingsSection settings={settings} saving={false} set={vi.fn()} />,
+    );
+
+    expect(await screen.findByRole("status")).toHaveTextContent(text);
+  });
+
+  it("hides the status row when the native widget is disabled or unavailable", async () => {
+    for (const status of [{ kind: "disabled" }, { kind: "unavailable" }] as const) {
+      getTaskbarWidgetStatus.mockResolvedValue(status);
+      const { unmount } = render(
+        <FloatBarSettingsSection settings={settings} saving={false} set={vi.fn()} />,
+      );
+
+      await waitFor(() => expect(getTaskbarWidgetStatus).toHaveBeenCalled());
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it("hides the status row when Show Taskbar Usage is off, even with an active status", async () => {
+    getTaskbarWidgetStatus.mockResolvedValue({ kind: "active", taskbars: 1 });
+    render(
+      <FloatBarSettingsSection
+        settings={{ ...settings, taskbarWidgetEnabled: false }}
+        saving={false}
+        set={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(getTaskbarWidgetStatus).toHaveBeenCalled());
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop-tauri/src/floatbar/SettingsSection.tsx
+++ b/apps/desktop-tauri/src/floatbar/SettingsSection.tsx
@@ -124,10 +124,14 @@ export default function FloatBarSettingsSection({ settings, saving, set }: Props
   );
   useEffect(() => {
     let cancelled = false;
+    let latestRequest = 0;
     const refreshTaskbarStatus = () => {
+      const request = ++latestRequest;
       getTaskbarWidgetStatus()
         .then((status) => {
-          if (!cancelled) setTaskbarStatus(status);
+          // Reads race: a re-fetch triggered by a newer status event may
+          // resolve before an older one. Only the latest request may write.
+          if (!cancelled && request === latestRequest) setTaskbarStatus(status);
         })
         .catch(() => {
           // Leave the last known status in place if the read fails.

--- a/apps/desktop-tauri/src/floatbar/SettingsSection.tsx
+++ b/apps/desktop-tauri/src/floatbar/SettingsSection.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
 import { Field, Select, Toggle } from "../components/FormControls";
 import { ProviderIcon } from "../components/providers/ProviderIcon";
-import { getDirectoryAccounts } from "../lib/tauri";
+import { getDirectoryAccounts, getTaskbarWidgetStatus } from "../lib/tauri";
 import type {
   FloatBarOrientation,
   FloatBarContrast,
@@ -10,6 +11,7 @@ import type {
   ProviderAccountsBridge,
   SettingsSnapshot,
   SettingsUpdate,
+  TaskbarWidgetStatus,
 } from "../types/bridge";
 
 /** Keep in sync with `MAX_TASKBAR_WIDGET_PROVIDERS` in taskbar_widget.rs. */
@@ -33,6 +35,24 @@ interface Props {
 
 function providerLabel(id: string): string {
   return PROVIDER_LABELS[id] ?? id.charAt(0).toUpperCase() + id.slice(1);
+}
+
+/** English status line for the Taskbar Usage group; `null` hides the row. */
+function taskbarWidgetStatusMessage(status: TaskbarWidgetStatus | null): string | null {
+  if (!status) return null;
+  switch (status.kind) {
+    case "active":
+      return `Shown on ${status.taskbars} taskbar${status.taskbars === 1 ? "" : "s"}.`;
+    case "noFit":
+      return "Hidden: no free space on the taskbar between Widgets and Start.";
+    case "waitingLandmarks":
+      return "Waiting for taskbar landmarks (Start button not found). A taskbar mod may be interfering.";
+    case "noProviders":
+      return "No enabled providers to show.";
+    case "disabled":
+    case "unavailable":
+      return null;
+  }
 }
 
 /** Providers that can track more than one config-directory account. */
@@ -98,6 +118,40 @@ export default function FloatBarSettingsSection({ settings, saving, set }: Props
   const commitScale = () => {
     scale.commit(scale.draft, (value) => set({ floatBarScale: value }));
   };
+
+  const [taskbarStatus, setTaskbarStatus] = useState<TaskbarWidgetStatus | null>(
+    null,
+  );
+  useEffect(() => {
+    let cancelled = false;
+    const refreshTaskbarStatus = () => {
+      getTaskbarWidgetStatus()
+        .then((status) => {
+          if (!cancelled) setTaskbarStatus(status);
+        })
+        .catch(() => {
+          // Leave the last known status in place if the read fails.
+        });
+    };
+    refreshTaskbarStatus();
+
+    let unlisten: (() => void) | undefined;
+    Promise.resolve(listen("taskbar-widget-status-changed", refreshTaskbarStatus))
+      .then((fn) => {
+        if (cancelled) {
+          fn?.();
+        } else {
+          unlisten = fn;
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+  const taskbarStatusMessage = taskbarWidgetStatusMessage(taskbarStatus);
 
   const [directoryAccounts, setDirectoryAccounts] = useState<
     ProviderAccountsBridge[]
@@ -242,6 +296,11 @@ export default function FloatBarSettingsSection({ settings, saving, set }: Props
               onChange={(v) => set({ floatBarShowResetInline: v })}
             />
           </Field>
+          {settings.taskbarWidgetEnabled && taskbarStatusMessage && (
+            <p className="settings-section__hint" role="status">
+              {taskbarStatusMessage}
+            </p>
+          )}
         </div>
 
         <div className="settings-section__group taskbar-provider-picker">

--- a/apps/desktop-tauri/src/lib/tauri.ts
+++ b/apps/desktop-tauri/src/lib/tauri.ts
@@ -32,6 +32,7 @@ import type {
   RegionOption,
   SafeDiagnostics,
   CredentialStorageStatus,
+  TaskbarWidgetStatus,
   WorkAreaRect,
   AgentSession,
   AgentSessionDiscoveryResult,
@@ -88,6 +89,11 @@ export function dismissTrayPanel(): Promise<void> {
 /** Sample the current Windows taskbar material for the native glance flyout. */
 export function getTaskbarSurfaceColor(): Promise<string | null> {
   return invoke<string | null>("get_taskbar_surface_color");
+}
+
+/** Current native taskbar widget visibility, and why it's hidden if so. */
+export function getTaskbarWidgetStatus(): Promise<TaskbarWidgetStatus> {
+  return invoke<TaskbarWidgetStatus>("get_taskbar_widget_status");
 }
 
 /** Hide the primary dashboard while Ceiling continues running in the tray. */

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -207,6 +207,15 @@ export interface ProviderSummary {
   order: number;
 }
 
+/** Mirrors the Rust `TaskbarWidgetStatus` enum (`taskbar_widget.rs`). */
+export type TaskbarWidgetStatus =
+  | { kind: "unavailable" }
+  | { kind: "disabled" }
+  | { kind: "noProviders" }
+  | { kind: "waitingLandmarks" }
+  | { kind: "noFit" }
+  | { kind: "active"; taskbars: number };
+
 export interface SettingsSnapshot {
   enabledProviders: string[];
   providerOrder?: string[];


### PR DESCRIPTION
First step toward #261: the native taskbar strip can be hidden by placement outcomes (`VerifiedNoFit`, persistent `TransientLandmarks`) with no feedback anywhere, which makes it look broken — especially under taskbar mods. This PR makes those states visible in Settings without changing any placement behavior or defaults.

## What changed

- The Settings "Taskbar Usage" group now shows a live status row: "Shown on N taskbar(s).", "Hidden: no free space on the taskbar between Widgets and Start.", "Waiting for taskbar landmarks (Start button not found). A taskbar mod may be interfering.", or "No enabled providers to show." The row is hidden when the widget is disabled (or on non-Windows).
- Backend: `prepare_widgets`' stringly errors became a typed `PrepareFailure` enum; the watchdog's completion path maps each pass to a `TaskbarWidgetStatus` stored next to the host state. Transient landmark misses are debounced (6 consecutive watchdog ticks, ~30s) before reporting "waiting", mirroring the existing keep-the-widget-visible policy, so a Start/Search flyout opening never flashes the row.
- A payload-less `taskbar-widget-status-changed` event (same idiom as `settings-changed`) plus a `get_taskbar_widget_status` command; the row re-fetches on event. Emitted only on actual status transitions.
- Status is set only after `apply_prepared` succeeds, so the row can never newly claim "shown" when the Win32 side failed; an existing "Shown" status persists through a transient apply failure until the next conclusive outcome (the watchdog retries every 5s).

No placement logic changed; all pre-existing tests pass unmodified. New unit tests cover the status mapping and debounce (pure, no Win32) and the Settings row rendering per status.

Interesting data point while validating: with Windhawk's "Start button always on left" active, the reported state is the *no-fit* one, not *waiting* — Start stays discoverable when pinned left; it's the collapsed lane that hides the strip. That matches the analysis in #261.

## Commands run

```
cargo fmt --all
cargo test --manifest-path rust\Cargo.toml
cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml
cargo clippy --manifest-path rust\Cargo.toml --all-targets -- -D warnings
cargo clippy --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml --all-targets -- -D warnings
pnpm --dir apps/desktop-tauri test
pnpm --dir apps/desktop-tauri run build
```

All green: 872 + 491 Rust tests, 488 frontend tests, clippy clean with `-D warnings`, `tsc` + vite build OK.

## Screenshots

**Widget visible (normal taskbar):**

<img width="600" height="580" alt="ceiling-show" src="https://github.com/user-attachments/assets/1a422cd2-38f9-495c-952c-67b96a17988a" />


**Widget hidden under Windhawk "Start button always on left" — previously silent, now explained:**

<img width="600" height="580" alt="ceiling-hidden" src="https://github.com/user-attachments/assets/ab86a892-6ffd-4a81-a6b1-49b0f56ce52b" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added taskbar widget status reporting in Settings.
  * Displays guidance for unavailable, disabled, waiting, or unsupported widget states.
  * Shows the number of active taskbars when the widget is running.
  * Updates status automatically when taskbar widget visibility changes.

* **Bug Fixes**
  * Prevents temporary landmark detection issues from immediately disrupting existing widgets.
  * Preserves the last known status when status checks temporarily fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
