### PR TITLE
Isolate chart data by account

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -24,10 +24,9 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const LOCAL_USAGE_TTL: Duration = Duration::from_secs(30);
 const CHART_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
-// Version 7: Codex priority/fast (2x) pricing for local cost. Entries cached at
-// version 6 still hold pre-2x standard dollars for reset windows, so the
-// Weekly window card could show ~half of the API-value ring after 1.5.13.
-const CHART_CACHE_VERSION: u8 = 8;
+// Version 9: account scope is part of every chart cache key. Older entries can
+// conflate an unresolved account with the machine-wide scan.
+const CHART_CACHE_VERSION: u8 = 9;
 
 /// A single (date, value) point for cost or credits history charts.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -340,7 +339,93 @@ pub struct ProviderChartData {
     pub usage_breakdown: Vec<DailyUsageBreakdown>,
     pub local_usage: Option<ProviderLocalUsageSummary>,
     #[serde(default)]
+    pub local_usage_scope: LocalUsageScope,
+    #[serde(default)]
     pub quota_history: Vec<crate::usage_history::UsageHistoryPoint>,
+}
+
+/// Scope used for local transcript-derived usage in this response.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum LocalUsageScope {
+    #[default]
+    MachineWide,
+    Account,
+    UnresolvedAccount,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ChartAccountScope {
+    MachineWide,
+    Account {
+        account_id: String,
+        config_dir: PathBuf,
+    },
+    UnresolvedAccount {
+        account_id: String,
+    },
+}
+
+impl ChartAccountScope {
+    fn kind(&self) -> LocalUsageScope {
+        match self {
+            Self::MachineWide => LocalUsageScope::MachineWide,
+            Self::Account { .. } => LocalUsageScope::Account,
+            Self::UnresolvedAccount { .. } => LocalUsageScope::UnresolvedAccount,
+        }
+    }
+
+    fn cache_identity(
+        &self,
+        account_email: Option<&str>,
+        account_organization: Option<&str>,
+    ) -> String {
+        match self {
+            Self::Account { account_id, .. } => {
+                format!("account:{}", account_id.trim().to_ascii_lowercase())
+            }
+            Self::UnresolvedAccount { account_id } => {
+                format!("unresolved:{}", account_id.trim().to_ascii_lowercase())
+            }
+            Self::MachineWide => {
+                let identity = account_email
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .or_else(|| {
+                        account_organization
+                            .map(str::trim)
+                            .filter(|value| !value.is_empty())
+                    })
+                    .unwrap_or("anonymous")
+                    .to_ascii_lowercase();
+                format!("machine:{identity}")
+            }
+        }
+    }
+}
+
+fn resolve_chart_account_scope(
+    provider_id: &str,
+    account_id: Option<&str>,
+    accounts: &codexbar::core::ConfiguredAccounts,
+) -> ChartAccountScope {
+    let Some(account_id) = account_id.map(str::trim).filter(|value| !value.is_empty()) else {
+        return ChartAccountScope::MachineWide;
+    };
+    let Some(provider) = codexbar::core::ProviderId::from_cli_name(provider_id) else {
+        return ChartAccountScope::UnresolvedAccount {
+            account_id: account_id.to_string(),
+        };
+    };
+    match accounts.config_dir_for_account(provider, account_id) {
+        Some(config_dir) => ChartAccountScope::Account {
+            account_id: account_id.to_string(),
+            config_dir,
+        },
+        None => ChartAccountScope::UnresolvedAccount {
+            account_id: account_id.to_string(),
+        },
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -395,21 +480,21 @@ pub async fn get_provider_chart_data(
     account_organization: Option<String>,
 ) -> ProviderChartData {
     let usage_windows = usage_windows.unwrap_or_default();
-    // An account's local logs live under its own config directory. Scanning
-    // that directory is what makes its charts distinct from another account's;
-    // without it every account shows the same machine-wide totals.
-    let scoped_home = account_id.as_deref().and_then(|id| {
-        codexbar::core::ProviderId::from_cli_name(&provider_id).and_then(|provider| {
-            codexbar::core::ConfiguredAccounts::load().config_dir_for_account(provider, id)
-        })
-    });
+    // Missing account identity is the intentional machine-wide case. A supplied
+    // id that no longer resolves must stay distinct: silently treating it as
+    // machine-wide can display another account's activity under the stale id.
+    let account_scope = resolve_chart_account_scope(
+        &provider_id,
+        account_id.as_deref(),
+        &codexbar::core::ConfiguredAccounts::load(),
+    );
     let cache_key = chart_cache_key(
         &provider_id,
         account_email.as_deref(),
-        account_id.as_deref(),
         account_organization.as_deref(),
         source_label.as_deref(),
         &usage_windows,
+        &account_scope,
     );
     if let Some(mut cached) = cached_chart_data(&cache_key) {
         cached.data.quota_history = crate::usage_history::provider_history(
@@ -427,7 +512,7 @@ pub async fn get_provider_chart_data(
                 account_email,
                 account_id,
                 account_organization,
-                scoped_home.clone(),
+                account_scope.clone(),
                 usage_windows,
             );
         }
@@ -441,7 +526,8 @@ pub async fn get_provider_chart_data(
         account_organization.as_deref(),
     );
     if !quota_history.is_empty() {
-        let mut immediate = ProviderChartData::empty(provider_id.clone());
+        let mut immediate =
+            ProviderChartData::empty_with_scope(provider_id.clone(), account_scope.kind());
         immediate.quota_history = quota_history;
         schedule_chart_cache_refresh(
             cache_key,
@@ -449,13 +535,14 @@ pub async fn get_provider_chart_data(
             account_email,
             account_id,
             account_organization,
-            scoped_home.clone(),
+            account_scope.clone(),
             usage_windows,
         );
         return immediate;
     }
 
     let fallback_provider_id = provider_id.clone();
+    let fallback_scope = account_scope.kind();
     let cancel = register_chart_scan(&provider_id);
     let result = tauri::async_runtime::spawn_blocking(move || {
         build_provider_chart_data_with_cancel(
@@ -463,7 +550,7 @@ pub async fn get_provider_chart_data(
             account_email,
             account_id,
             account_organization,
-            scoped_home,
+            account_scope,
             usage_windows,
             Some(cancel),
         )
@@ -471,7 +558,7 @@ pub async fn get_provider_chart_data(
     .await
     .unwrap_or_else(|err| {
         tracing::warn!("Provider chart data worker failed: {}", err);
-        ProviderChartData::empty(fallback_provider_id)
+        ProviderChartData::empty_with_scope(fallback_provider_id, fallback_scope)
     });
     store_chart_data(cache_key, result.clone());
     result
@@ -512,7 +599,7 @@ fn schedule_chart_cache_refresh(
     account_email: Option<String>,
     account_id: Option<String>,
     account_organization: Option<String>,
-    scoped_home: Option<std::path::PathBuf>,
+    account_scope: ChartAccountScope,
     usage_windows: Vec<LocalUsageWindowRequest>,
 ) {
     let Ok(mut active) = active_cache_refreshes().lock() else {
@@ -531,7 +618,7 @@ fn schedule_chart_cache_refresh(
                 account_email,
                 account_id,
                 account_organization,
-                scoped_home,
+                account_scope,
                 usage_windows,
                 None,
             )
@@ -550,26 +637,12 @@ fn schedule_chart_cache_refresh(
 fn chart_cache_key(
     provider_id: &str,
     account_email: Option<&str>,
-    account_id: Option<&str>,
     account_organization: Option<&str>,
     source_label: Option<&str>,
     usage_windows: &[LocalUsageWindowRequest],
+    account_scope: &ChartAccountScope,
 ) -> String {
-    let identity = account_id
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .or_else(|| {
-            account_email
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-        })
-        .or_else(|| {
-            account_organization
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-        })
-        .unwrap_or("anonymous")
-        .to_ascii_lowercase();
+    let identity = account_scope.cache_identity(account_email, account_organization);
     let windows = usage_windows
         .iter()
         .map(|window| format!("{}:{}:{}", window.id, window.starts_at, window.ends_at))
@@ -1161,7 +1234,7 @@ pub(crate) fn build_provider_chart_data(
         account_email,
         None,
         None,
-        None,
+        ChartAccountScope::MachineWide,
         Vec::new(),
         None,
     )
@@ -1172,7 +1245,7 @@ fn build_provider_chart_data_with_cancel(
     account_email: Option<String>,
     account_id: Option<String>,
     account_organization: Option<String>,
-    scoped_home: Option<std::path::PathBuf>,
+    account_scope: ChartAccountScope,
     usage_window_requests: Vec<LocalUsageWindowRequest>,
     cancel: Option<Arc<AtomicBool>>,
 ) -> ProviderChartData {
@@ -1197,7 +1270,15 @@ fn build_provider_chart_data_with_cancel(
     // reset-aligned windows so one pass over the logs serves both.
     let (comparison_specs, comparison_windows) = comparison_period_specs(Utc::now());
     usage_windows.extend(comparison_windows);
-    let report = get_cost_usage_report_scoped(&provider_id, 30, &usage_windows, scoped_home);
+    let report = match &account_scope {
+        ChartAccountScope::MachineWide => {
+            get_cost_usage_report_scoped(&provider_id, 30, &usage_windows, None)
+        }
+        ChartAccountScope::Account { config_dir, .. } => {
+            get_cost_usage_report_scoped(&provider_id, 30, &usage_windows, Some(config_dir.clone()))
+        }
+        ChartAccountScope::UnresolvedAccount { .. } => None,
+    };
     let cost_history: Vec<DailyCostPoint> = report
         .as_ref()
         .map(|report| {
@@ -1220,17 +1301,19 @@ fn build_provider_chart_data_with_cancel(
     {
         None
     } else {
-        report
-            .as_ref()
-            .and_then(|report| {
-                local_usage_summary_from_report(
-                    &provider_id,
-                    report,
-                    &usage_window_requests,
-                    &comparison_specs,
-                )
-            })
-            .or_else(|| load_local_usage_summary_cached(&provider_id, cancel.as_deref()))
+        let scoped_summary = report.as_ref().and_then(|report| {
+            local_usage_summary_from_report(
+                &provider_id,
+                report,
+                &usage_window_requests,
+                &comparison_specs,
+            )
+        });
+        if scoped_summary.is_some() || account_scope != ChartAccountScope::MachineWide {
+            scoped_summary
+        } else {
+            load_local_usage_summary_cached(&provider_id, cancel.as_deref())
+        }
     };
 
     ProviderChartData {
@@ -1245,6 +1328,7 @@ fn build_provider_chart_data_with_cancel(
         credits_history,
         usage_breakdown,
         local_usage,
+        local_usage_scope: account_scope.kind(),
     }
 }
 
@@ -1349,13 +1433,14 @@ fn local_usage_summary_from_report(
 }
 
 impl ProviderChartData {
-    fn empty(provider_id: String) -> Self {
+    fn empty_with_scope(provider_id: String, local_usage_scope: LocalUsageScope) -> Self {
         Self {
             provider_id,
             cost_history: Vec::new(),
             credits_history: Vec::new(),
             usage_breakdown: Vec::new(),
             local_usage: None,
+            local_usage_scope,
             quota_history: Vec::new(),
         }
     }
@@ -1846,19 +1931,22 @@ fn load_openai_dashboard_chart_data(
 #[cfg(test)]
 mod tests {
     use super::{
-        CostFetchFailure, LocalEffortCost, LocalModelCost, LocalPlanUsage, LocalProjectCost,
-        LocalTokenBreakdown, LocalUsageWindowRequest, ProviderLocalUsageSummary, api_value_period,
-        chart_cache_key, comparison_period_specs, cost_fetch_failure_allows_early_retry,
-        daily_series_from_report, effort_breakdown, format_cost_csv, local_midnight_in_tz,
-        local_usage_summary_from_report, local_yesterday_window_utc, localized_estimate_note,
-        model_breakdown, parse_api_value_custom_range, period_from_daily_series,
-        pricing_coverage_tokens, project_breakdown, spend_budget_period_details, token_breakdown,
-        token_cost_cache_is_fresh,
+        ChartAccountScope, CostFetchFailure, LocalEffortCost, LocalModelCost, LocalPlanUsage,
+        LocalProjectCost, LocalTokenBreakdown, LocalUsageWindowRequest, ProviderLocalUsageSummary,
+        api_value_period, chart_cache_key, comparison_period_specs,
+        cost_fetch_failure_allows_early_retry, daily_series_from_report, effort_breakdown,
+        format_cost_csv, local_midnight_in_tz, local_usage_summary_from_report,
+        local_yesterday_window_utc, localized_estimate_note, model_breakdown,
+        parse_api_value_custom_range, period_from_daily_series, pricing_coverage_tokens,
+        project_breakdown, resolve_chart_account_scope, spend_budget_period_details,
+        token_breakdown, token_cost_cache_is_fresh,
     };
     use crate::commands::is_provider_cache_fresh;
     use chrono::{Local, LocalResult, NaiveDate, NaiveTime, TimeZone, Timelike, Utc};
+    use codexbar::core::{CodexIdentity, ConfiguredAccounts, DirectoryAccount};
     use codexbar::cost_scanner::{CostSummary, CostUsageReport, ModelTokenCounts};
     use codexbar::settings::Language;
+    use std::path::PathBuf;
     use std::time::{Duration, Instant};
 
     #[test]
@@ -1866,21 +1954,81 @@ mod tests {
         let personal = chart_cache_key(
             "codex",
             Some("shared@example.com"),
-            Some("acct-personal"),
             None,
             Some("oauth"),
             &[],
+            &ChartAccountScope::Account {
+                account_id: "acct-personal".into(),
+                config_dir: PathBuf::from("personal"),
+            },
         );
         let work = chart_cache_key(
             "codex",
             Some("shared@example.com"),
-            Some("acct-work"),
             None,
             Some("oauth"),
             &[],
+            &ChartAccountScope::Account {
+                account_id: "acct-work".into(),
+                config_dir: PathBuf::from("work"),
+            },
         );
 
         assert_ne!(personal, work);
+    }
+
+    #[test]
+    fn chart_scope_distinguishes_machine_wide_resolved_and_stale_accounts() {
+        let mut accounts = ConfiguredAccounts::default();
+        let account_id = accounts
+            .codex
+            .add_account(DirectoryAccount::<CodexIdentity>::new(
+                Some("work".into()),
+                PathBuf::from("/homes/work"),
+            ))
+            .to_string();
+
+        assert_eq!(
+            resolve_chart_account_scope("codex", None, &accounts),
+            ChartAccountScope::MachineWide
+        );
+        assert_eq!(
+            resolve_chart_account_scope("codex", Some(&account_id), &accounts),
+            ChartAccountScope::Account {
+                account_id: account_id.clone(),
+                config_dir: PathBuf::from("/homes/work"),
+            }
+        );
+        assert_eq!(
+            resolve_chart_account_scope("codex", Some("removed-account"), &accounts),
+            ChartAccountScope::UnresolvedAccount {
+                account_id: "removed-account".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn unresolved_account_never_shares_the_machine_wide_chart_cache() {
+        let machine = chart_cache_key(
+            "claude",
+            Some("same@example.com"),
+            None,
+            Some("oauth"),
+            &[],
+            &ChartAccountScope::MachineWide,
+        );
+        let unresolved = chart_cache_key(
+            "claude",
+            Some("same@example.com"),
+            None,
+            Some("oauth"),
+            &[],
+            &ChartAccountScope::UnresolvedAccount {
+                account_id: "stale-id".into(),
+            },
+        );
+
+        assert_ne!(machine, unresolved);
     }
 
     #[test]

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -377,8 +377,8 @@ impl ChartAccountScope {
 
     fn cache_identity(
         &self,
-        account_email: Option<&str>,
-        account_organization: Option<&str>,
+        _account_email: Option<&str>,
+        _account_organization: Option<&str>,
     ) -> String {
         match self {
             Self::Account { account_id, .. } => {
@@ -387,19 +387,9 @@ impl ChartAccountScope {
             Self::UnresolvedAccount { account_id } => {
                 format!("unresolved:{}", account_id.trim().to_ascii_lowercase())
             }
-            Self::MachineWide => {
-                let identity = account_email
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                    .or_else(|| {
-                        account_organization
-                            .map(str::trim)
-                            .filter(|value| !value.is_empty())
-                    })
-                    .unwrap_or("anonymous")
-                    .to_ascii_lowercase();
-                format!("machine:{identity}")
-            }
+            // The underlying scan covers the whole machine, so requests from a
+            // provider tab and the identity-free Compare view must share it.
+            Self::MachineWide => "machine".to_string(),
         }
     }
 }
@@ -1975,6 +1965,19 @@ mod tests {
         );
 
         assert_ne!(personal, work);
+    }
+
+    #[test]
+    fn machine_wide_cache_identity_matches_charts_panel_and_compare() {
+        let scope = ChartAccountScope::MachineWide;
+        let charts_panel_with_email = scope.cache_identity(Some("person@example.com"), None);
+        let charts_panel_with_organization =
+            scope.cache_identity(None, Some("Example Organization"));
+        let compare = scope.cache_identity(None, None);
+
+        assert_eq!(compare, "machine");
+        assert_eq!(charts_panel_with_email, compare);
+        assert_eq!(charts_panel_with_organization, compare);
     }
 
     #[test]

--- a/apps/desktop-tauri/src-tauri/src/commands/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/tests.rs
@@ -1216,7 +1216,9 @@ fn non_claude_error_message_is_preserved() {
 
 #[test]
 fn chart_data_serde_roundtrip_preserves_fields() {
-    use super::{DailyCostPoint, DailyUsageBreakdown, ProviderChartData, ServiceUsagePoint};
+    use super::{
+        DailyCostPoint, DailyUsageBreakdown, LocalUsageScope, ProviderChartData, ServiceUsagePoint,
+    };
 
     let original = ProviderChartData {
         provider_id: "codex".into(),
@@ -1249,6 +1251,7 @@ fn chart_data_serde_roundtrip_preserves_fields() {
             total_credits_used: 13.5,
         }],
         local_usage: None,
+        local_usage_scope: LocalUsageScope::Account,
         quota_history: Vec::new(),
     };
 
@@ -1261,6 +1264,7 @@ fn chart_data_serde_roundtrip_preserves_fields() {
     assert!(json.contains("\"creditsHistory\""));
     assert!(json.contains("\"usageBreakdown\""));
     assert!(json.contains("\"localUsage\":null"));
+    assert!(json.contains("\"localUsageScope\":\"account\""));
     assert!(json.contains("\"quotaHistory\":[]"));
     assert!(json.contains("\"creditsUsed\":10.0"));
     assert!(json.contains("\"totalCreditsUsed\":13.5"));
@@ -1272,6 +1276,7 @@ fn chart_data_serde_roundtrip_preserves_fields() {
     assert_eq!(back.credits_history[0].value, 42.0);
     assert_eq!(back.usage_breakdown[0].services.len(), 2);
     assert_eq!(back.usage_breakdown[0].total_credits_used, 13.5);
+    assert_eq!(back.local_usage_scope, LocalUsageScope::Account);
 }
 
 #[test]

--- a/apps/desktop-tauri/src/surfaces/ChartsPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/ChartsPanel.test.tsx
@@ -9,13 +9,16 @@ vi.mock("./settings/providers/sections/charts/ChartsSection", () => ({
   ChartsSection: ({
     providerId,
     accountEmail,
+    accountId,
   }: {
     providerId: string;
     accountEmail?: string | null;
+    accountId?: string | null;
   }) => (
     <div data-testid="charts-section">
       {providerId}
       {accountEmail ? `:${accountEmail}` : ""}
+      {accountId ? `:${accountId}` : ""}
     </div>
   ),
 }));
@@ -158,9 +161,7 @@ describe("ChartsPanel", () => {
     expect(panel.getAttribute("aria-labelledby")).toBe(compare.id);
   });
 
-  it("collapses a provider's accounts into a single tab, since local logs are machine-wide", () => {
-    // Local activity is scanned from logs that carry no account identity, so
-    // two Codex accounts must not present as two tabs of separable data.
+  it("shows and selects each configured account independently", () => {
     const { getAllByRole, getByTestId } = render(
       <ChartsPanel
         providers={[
@@ -181,13 +182,35 @@ describe("ChartsPanel", () => {
       />,
     );
 
-    // One Codex tab, one Claude tab, plus Compare — not one tab per account.
-    expect(getAllByRole("tab", { name: /Codex/ })).toHaveLength(1);
+    expect(getAllByRole("tab", { name: /Codex/ })).toHaveLength(2);
     expect(getAllByRole("tab", { name: /Claude/ })).toHaveLength(1);
 
-    fireEvent.click(getAllByRole("tab", { name: /Codex/ })[0]);
-    // One Codex section, not one per account.
-    expect(getByTestId("charts-section").textContent).toMatch(/^codex/);
+    fireEvent.click(getAllByRole("tab", { name: /Codex — bts@cssi\.us/ })[0]);
+    expect(getByTestId("charts-section").textContent).toBe(
+      "codex:bts@cssi.us:acct-work",
+    );
+  });
+
+  it("masks account identities in tabs when personal info is hidden", () => {
+    const { getAllByRole } = render(
+      <ChartsPanel
+        hideEmail
+        providers={[
+          provider({
+            accountId: "acct-personal",
+            accountEmail: "personal@example.com",
+          }),
+          provider({
+            accountId: "acct-work",
+            accountEmail: "work@example.com",
+          }),
+        ]}
+      />,
+    );
+
+    const names = getAllByRole("tab").map((tab) => tab.textContent ?? "");
+    expect(names.join(" ")).not.toContain("personal@example.com");
+    expect(names.join(" ")).not.toContain("work@example.com");
   });
 
   it("omits the selector when only one provider is supported", () => {

--- a/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
@@ -8,7 +8,8 @@ import { ChartsSection } from "./settings/providers/sections/charts/ChartsSectio
 import ProviderComparison from "./ProviderComparison";
 import { TotalApiValueCard } from "../components/TotalApiValueCard";
 import {
-  onePerProvider,
+  accountIdentityLabel,
+  hasMultipleAccounts,
   representativeForProvider,
 } from "../lib/providerRow";
 
@@ -32,17 +33,17 @@ export function chartSectionKey(provider: ProviderUsageSnapshot): string {
  */
 export default function ChartsPanel({
   providers,
+  hideEmail = false,
 }: {
   providers: ProviderUsageSnapshot[];
+  hideEmail?: boolean;
 }) {
   const { t } = useLocale();
 
   const supported = useMemo(
     () =>
-      onePerProvider(
-        providers.filter(
-          (p) => providerSupportsChartData(p.providerId) && !p.error,
-        ),
+      providers.filter(
+        (p) => providerSupportsChartData(p.providerId) && !p.error,
       ),
     [providers],
   );
@@ -65,19 +66,19 @@ export default function ChartsPanel({
     }
     setSelectedId((prev) =>
       prev &&
-      (supported.some((p) => p.providerId === prev) ||
+      (supported.some((p) => chartSectionKey(p) === prev) ||
         (prev === COMPARE_ID && comparisonProviders))
         ? prev
         : comparisonProviders
           ? COMPARE_ID
-          : supported[0].providerId,
+          : chartSectionKey(supported[0]),
     );
   }, [supported, comparisonProviders]);
 
   const tabIds = useMemo(
     () => [
       ...(comparisonProviders ? [COMPARE_ID] : []),
-      ...supported.map((p) => p.providerId),
+      ...supported.map(chartSectionKey),
     ],
     [comparisonProviders, supported],
   );
@@ -87,7 +88,9 @@ export default function ChartsPanel({
   // the body actually renders: the first supported provider.
   const activeTabId = comparing
     ? COMPARE_ID
-    : (tabIds.includes(selectedId ?? "") ? selectedId : supported[0]?.providerId) ?? null;
+    : (tabIds.includes(selectedId ?? "")
+        ? selectedId
+        : supported[0] && chartSectionKey(supported[0])) ?? null;
 
   // Manual activation: picking a provider remounts ChartsSection, which loads
   // that provider's history. Arrowing across the strip should not fire a load
@@ -115,7 +118,7 @@ export default function ChartsPanel({
   }
 
   const selected =
-    supported.find((p) => p.providerId === selectedId) ?? supported[0];
+    supported.find((p) => chartSectionKey(p) === activeTabId) ?? supported[0];
   const tabCount = tabIds.length;
 
   return (
@@ -136,15 +139,19 @@ export default function ChartsPanel({
             </button>
           )}
           {supported.map((p) => {
-            const isActive = p.providerId === activeTabId;
+            const tabId = chartSectionKey(p);
+            const isActive = tabId === activeTabId;
+            const accountName = hasMultipleAccounts(supported, p.providerId)
+              ? accountIdentityLabel(p, hideEmail) ?? p.accountId ?? "Account"
+              : null;
             return (
               <button
-                key={p.providerId}
+                key={tabId}
                 type="button"
-                {...getTabProps(p.providerId)}
+                {...getTabProps(tabId)}
                 className="charts-provider-tab"
                 data-active={isActive ? "true" : "false"}
-                onClick={() => setSelectedId(p.providerId)}
+                onClick={() => setSelectedId(tabId)}
               >
                 <ProviderIcon
                   providerId={p.providerId}
@@ -152,7 +159,7 @@ export default function ChartsPanel({
                   className="charts-provider-tab__icon"
                   title={p.displayName}
                 />
-                <span>{p.displayName}</span>
+                <span>{accountName ? `${p.displayName} — ${accountName}` : p.displayName}</span>
               </button>
             );
           })}

--- a/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
@@ -443,7 +443,10 @@ export default function PopOutPanel({
                 hideEmail={settings.hidePersonalInfo}
               />
             ) : activeSection === "charts" ? (
-              <ChartsPanel providers={sorted} />
+              <ChartsPanel
+                providers={sorted}
+                hideEmail={settings.hidePersonalInfo}
+              />
             ) : activeSection === "accounts" ? (
               <AccountsPanel
                 providers={sorted}

--- a/apps/desktop-tauri/src/surfaces/ProviderComparison.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/ProviderComparison.test.tsx
@@ -1,0 +1,84 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderChartData, ProviderUsageSnapshot } from "../types/bridge";
+import ProviderComparison from "./ProviderComparison";
+
+const mocks = vi.hoisted(() => ({
+  getProviderChartData: vi.fn(),
+}));
+
+vi.mock("../lib/tauri", () => ({
+  getProviderChartData: mocks.getProviderChartData,
+}));
+
+vi.mock("../components/providers/ProviderIcon", () => ({
+  ProviderIcon: () => <span aria-hidden="true" />,
+}));
+
+function provider(
+  providerId: string,
+  accountId: string,
+  accountEmail: string,
+): ProviderUsageSnapshot {
+  return {
+    providerId,
+    displayName: providerId === "codex" ? "Codex" : "Claude",
+    accountId,
+    accountEmail,
+    primary: {
+      usedPercent: 25,
+      remainingPercent: 75,
+      windowMinutes: 300,
+      resetsAt: null,
+      resetDescription: null,
+      isExhausted: false,
+      reservePercent: null,
+      reserveDescription: null,
+      reserveWillLastToReset: false,
+      reserveEtaSeconds: null,
+    },
+    primaryLabel: "Session",
+    secondary: null,
+    modelSpecific: null,
+    tertiary: null,
+    extraRateWindows: [],
+    inactiveRateWindows: [],
+    cost: null,
+    planName: null,
+    sourceLabel: "oauth",
+    updatedAt: new Date().toISOString(),
+    error: null,
+    pace: null,
+    accountOrganization: null,
+    trayStatusLabel: null,
+  };
+}
+
+describe("ProviderComparison", () => {
+  beforeEach(() => {
+    mocks.getProviderChartData.mockReset();
+    mocks.getProviderChartData.mockImplementation(
+      () => new Promise<ProviderChartData>(() => undefined),
+    );
+  });
+
+  it("requests the explicit machine-wide scope instead of a representative account", async () => {
+    render(
+      <ProviderComparison
+        providers={[
+          provider("codex", "codex-account", "codex@example.com"),
+          provider("claude", "claude-account", "claude@example.com"),
+        ]}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(mocks.getProviderChartData).toHaveBeenCalledTimes(2),
+    );
+    for (const call of mocks.getProviderChartData.mock.calls) {
+      expect(call[1]).toBeUndefined();
+      expect(call[2]).toBeUndefined();
+      expect(call[5]).toBeUndefined();
+    }
+  });
+});

--- a/apps/desktop-tauri/src/surfaces/ProviderComparison.tsx
+++ b/apps/desktop-tauri/src/surfaces/ProviderComparison.tsx
@@ -101,7 +101,6 @@ export default function ProviderComparison({ providers }: {
     const windows = providerLocalUsageWindows(provider);
     return JSON.stringify({
       providerId: provider.providerId,
-      accountEmail: provider.accountEmail ?? null,
       windows,
     });
   }).join("|"), [providers]);
@@ -125,11 +124,14 @@ export default function ProviderComparison({ providers }: {
         const results = await Promise.all(providers.map(async (provider) => {
           const result = await getProviderChartData(
             provider.providerId,
-            provider.accountEmail ?? undefined,
-            provider.accountId ?? undefined,
+            // Compare is the one explicit all-account view. Omitting account
+            // identity selects the machine-wide scope instead of silently
+            // choosing whichever account represents the provider tab.
+            undefined,
+            undefined,
             providerLocalUsageWindows(provider),
             undefined,
-            provider.accountOrganization ?? undefined,
+            undefined,
           );
           return [provider.providerId, result] as const;
         }));

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/charts/ChartsSection.tsx
@@ -531,6 +531,7 @@ export function ChartsSection({ providerId, accountEmail, accountId, providerSna
     setEnriching(
       cached !== null &&
       !cached.localUsage &&
+      cached.localUsageScope !== "unresolvedAccount" &&
       ["codex", "claude", "grok"].includes(providerId.toLowerCase()),
     );
     setFailed(false);
@@ -553,7 +554,9 @@ export function ChartsSection({ providerId, accountEmail, accountId, providerSna
           chartDataCache.set(cacheKey, d);
           setData(d);
           setEnriching(
-            !d.localUsage && ["codex", "claude", "grok"].includes(providerId.toLowerCase()),
+            !d.localUsage &&
+            d.localUsageScope !== "unresolvedAccount" &&
+            ["codex", "claude", "grok"].includes(providerId.toLowerCase()),
           );
           setLoading(false);
         }
@@ -613,9 +616,14 @@ export function ChartsSection({ providerId, accountEmail, accountId, providerSna
     if (
       !data ||
       data.localUsage ||
+      data.localUsageScope === "unresolvedAccount" ||
       !["codex", "claude", "grok"].includes(providerId.toLowerCase())
     ) {
-      if (data?.localUsage || !["codex", "claude", "grok"].includes(providerId.toLowerCase())) {
+      if (
+        data?.localUsage ||
+        data?.localUsageScope === "unresolvedAccount" ||
+        !["codex", "claude", "grok"].includes(providerId.toLowerCase())
+      ) {
         setEnriching(false);
       }
       return;

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -844,6 +844,8 @@ export interface ProviderChartData {
   creditsHistory: DailyCostPoint[];
   usageBreakdown: DailyUsageBreakdown[];
   localUsage: ProviderLocalUsageSummary | null;
+  /** Explicit transcript scope; absent only for payloads cached by older builds. */
+  localUsageScope?: "machineWide" | "account" | "unresolvedAccount";
   quotaHistory: UsageHistoryPoint[];
 }
 


### PR DESCRIPTION
## Summary
- resolve chart transcript scans to an explicit machine-wide, account, or unresolved-account scope
- include that scope in cache identity so removed accounts cannot inherit machine-wide usage
- show each configured account as its own chart tab while keeping Compare explicitly aggregated
- stop retry polling for account identities that no longer resolve

## Validation
- `pnpm run build`
- `pnpm test -- --reporter=dot --silent` (68 files, 502 tests)
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` (496 tests)
- `cargo clippy --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all -- --check`
- `cargo test --manifest-path rust/Cargo.toml` (871 passed; known Windows PTY failure tracked in #270)

Linear: SBS-732