### PR TITLE
Discard stale provider detail responses

### DIFF
--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.test.tsx
@@ -1,0 +1,237 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderDetail } from "../../../types/bridge";
+import { ProviderDetailPane } from "./ProviderDetailPane";
+
+const tauriMocks = vi.hoisted(() => ({
+  getCredentialStorageStatus: vi.fn(),
+  getProviderDetail: vi.fn(),
+  getProviderRegionOptions: vi.fn(),
+  getTokenAccountProviders: vi.fn(),
+  openProviderDashboard: vi.fn(),
+  openProviderStatusPage: vi.fn(),
+  refreshProviders: vi.fn(),
+  revokeProviderCredentials: vi.fn(),
+  setProviderGatewayUrl: vi.fn(),
+  triggerProviderLogin: vi.fn(),
+}));
+
+const eventMocks = vi.hoisted(() => ({
+  handlers: new Map<string, Set<(event: { payload: unknown }) => void>>(),
+  listen: vi.fn(),
+}));
+
+vi.mock("../../../lib/tauri", () => tauriMocks);
+vi.mock("@tauri-apps/api/event", () => ({ listen: eventMocks.listen }));
+vi.mock("../../../hooks/useLocale", () => ({
+  useLocale: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("./sections/IdentitySection", () => ({
+  IdentitySection: ({ provider }: { provider: ProviderDetail }) => (
+    <div data-testid="provider-identity">
+      {provider.id}:{provider.accountId ?? "ambient"}:{provider.email ?? "none"}
+    </div>
+  ),
+}));
+
+vi.mock("./sections/DataSourceSection", () => ({ DataSourceSection: () => null }));
+vi.mock("./sections/UsageSection", () => ({ UsageSection: () => null }));
+vi.mock("./sections/PaceSection", () => ({ PaceSection: () => null }));
+vi.mock("./sections/CostSection", () => ({ CostSection: () => null }));
+vi.mock("./sections/QuickActionsSection", () => ({ QuickActionsSection: () => null }));
+vi.mock("./sections/charts/ChartsSection", () => ({ ChartsSection: () => null }));
+vi.mock("./sections/RegionSection", () => ({ RegionSection: () => null }));
+vi.mock("./sections/credentials/GeminiCliCreds", () => ({ GeminiCliCreds: () => null }));
+vi.mock("./sections/credentials/VertexAiCreds", () => ({ VertexAiCreds: () => null }));
+vi.mock("./sections/credentials/JetBrainsCreds", () => ({ JetBrainsCreds: () => null }));
+vi.mock("./sections/credentials/KiroCreds", () => ({ KiroCreds: () => null }));
+vi.mock("./sections/credentials/ClaudeCreds", () => ({ ClaudeCreds: () => null }));
+vi.mock("./sections/credentials/CodexUsageOptions", () => ({ CodexUsageOptions: () => null }));
+vi.mock("./sections/credentials/OpenAiExtras", () => ({ OpenAiExtras: () => null }));
+vi.mock("../tokens/TokenAccountsPanel", () => ({ TokenAccountsPanel: () => null }));
+vi.mock("./ApiKeySection", () => ({ ApiKeySection: () => null }));
+vi.mock("./CookieSection", () => ({ CookieSection: () => null }));
+vi.mock("./sections/MenuBarMetricSection", () => ({ MenuBarMetricSection: () => null }));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function detail(
+  providerId: string,
+  accountId: string | null,
+  email: string,
+): ProviderDetail {
+  return {
+    id: providerId,
+    displayName: providerId === "codex" ? "Codex" : "Claude",
+    enabled: true,
+    accountId,
+    accounts:
+      providerId === "codex"
+        ? [
+            { accountId: "personal", label: "Personal", tint: null },
+            { accountId: "work", label: "Work", tint: null },
+          ]
+        : [],
+    email,
+    plan: null,
+    authType: null,
+    sourceLabel: "oauth",
+    organization: null,
+    lastUpdated: null,
+    session: null,
+    weekly: null,
+    modelSpecific: null,
+    tertiary: null,
+    extraRateWindows: [],
+    cost: null,
+    pace: null,
+    lastError: null,
+    dashboardUrl: null,
+    statusPageUrl: null,
+    buyCreditsUrl: null,
+    hasSnapshot: true,
+    cookieSource: null,
+    region: null,
+  };
+}
+
+function renderPane(providerId: string | null) {
+  return render(
+    <ProviderDetailPane
+      providerId={providerId}
+      resetTimeRelative
+      providerMetrics={{}}
+      wayfinderGatewayUrl=""
+      settingsDisabled={false}
+      onSettingsChange={vi.fn()}
+    />,
+  );
+}
+
+function emitProviderUpdated(providerId: string) {
+  for (const handler of eventMocks.handlers.get("provider-updated") ?? []) {
+    handler({ payload: { providerId } });
+  }
+}
+
+describe("ProviderDetailPane request ordering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eventMocks.handlers.clear();
+    eventMocks.listen.mockImplementation(
+      async (eventName: string, handler: (event: { payload: unknown }) => void) => {
+        const handlers = eventMocks.handlers.get(eventName) ?? new Set();
+        handlers.add(handler);
+        eventMocks.handlers.set(eventName, handlers);
+        return () => handlers.delete(handler);
+      },
+    );
+    tauriMocks.getCredentialStorageStatus.mockResolvedValue({
+      manualCookies: "missing",
+      apiKeys: "missing",
+      tokenAccounts: "missing",
+    });
+    tauriMocks.getProviderRegionOptions.mockResolvedValue([]);
+    tauriMocks.getTokenAccountProviders.mockResolvedValue([]);
+    tauriMocks.refreshProviders.mockResolvedValue(undefined);
+  });
+
+  it("keeps the newest account when account requests resolve out of order", async () => {
+    const work = deferred<ProviderDetail>();
+    const personal = deferred<ProviderDetail>();
+    tauriMocks.getProviderDetail.mockImplementation(
+      (_providerId: string, accountId: string | null) => {
+        if (accountId === "work") return work.promise;
+        if (accountId === "personal") return personal.promise;
+        return Promise.resolve(detail("codex", "personal", "personal@example.com"));
+      },
+    );
+
+    renderPane("codex");
+    expect(await screen.findByTestId("provider-identity")).toHaveTextContent(
+      "codex:personal:personal@example.com",
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByRole("tab", { name: "Work" }));
+      fireEvent.click(screen.getByRole("tab", { name: "Personal" }));
+    });
+
+    await act(async () => {
+      personal.resolve(detail("codex", "personal", "new-personal@example.com"));
+    });
+    expect(screen.getByTestId("provider-identity")).toHaveTextContent(
+      "codex:personal:new-personal@example.com",
+    );
+
+    await act(async () => {
+      work.resolve(detail("codex", "work", "work@example.com"));
+    });
+    expect(screen.getByTestId("provider-identity")).toHaveTextContent(
+      "codex:personal:new-personal@example.com",
+    );
+  });
+
+  it("keeps the newest provider when provider requests resolve out of order", async () => {
+    const codex = deferred<ProviderDetail>();
+    const claude = deferred<ProviderDetail>();
+    tauriMocks.getProviderDetail.mockImplementation((providerId: string) =>
+      providerId === "codex" ? codex.promise : claude.promise,
+    );
+
+    const view = renderPane("codex");
+    await waitFor(() =>
+      expect(tauriMocks.getProviderDetail).toHaveBeenCalledWith("codex", null),
+    );
+    view.rerender(
+      <ProviderDetailPane
+        providerId="claude"
+        resetTimeRelative
+        providerMetrics={{}}
+        wayfinderGatewayUrl=""
+        settingsDisabled={false}
+        onSettingsChange={vi.fn()}
+      />,
+    );
+
+    await act(async () => {
+      claude.resolve(detail("claude", null, "claude@example.com"));
+    });
+    expect(screen.getByTestId("provider-identity")).toHaveTextContent(
+      "claude:ambient:claude@example.com",
+    );
+
+    await act(async () => {
+      codex.resolve(detail("codex", null, "codex@example.com"));
+    });
+    expect(screen.getByTestId("provider-identity")).toHaveTextContent(
+      "claude:ambient:claude@example.com",
+    );
+  });
+
+  it("coalesces a burst of provider-updated events", async () => {
+    tauriMocks.getProviderDetail.mockResolvedValue(
+      detail("codex", "personal", "personal@example.com"),
+    );
+    renderPane("codex");
+    await screen.findByTestId("provider-identity");
+
+    act(() => {
+      emitProviderUpdated("codex");
+      emitProviderUpdated("codex");
+      emitProviderUpdated("codex");
+    });
+    await waitFor(() =>
+      expect(tauriMocks.getProviderDetail).toHaveBeenCalledTimes(2),
+    );
+  });
+});

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.test.tsx
@@ -39,7 +39,13 @@ vi.mock("./sections/DataSourceSection", () => ({ DataSourceSection: () => null }
 vi.mock("./sections/UsageSection", () => ({ UsageSection: () => null }));
 vi.mock("./sections/PaceSection", () => ({ PaceSection: () => null }));
 vi.mock("./sections/CostSection", () => ({ CostSection: () => null }));
-vi.mock("./sections/QuickActionsSection", () => ({ QuickActionsSection: () => null }));
+vi.mock("./sections/QuickActionsSection", () => ({
+  QuickActionsSection: ({
+    onSwitchAccount,
+  }: {
+    onSwitchAccount: () => void;
+  }) => <button onClick={onSwitchAccount}>switch-account</button>,
+}));
 vi.mock("./sections/charts/ChartsSection", () => ({ ChartsSection: () => null }));
 vi.mock("./sections/RegionSection", () => ({ RegionSection: () => null }));
 vi.mock("./sections/credentials/GeminiCliCreds", () => ({ GeminiCliCreds: () => null }));
@@ -143,6 +149,8 @@ describe("ProviderDetailPane request ordering", () => {
     tauriMocks.getProviderRegionOptions.mockResolvedValue([]);
     tauriMocks.getTokenAccountProviders.mockResolvedValue([]);
     tauriMocks.refreshProviders.mockResolvedValue(undefined);
+    tauriMocks.revokeProviderCredentials.mockResolvedValue(undefined);
+    tauriMocks.triggerProviderLogin.mockResolvedValue(undefined);
   });
 
   it("keeps the newest account when account requests resolve out of order", async () => {
@@ -232,6 +240,140 @@ describe("ProviderDetailPane request ordering", () => {
     });
     await waitFor(() =>
       expect(tauriMocks.getProviderDetail).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it("does not let a completed switch-account flow clear a newer provider selection", async () => {
+    const login = deferred<void>();
+    tauriMocks.triggerProviderLogin.mockReturnValue(login.promise);
+    tauriMocks.getProviderDetail.mockImplementation(
+      (providerId: string, accountId: string | null) =>
+        Promise.resolve({
+          ...detail(
+            providerId,
+            accountId ?? "personal",
+            `${accountId ?? "personal"}@${providerId}.example.com`,
+          ),
+          accounts: [
+            { accountId: "personal", label: "Personal", tint: null },
+            { accountId: "work", label: "Work", tint: null },
+          ],
+        }),
+    );
+
+    const view = renderPane("codex");
+    await screen.findByTestId("provider-identity");
+    fireEvent.click(screen.getByRole("button", { name: "switch-account" }));
+
+    view.rerender(
+      <ProviderDetailPane
+        providerId="claude"
+        resetTimeRelative
+        providerMetrics={{}}
+        wayfinderGatewayUrl=""
+        settingsDisabled={false}
+        onSettingsChange={vi.fn()}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-identity")).toHaveTextContent(
+        "claude:personal:personal@claude.example.com",
+      ),
+    );
+    fireEvent.click(screen.getByRole("tab", { name: "Work" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-identity")).toHaveTextContent(
+        "claude:work:work@claude.example.com",
+      ),
+    );
+
+    await act(async () => login.resolve());
+    await waitFor(() => expect(tauriMocks.refreshProviders).toHaveBeenCalled());
+    expect(screen.getByTestId("provider-identity")).toHaveTextContent(
+      "claude:work:work@claude.example.com",
+    );
+  });
+
+  it("falls back to ambient detail when the selected account fails", async () => {
+    tauriMocks.getProviderDetail.mockImplementation(
+      (providerId: string, accountId: string | null) => {
+        if (accountId === "work") return Promise.reject(new Error("missing account"));
+        return Promise.resolve(detail(providerId, "personal", "personal@example.com"));
+      },
+    );
+
+    renderPane("codex");
+    await screen.findByTestId("provider-identity");
+    fireEvent.click(screen.getByRole("tab", { name: "Work" }));
+
+    await waitFor(() =>
+      expect(tauriMocks.getProviderDetail).toHaveBeenLastCalledWith("codex", null),
+    );
+    expect(screen.getByTestId("provider-identity")).toHaveTextContent(
+      "codex:personal:personal@example.com",
+    );
+    expect(screen.getByRole("tab", { name: "Personal" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("cancels a queued provider refresh when an account is selected manually", async () => {
+    tauriMocks.getProviderDetail.mockImplementation(
+      (providerId: string, accountId: string | null) =>
+        Promise.resolve(
+          detail(
+            providerId,
+            accountId ?? "personal",
+            `${accountId ?? "personal"}@example.com`,
+          ),
+        ),
+    );
+
+    renderPane("codex");
+    await screen.findByTestId("provider-identity");
+    act(() => {
+      emitProviderUpdated("codex");
+      fireEvent.click(screen.getByRole("tab", { name: "Work" }));
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-identity")).toHaveTextContent(
+        "codex:work:work@example.com",
+      ),
+    );
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 75));
+    });
+    expect(tauriMocks.getProviderDetail).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns to ambient detail after revoking credentials", async () => {
+    tauriMocks.getProviderDetail.mockImplementation(
+      (providerId: string, accountId: string | null) =>
+        Promise.resolve(
+          detail(
+            providerId,
+            accountId ?? "personal",
+            `${accountId ?? "personal"}@example.com`,
+          ),
+        ),
+    );
+
+    renderPane("codex");
+    await screen.findByTestId("provider-identity");
+    fireEvent.click(screen.getByRole("tab", { name: "Work" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-identity")).toHaveTextContent(
+        "codex:work:work@example.com",
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "CredentialRevokeStored" }));
+    await waitFor(() =>
+      expect(tauriMocks.getProviderDetail).toHaveBeenLastCalledWith("codex", null),
+    );
+    expect(screen.getByTestId("provider-identity")).toHaveTextContent(
+      "codex:personal:personal@example.com",
     );
   });
 });

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.test.tsx
@@ -1,6 +1,9 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ProviderDetail } from "../../../types/bridge";
+import type {
+  CredentialStorageStatus,
+  ProviderDetail,
+} from "../../../types/bridge";
 import { ProviderDetailPane } from "./ProviderDetailPane";
 
 const tauriMocks = vi.hoisted(() => ({
@@ -123,6 +126,20 @@ function renderPane(providerId: string | null) {
   );
 }
 
+const absentStatus: CredentialStorageStatus = {
+  apiKeys: { fileStatus: "missing", hasProviderCredentials: false },
+  manualCookies: { fileStatus: "missing", hasProviderCredentials: false },
+  tokenAccounts: { fileStatus: "missing", hasProviderCredentials: false },
+};
+
+const presentStatus: CredentialStorageStatus = {
+  ...absentStatus,
+  apiKeys: {
+    fileStatus: "protected:windows-dpapi-user",
+    hasProviderCredentials: true,
+  },
+};
+
 function emitProviderUpdated(providerId: string) {
   for (const handler of eventMocks.handlers.get("provider-updated") ?? []) {
     handler({ payload: { providerId } });
@@ -132,6 +149,10 @@ function emitProviderUpdated(providerId: string) {
 describe("ProviderDetailPane request ordering", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    tauriMocks.getProviderDetail.mockReset();
+    tauriMocks.getCredentialStorageStatus.mockReset();
+    tauriMocks.triggerProviderLogin.mockReset();
+    tauriMocks.revokeProviderCredentials.mockReset();
     eventMocks.handlers.clear();
     eventMocks.listen.mockImplementation(
       async (eventName: string, handler: (event: { payload: unknown }) => void) => {
@@ -141,11 +162,7 @@ describe("ProviderDetailPane request ordering", () => {
         return () => handlers.delete(handler);
       },
     );
-    tauriMocks.getCredentialStorageStatus.mockResolvedValue({
-      manualCookies: "missing",
-      apiKeys: "missing",
-      tokenAccounts: "missing",
-    });
+    tauriMocks.getCredentialStorageStatus.mockResolvedValue(absentStatus);
     tauriMocks.getProviderRegionOptions.mockResolvedValue([]);
     tauriMocks.getTokenAccountProviders.mockResolvedValue([]);
     tauriMocks.refreshProviders.mockResolvedValue(undefined);
@@ -359,6 +376,7 @@ describe("ProviderDetailPane request ordering", () => {
         ),
     );
 
+    tauriMocks.getCredentialStorageStatus.mockResolvedValue(presentStatus);
     renderPane("codex");
     await screen.findByTestId("provider-identity");
     fireEvent.click(screen.getByRole("tab", { name: "Work" }));

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
@@ -95,7 +95,11 @@ export function ProviderDetailPane({
   const [gatewayError, setGatewayError] = useState<string | null>(null);
   const activeProviderIdRef = useRef(providerId);
   const credentialStatusEpochRef = useRef(0);
+  const requestEpochRef = useRef(0);
+  const providerRefreshTimerRef = useRef<number | null>(null);
+  const providerIdRef = useRef(providerId);
   activeProviderIdRef.current = providerId;
+  providerIdRef.current = providerId;
 
   useEffect(() => {
     if (providerId === "wayfinder") setGatewayDraft(wayfinderGatewayUrl);
@@ -159,57 +163,81 @@ export function ProviderDetailPane({
 
   const load = useCallback(async (
     id: string,
-    signal?: { stale: boolean },
     accountId: string | null = null,
   ) => {
+    if (providerRefreshTimerRef.current !== null) {
+      window.clearTimeout(providerRefreshTimerRef.current);
+      providerRefreshTimerRef.current = null;
+    }
+    if (providerIdRef.current !== id) return;
+    const requestEpoch = ++requestEpochRef.current;
     const credentialRequestEpoch = ++credentialStatusEpochRef.current;
+    let requestedAccountId = accountId;
+    const isCurrentRequest = () =>
+      requestEpoch === requestEpochRef.current &&
+      providerIdRef.current === id &&
+      selectedAccountIdRef.current === requestedAccountId;
     setLoading(true);
     setError(null);
     try {
-      const [next, regionOpts, storageStatus] = await Promise.all([
-        getProviderDetail(id, accountId),
-        getProviderRegionOptions(id),
-        getCredentialStorageStatus(id),
-      ]);
-      if (signal?.stale) return;
-      setDetail(next);
-      setRegionOptions(regionOpts);
-      if (credentialStatusEpochRef.current === credentialRequestEpoch) {
-        setCredentialStatus(storageStatus);
+      while (true) {
+        try {
+          const [next, regionOpts, storageStatus] = await Promise.all([
+            getProviderDetail(id, requestedAccountId),
+            getProviderRegionOptions(id),
+            getCredentialStorageStatus(id),
+          ]);
+          if (!isCurrentRequest()) return;
+          setDetail(next);
+          setRegionOptions(regionOpts);
+          if (credentialStatusEpochRef.current === credentialRequestEpoch) {
+            setCredentialStatus(storageStatus);
+          }
+          return;
+        } catch (e) {
+          if (!isCurrentRequest()) return;
+          if (requestedAccountId !== null) {
+            selectedAccountIdRef.current = null;
+            setSelectedAccountId(null);
+            requestedAccountId = null;
+            continue;
+          }
+          setError(String(e));
+          setDetail(null);
+          setRegionOptions([]);
+          if (credentialStatusEpochRef.current === credentialRequestEpoch) {
+            setCredentialStatus(null);
+          }
+          return;
+        }
       }
-    } catch (e) {
-      if (signal?.stale) return;
-      setError(String(e));
-      setDetail(null);
-      setRegionOptions([]);
-      if (credentialStatusEpochRef.current === credentialRequestEpoch) {
-        setCredentialStatus(null);
-      }
-      setSelectedAccountId(null);
-      selectedAccountIdRef.current = null;
     } finally {
-      if (!signal?.stale) setLoading(false);
+      if (isCurrentRequest()) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
     // ProvidersTab keeps one pane instance. A Claude directory-account tab
     // must not be sent to the next provider as getProviderDetail(accountId).
-    setSelectedAccountId(null);
     selectedAccountIdRef.current = null;
+    setSelectedAccountId(null);
+    ++requestEpochRef.current;
     if (!providerId) {
       setDetail(null);
       setRegionOptions([]);
       setCredentialStatus(null);
+      setError(null);
+      setLoading(false);
       return;
     }
     // Clear stale detail immediately so we don't render the old provider
     setDetail(null);
     setRegionOptions([]);
     setCredentialStatus(null);
-    const signal = { stale: false };
-    void load(providerId, signal, null);
-    return () => { signal.stale = true; };
+    void load(providerId);
+    return () => {
+      ++requestEpochRef.current;
+    };
   }, [providerId, load]);
 
   // Live-refresh when a new snapshot lands for this provider.
@@ -221,12 +249,27 @@ export function ProviderDetailPane({
       (event) => {
         const pid = event.payload?.providerId;
         if (!pid || pid === providerId) {
-          void load(providerId, signal, selectedAccountIdRef.current);
+          // Snapshot bursts can contain several updates for one provider.
+          // Collapse the burst into a single detail request using the account
+          // that is selected when the refresh actually starts.
+          if (providerRefreshTimerRef.current !== null) {
+            window.clearTimeout(providerRefreshTimerRef.current);
+          }
+          providerRefreshTimerRef.current = window.setTimeout(() => {
+            providerRefreshTimerRef.current = null;
+            if (!signal.stale) {
+              void load(providerId, selectedAccountIdRef.current);
+            }
+          }, 50);
         }
       },
     );
     return () => {
       signal.stale = true;
+      if (providerRefreshTimerRef.current !== null) {
+        window.clearTimeout(providerRefreshTimerRef.current);
+        providerRefreshTimerRef.current = null;
+      }
       void unlistenPromise.then((fn) => fn());
     };
   }, [providerId, load]);
@@ -253,8 +296,9 @@ export function ProviderDetailPane({
 
   const selectAccount = useCallback(
     (accountId: string) => {
+      selectedAccountIdRef.current = accountId;
       setSelectedAccountId(accountId);
-      if (providerId) void load(providerId, undefined, accountId);
+      if (providerId) void load(providerId, accountId);
     },
     [load, providerId],
   );
@@ -315,15 +359,19 @@ export function ProviderDetailPane({
   };
 
   const handleSwitchAccount = async () => {
+    const switchedProviderId = detail.id;
     setBusy(true);
     setLoginPhase(null);
     setLoginCode(null);
     setLoginUrl(null);
     try {
-      await triggerProviderLogin(detail.id);
+      await triggerProviderLogin(switchedProviderId);
       setCredentialRevision((value) => value + 1);
       await refreshProviders();
-      await load(detail.id);
+      if (providerIdRef.current !== switchedProviderId) return;
+      selectedAccountIdRef.current = null;
+      setSelectedAccountId(null);
+      await load(switchedProviderId);
     } catch (e) {
       setError(String(e));
     } finally {
@@ -332,12 +380,16 @@ export function ProviderDetailPane({
   };
 
   const handleRevokeCredentials = async () => {
+    const revokedProviderId = detail.id;
     setBusy(true);
     setError(null);
     try {
-      await revokeProviderCredentials(detail.id);
+      await revokeProviderCredentials(revokedProviderId);
       setCredentialRevision((value) => value + 1);
-      await load(detail.id);
+      if (providerIdRef.current !== revokedProviderId) return;
+      selectedAccountIdRef.current = null;
+      setSelectedAccountId(null);
+      await load(revokedProviderId);
     } catch (e) {
       setError(String(e));
     } finally {


### PR DESCRIPTION
## Summary
- guard provider-detail state commits with a monotonically increasing request epoch plus provider/account identity
- reset account selection at provider boundaries and preserve it for account-scoped refreshes
- coalesce provider update bursts before refreshing detail
- cover out-of-order account responses, out-of-order provider responses, and event bursts

## Validation
- `pnpm run build`
- `pnpm test -- --reporter=dot --silent` (68 files, 503 tests)

Linear: SBS-730