### PR TITLE
Pin checkout on the persistent PR review runner

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -43,7 +43,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # PR head, not the base: the file inventory and cited-region
           # evidence must describe the code under review. The contents are


### PR DESCRIPTION
## Summary

- pin `actions/checkout` to the reviewed v6 commit already used by the release workflows
- remove the last mutable action reference from the privileged persistent PR-review runner
- preserve the owner-only `pull_request_target` guard and explicit PR-head checkout

## Validation

- `git diff --check`
- verified `df4cb1c069e1874edd31b4311f1884172cec0e10` resolves in `actions/checkout`
- searched workflows for remaining mutable `actions/checkout@vN` references

Linear: SBS-725