### PR TITLE
Scope credential status to the selected provider

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/provider_detail.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/provider_detail.rs
@@ -211,12 +211,23 @@ pub fn revoke_provider_credentials(provider_id: String) -> Result<(), String> {
     codexbar::settings::revoke_managed_credentials(id).map_err(|e| e.to_string())
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialStoreStatusBridge {
+    /// Protection/readability of the shared file that contains credentials for
+    /// every provider. This is deliberately distinct from provider presence.
+    pub file_status: String,
+    /// Whether the selected provider has an entry in this store. `None` means
+    /// the store could not be decoded, so absence cannot be asserted safely.
+    pub has_provider_credentials: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CredentialStorageStatusBridge {
-    pub manual_cookies: String,
-    pub api_keys: String,
-    pub token_accounts: String,
+    pub manual_cookies: CredentialStoreStatusBridge,
+    pub api_keys: CredentialStoreStatusBridge,
+    pub token_accounts: CredentialStoreStatusBridge,
 }
 
 pub(crate) fn credential_file_status_label(status: SecureFileStatus) -> String {
@@ -228,18 +239,96 @@ pub(crate) fn credential_file_status_label(status: SecureFileStatus) -> String {
     }
 }
 
-fn optional_credential_status(path: Option<std::path::PathBuf>) -> String {
-    path.map(|path| credential_file_status_label(secure_file::status(&path)))
-        .unwrap_or_else(|| "unavailable".to_string())
+fn provider_store_status(
+    file_status: Option<SecureFileStatus>,
+    has_provider_credentials: Option<bool>,
+) -> CredentialStoreStatusBridge {
+    let has_provider_credentials = match file_status.as_ref() {
+        Some(SecureFileStatus::Missing) => Some(false),
+        Some(SecureFileStatus::Unreadable(_)) | None => None,
+        Some(SecureFileStatus::Plaintext | SecureFileStatus::Protected(_)) => {
+            has_provider_credentials
+        }
+    };
+    CredentialStoreStatusBridge {
+        file_status: file_status
+            .map(credential_file_status_label)
+            .unwrap_or_else(|| "unavailable".to_string()),
+        has_provider_credentials,
+    }
+}
+
+pub(crate) struct CredentialStorageSources<'a> {
+    pub manual_cookie_file_status: Option<SecureFileStatus>,
+    pub manual_cookies: Option<&'a ManualCookies>,
+    pub api_key_file_status: Option<SecureFileStatus>,
+    pub api_keys: Option<&'a ApiKeys>,
+    pub token_account_file_status: SecureFileStatus,
+    pub token_accounts: Option<&'a HashMap<ProviderId, ProviderAccountData>>,
+}
+
+pub(crate) fn build_credential_storage_status(
+    provider: ProviderId,
+    account_id: Option<&str>,
+    sources: CredentialStorageSources<'_>,
+) -> CredentialStorageStatusBridge {
+    let provider_id = provider.cli_name();
+    CredentialStorageStatusBridge {
+        manual_cookies: provider_store_status(
+            sources.manual_cookie_file_status,
+            sources
+                .manual_cookies
+                .map(|store| store.get(provider_id).is_some()),
+        ),
+        api_keys: provider_store_status(
+            sources.api_key_file_status,
+            sources
+                .api_keys
+                .map(|store| store.get(provider_id).is_some()),
+        ),
+        token_accounts: provider_store_status(
+            Some(sources.token_account_file_status),
+            sources.token_accounts.map(|store| {
+                store
+                    .get(&provider)
+                    .is_some_and(|accounts| match account_id {
+                        Some(account_id) => accounts
+                            .accounts
+                            .iter()
+                            .any(|account| account.id.to_string() == account_id),
+                        None => !accounts.accounts.is_empty(),
+                    })
+            }),
+        ),
+    }
 }
 
 #[tauri::command]
-pub fn get_credential_storage_status() -> CredentialStorageStatusBridge {
-    CredentialStorageStatusBridge {
-        manual_cookies: optional_credential_status(ManualCookies::cookies_path()),
-        api_keys: optional_credential_status(ApiKeys::keys_path()),
-        token_accounts: credential_file_status_label(secure_file::status(
-            &TokenAccountStore::default_path(),
-        )),
-    }
+pub fn get_credential_storage_status(
+    provider_id: String,
+    account_id: Option<String>,
+) -> Result<CredentialStorageStatusBridge, String> {
+    let provider = parse_provider_arg(&provider_id)?;
+    let manual_cookie_file_status =
+        ManualCookies::cookies_path().map(|path| secure_file::status(&path));
+    let api_key_file_status = ApiKeys::keys_path().map(|path| secure_file::status(&path));
+    let token_store = TokenAccountStore::new();
+    let token_account_file_status = secure_file::status(&TokenAccountStore::default_path());
+
+    let manual_cookies = ManualCookies::try_load_for_read().ok();
+    let api_keys = ApiKeys::try_load_for_read().ok();
+    let token_accounts = token_store.load().ok();
+
+    Ok(build_credential_storage_status(
+        provider,
+        account_id.as_deref(),
+        CredentialStorageSources {
+            manual_cookie_file_status,
+            manual_cookies: manual_cookies.as_ref(),
+            api_key_file_status,
+            api_keys: api_keys.as_ref(),
+            token_account_file_status,
+            token_accounts: token_accounts.as_ref(),
+        },
+    ))
 }

--- a/apps/desktop-tauri/src-tauri/src/commands/provider_detail.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/provider_detail.rs
@@ -269,7 +269,6 @@ pub(crate) struct CredentialStorageSources<'a> {
 
 pub(crate) fn build_credential_storage_status(
     provider: ProviderId,
-    account_id: Option<&str>,
     sources: CredentialStorageSources<'_>,
 ) -> CredentialStorageStatusBridge {
     let provider_id = provider.cli_name();
@@ -291,13 +290,7 @@ pub(crate) fn build_credential_storage_status(
             sources.token_accounts.map(|store| {
                 store
                     .get(&provider)
-                    .is_some_and(|accounts| match account_id {
-                        Some(account_id) => accounts
-                            .accounts
-                            .iter()
-                            .any(|account| account.id.to_string() == account_id),
-                        None => !accounts.accounts.is_empty(),
-                    })
+                    .is_some_and(|accounts| !accounts.accounts.is_empty())
             }),
         ),
     }
@@ -306,7 +299,6 @@ pub(crate) fn build_credential_storage_status(
 #[tauri::command]
 pub fn get_credential_storage_status(
     provider_id: String,
-    account_id: Option<String>,
 ) -> Result<CredentialStorageStatusBridge, String> {
     let provider = parse_provider_arg(&provider_id)?;
     let manual_cookie_file_status =
@@ -321,7 +313,6 @@ pub fn get_credential_storage_status(
 
     Ok(build_credential_storage_status(
         provider,
-        account_id.as_deref(),
         CredentialStorageSources {
             manual_cookie_file_status,
             manual_cookies: manual_cookies.as_ref(),

--- a/apps/desktop-tauri/src-tauri/src/commands/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/tests.rs
@@ -100,11 +100,124 @@ fn credential_status_labels_do_not_include_error_details() {
 }
 
 #[test]
+fn credential_status_is_scoped_to_the_selected_provider() {
+    let mut api_keys = ApiKeys::default();
+    api_keys.set("claude", "sk-claude", None);
+    let mut manual_cookies = ManualCookies::default();
+    manual_cookies.set("claude", "sessionKey=secret");
+    let mut account_data = ProviderAccountData::new();
+    let token_account = TokenAccount::new("Claude", "token-secret");
+    let token_account_id = token_account.id.to_string();
+    account_data.add_account(token_account);
+    let mut token_accounts = HashMap::new();
+    token_accounts.insert(ProviderId::Claude, account_data);
+
+    let protected =
+        || codexbar::secure_file::SecureFileStatus::Protected("windows-dpapi-user".to_string());
+    let claude = super::build_credential_storage_status(
+        ProviderId::Claude,
+        Some(&token_account_id),
+        super::CredentialStorageSources {
+            manual_cookie_file_status: Some(protected()),
+            manual_cookies: Some(&manual_cookies),
+            api_key_file_status: Some(protected()),
+            api_keys: Some(&api_keys),
+            token_account_file_status: protected(),
+            token_accounts: Some(&token_accounts),
+        },
+    );
+    assert_eq!(claude.api_keys.has_provider_credentials, Some(true));
+    assert_eq!(claude.manual_cookies.has_provider_credentials, Some(true));
+    assert_eq!(claude.token_accounts.has_provider_credentials, Some(true));
+
+    // The files remain globally protected, but another provider has no entry
+    // in any of them and must not inherit Claude's status in its detail pane.
+    let codex = super::build_credential_storage_status(
+        ProviderId::Codex,
+        None,
+        super::CredentialStorageSources {
+            manual_cookie_file_status: Some(protected()),
+            manual_cookies: Some(&manual_cookies),
+            api_key_file_status: Some(protected()),
+            api_keys: Some(&api_keys),
+            token_account_file_status: protected(),
+            token_accounts: Some(&token_accounts),
+        },
+    );
+    assert_eq!(codex.api_keys.file_status, "protected:windows-dpapi-user");
+    assert_eq!(codex.api_keys.has_provider_credentials, Some(false));
+    assert_eq!(codex.manual_cookies.has_provider_credentials, Some(false));
+    assert_eq!(codex.token_accounts.has_provider_credentials, Some(false));
+
+    let different_claude_account = super::build_credential_storage_status(
+        ProviderId::Claude,
+        Some("00000000-0000-0000-0000-000000000000"),
+        super::CredentialStorageSources {
+            manual_cookie_file_status: Some(protected()),
+            manual_cookies: Some(&manual_cookies),
+            api_key_file_status: Some(protected()),
+            api_keys: Some(&api_keys),
+            token_account_file_status: protected(),
+            token_accounts: Some(&token_accounts),
+        },
+    );
+    assert_eq!(
+        different_claude_account
+            .token_accounts
+            .has_provider_credentials,
+        Some(false)
+    );
+
+    api_keys.remove("claude");
+    manual_cookies.remove("claude");
+    token_accounts.remove(&ProviderId::Claude);
+    let revoked = super::build_credential_storage_status(
+        ProviderId::Claude,
+        Some(&token_account_id),
+        super::CredentialStorageSources {
+            manual_cookie_file_status: Some(protected()),
+            manual_cookies: Some(&manual_cookies),
+            api_key_file_status: Some(protected()),
+            api_keys: Some(&api_keys),
+            token_account_file_status: protected(),
+            token_accounts: Some(&token_accounts),
+        },
+    );
+    assert_eq!(revoked.api_keys.has_provider_credentials, Some(false));
+    assert_eq!(revoked.manual_cookies.has_provider_credentials, Some(false));
+    assert_eq!(revoked.token_accounts.has_provider_credentials, Some(false));
+}
+
+#[test]
+fn unreadable_credential_store_does_not_claim_provider_absence() {
+    let status = super::build_credential_storage_status(
+        ProviderId::Claude,
+        None,
+        super::CredentialStorageSources {
+            manual_cookie_file_status: Some(codexbar::secure_file::SecureFileStatus::Unreadable(
+                "secret error".to_string(),
+            )),
+            manual_cookies: None,
+            api_key_file_status: Some(codexbar::secure_file::SecureFileStatus::Missing),
+            api_keys: Some(&ApiKeys::default()),
+            token_account_file_status: codexbar::secure_file::SecureFileStatus::Missing,
+            token_accounts: Some(&HashMap::new()),
+        },
+    );
+
+    assert_eq!(status.manual_cookies.file_status, "unreadable");
+    assert_eq!(status.manual_cookies.has_provider_credentials, None);
+    assert_eq!(status.api_keys.has_provider_credentials, Some(false));
+    assert_eq!(status.token_accounts.has_provider_credentials, Some(false));
+}
+
+#[test]
 fn command_inputs_reject_invalid_provider_ids_before_storage_writes() {
     assert!(super::set_api_key("not-a-provider".into(), "sk-test".into(), None).is_err());
     assert!(super::set_manual_cookie("not-a-provider".into(), "a=b".into()).is_err());
     assert!(super::remove_api_key("bad\nprovider".into()).is_err());
     assert!(super::remove_manual_cookie("".into()).is_err());
+    assert!(super::get_credential_storage_status("not-a-provider".into(), None).is_err());
 }
 
 #[test]

--- a/apps/desktop-tauri/src-tauri/src/commands/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/tests.rs
@@ -100,7 +100,7 @@ fn credential_status_labels_do_not_include_error_details() {
 }
 
 #[test]
-fn credential_status_is_scoped_to_the_selected_provider() {
+fn credential_status_is_scoped_to_the_provider() {
     let mut api_keys = ApiKeys::default();
     api_keys.set("claude", "sk-claude", None);
     let mut manual_cookies = ManualCookies::default();
@@ -108,15 +108,19 @@ fn credential_status_is_scoped_to_the_selected_provider() {
     let mut account_data = ProviderAccountData::new();
     let token_account = TokenAccount::new("Claude", "token-secret");
     let token_account_id = token_account.id.to_string();
+    let detail_account_id = "00000000-0000-0000-0000-000000000000";
+    assert_ne!(token_account_id, detail_account_id);
     account_data.add_account(token_account);
     let mut token_accounts = HashMap::new();
     token_accounts.insert(ProviderId::Claude, account_data);
 
     let protected =
         || codexbar::secure_file::SecureFileStatus::Protected("windows-dpapi-user".to_string());
+    // Detail-pane account tabs use a separate UUID namespace from token
+    // accounts. The detail account ID is intentionally not an input here:
+    // credential presence is provider-level.
     let claude = super::build_credential_storage_status(
         ProviderId::Claude,
-        Some(&token_account_id),
         super::CredentialStorageSources {
             manual_cookie_file_status: Some(protected()),
             manual_cookies: Some(&manual_cookies),
@@ -134,7 +138,6 @@ fn credential_status_is_scoped_to_the_selected_provider() {
     // in any of them and must not inherit Claude's status in its detail pane.
     let codex = super::build_credential_storage_status(
         ProviderId::Codex,
-        None,
         super::CredentialStorageSources {
             manual_cookie_file_status: Some(protected()),
             manual_cookies: Some(&manual_cookies),
@@ -149,31 +152,11 @@ fn credential_status_is_scoped_to_the_selected_provider() {
     assert_eq!(codex.manual_cookies.has_provider_credentials, Some(false));
     assert_eq!(codex.token_accounts.has_provider_credentials, Some(false));
 
-    let different_claude_account = super::build_credential_storage_status(
-        ProviderId::Claude,
-        Some("00000000-0000-0000-0000-000000000000"),
-        super::CredentialStorageSources {
-            manual_cookie_file_status: Some(protected()),
-            manual_cookies: Some(&manual_cookies),
-            api_key_file_status: Some(protected()),
-            api_keys: Some(&api_keys),
-            token_account_file_status: protected(),
-            token_accounts: Some(&token_accounts),
-        },
-    );
-    assert_eq!(
-        different_claude_account
-            .token_accounts
-            .has_provider_credentials,
-        Some(false)
-    );
-
     api_keys.remove("claude");
     manual_cookies.remove("claude");
     token_accounts.remove(&ProviderId::Claude);
     let revoked = super::build_credential_storage_status(
         ProviderId::Claude,
-        Some(&token_account_id),
         super::CredentialStorageSources {
             manual_cookie_file_status: Some(protected()),
             manual_cookies: Some(&manual_cookies),
@@ -192,7 +175,6 @@ fn credential_status_is_scoped_to_the_selected_provider() {
 fn unreadable_credential_store_does_not_claim_provider_absence() {
     let status = super::build_credential_storage_status(
         ProviderId::Claude,
-        None,
         super::CredentialStorageSources {
             manual_cookie_file_status: Some(codexbar::secure_file::SecureFileStatus::Unreadable(
                 "secret error".to_string(),
@@ -217,7 +199,7 @@ fn command_inputs_reject_invalid_provider_ids_before_storage_writes() {
     assert!(super::set_manual_cookie("not-a-provider".into(), "a=b".into()).is_err());
     assert!(super::remove_api_key("bad\nprovider".into()).is_err());
     assert!(super::remove_manual_cookie("".into()).is_err());
-    assert!(super::get_credential_storage_status("not-a-provider".into(), None).is_err());
+    assert!(super::get_credential_storage_status("not-a-provider".into()).is_err());
 }
 
 #[test]

--- a/apps/desktop-tauri/src/lib/tauri.ts
+++ b/apps/desktop-tauri/src/lib/tauri.ts
@@ -158,8 +158,14 @@ export function getWorkAreaRect(): Promise<WorkAreaRect> {
   return invoke<WorkAreaRect>("get_work_area_rect");
 }
 
-export function getCredentialStorageStatus(): Promise<CredentialStorageStatus> {
-  return invoke<CredentialStorageStatus>("get_credential_storage_status");
+export function getCredentialStorageStatus(
+  providerId: string,
+  accountId: string | null = null,
+): Promise<CredentialStorageStatus> {
+  return invoke<CredentialStorageStatus>("get_credential_storage_status", {
+    providerId,
+    accountId,
+  });
 }
 
 export function getUpdateState(): Promise<UpdateStatePayload> {

--- a/apps/desktop-tauri/src/lib/tauri.ts
+++ b/apps/desktop-tauri/src/lib/tauri.ts
@@ -160,11 +160,9 @@ export function getWorkAreaRect(): Promise<WorkAreaRect> {
 
 export function getCredentialStorageStatus(
   providerId: string,
-  accountId: string | null = null,
 ): Promise<CredentialStorageStatus> {
   return invoke<CredentialStorageStatus>("get_credential_storage_status", {
     providerId,
-    accountId,
   });
 }
 

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ApiKeySection.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ApiKeySection.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiKeySection } from "./ApiKeySection";
+
+const tauriMocks = vi.hoisted(() => ({
+  getApiKeyProviders: vi.fn(),
+  getApiKeys: vi.fn(),
+  removeApiKey: vi.fn(),
+  setApiKey: vi.fn(),
+}));
+
+vi.mock("../../../lib/tauri", () => tauriMocks);
+
+describe("ApiKeySection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tauriMocks.getApiKeyProviders.mockResolvedValue([
+      {
+        id: "claude",
+        displayName: "Claude",
+        envVar: null,
+        help: null,
+        dashboardUrl: null,
+      },
+    ]);
+    tauriMocks.getApiKeys.mockResolvedValue([]);
+    tauriMocks.setApiKey.mockResolvedValue([
+      {
+        providerId: "claude",
+        provider: "Claude",
+        maskedKey: "sk-...test",
+        savedAt: "now",
+        label: null,
+      },
+    ]);
+  });
+
+  it("notifies the detail pane after a key is saved", async () => {
+    const onCredentialsChanged = vi.fn();
+    render(
+      <ApiKeySection
+        providerId="claude"
+        onCredentialsChanged={onCredentialsChanged}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add Key" }));
+    fireEvent.change(screen.getByPlaceholderText("Paste API key…"), {
+      target: { value: "sk-test" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(onCredentialsChanged).toHaveBeenCalledOnce());
+    expect(tauriMocks.setApiKey).toHaveBeenCalledWith(
+      "claude",
+      "sk-test",
+      undefined,
+    );
+  });
+});

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ApiKeySection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ApiKeySection.tsx
@@ -12,6 +12,7 @@ import type {
 
 interface Props {
   providerId: string;
+  onCredentialsChanged?: () => void;
 }
 
 /**
@@ -19,7 +20,7 @@ interface Props {
  * Mirrors the upstream macOS layout where credential management lives next
  * to provider state instead of in a separate tab.
  */
-export function ApiKeySection({ providerId }: Props) {
+export function ApiKeySection({ providerId, onCredentialsChanged }: Props) {
   const [info, setInfo] = useState<ApiKeyProviderInfoBridge | null>(null);
   const [saved, setSaved] = useState<ApiKeyInfoBridge | null>(null);
   const [loaded, setLoaded] = useState(false);
@@ -89,6 +90,7 @@ export function ApiKeySection({ providerId }: Props) {
       setEditing(false);
       setEditValue("");
       setEditLabel("");
+      onCredentialsChanged?.();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -102,6 +104,7 @@ export function ApiKeySection({ providerId }: Props) {
     try {
       const next = await removeApiKey(providerId);
       setSaved(next.find((k) => k.providerId === providerId) ?? null);
+      onCredentialsChanged?.();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {

--- a/apps/desktop-tauri/src/surfaces/settings/providers/CookieSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/CookieSection.tsx
@@ -10,6 +10,7 @@ import type { CookieInfoBridge } from "../../../types/bridge";
 interface Props {
   providerId: string;
   cookieDomain: string | null;
+  onCredentialsChanged?: () => void;
 }
 
 function cookiePlaceholder(
@@ -29,7 +30,11 @@ function cookiePlaceholder(
  * Per-provider browser cookie management. Renders nothing for providers
  * that do not have a cookieDomain (i.e. don't authenticate via web cookies).
  */
-export function CookieSection({ providerId, cookieDomain }: Props) {
+export function CookieSection({
+  providerId,
+  cookieDomain,
+  onCredentialsChanged,
+}: Props) {
   const { t } = useLocale();
   const [saved, setSaved] = useState<CookieInfoBridge | null>(null);
   const [loaded, setLoaded] = useState(false);
@@ -71,6 +76,7 @@ export function CookieSection({ providerId, cookieDomain }: Props) {
     try {
       const next = await removeManualCookie(providerId);
       setSaved(next.find((c) => c.providerId === providerId) ?? null);
+      onCredentialsChanged?.();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -86,6 +92,7 @@ export function CookieSection({ providerId, cookieDomain }: Props) {
       const next = await setManualCookie(providerId, pasteValue.trim());
       setSaved(next.find((c) => c.providerId === providerId) ?? null);
       setPasteValue("");
+      onCredentialsChanged?.();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.credential-refresh.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.credential-refresh.test.tsx
@@ -139,4 +139,90 @@ describe("ProviderDetailPane credential status refresh", () => {
       screen.getByRole("button", { name: "CredentialRevokeStored" }),
     ).toBeInTheDocument();
   });
+
+  it("does not leak a Claude account tab into the next provider's token status", async () => {
+    const claudeWorkId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    const claudePersonalId = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    const claudeDetail: ProviderDetail = {
+      ...providerDetail,
+      accountId: claudeWorkId,
+      accounts: [
+        { accountId: claudeWorkId, label: "Work", tint: null },
+        { accountId: claudePersonalId, label: "Personal", tint: null },
+      ],
+    };
+    const cursorDetail: ProviderDetail = {
+      ...providerDetail,
+      id: "cursor",
+      displayName: "Cursor",
+    };
+    const tokenPresentStatus: CredentialStorageStatus = {
+      ...absentStatus,
+      tokenAccounts: {
+        fileStatus: "protected:windows-dpapi-user",
+        hasProviderCredentials: true,
+      },
+    };
+
+    tauriMocks.getProviderDetail.mockImplementation(
+      async (id: string, accountId: string | null) => {
+        if (id === "cursor") return cursorDetail;
+        if (accountId === claudePersonalId) {
+          return { ...claudeDetail, accountId: claudePersonalId };
+        }
+        return claudeDetail;
+      },
+    );
+    tauriMocks.getCredentialStorageStatus.mockImplementation(async (id: string) =>
+      id === "cursor" ? tokenPresentStatus : absentStatus,
+    );
+
+    const view = render(
+      <ProviderDetailPane
+        providerId="claude"
+        resetTimeRelative
+        providerMetrics={{}}
+        wayfinderGatewayUrl=""
+        settingsDisabled={false}
+        onSettingsChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: "Personal" })).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("tab", { name: "Personal" }));
+    await waitFor(() =>
+      expect(tauriMocks.getProviderDetail).toHaveBeenCalledWith(
+        "claude",
+        claudePersonalId,
+      ),
+    );
+
+    view.rerender(
+      <ProviderDetailPane
+        providerId="cursor"
+        resetTimeRelative
+        providerMetrics={{}}
+        wayfinderGatewayUrl=""
+        settingsDisabled={false}
+        onSettingsChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText(
+        "CredentialProtectedPrefix (windows-dpapi-user)",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "CredentialRevokeStored" }),
+    ).toBeInTheDocument();
+    expect(tauriMocks.getProviderDetail).toHaveBeenCalledWith("cursor", null);
+    expect(tauriMocks.getProviderDetail).not.toHaveBeenCalledWith(
+      "cursor",
+      claudePersonalId,
+    );
+    expect(tauriMocks.getCredentialStorageStatus).toHaveBeenCalledWith("cursor");
+  });
 });

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.credential-refresh.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.credential-refresh.test.tsx
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  CredentialStorageStatus,
+  ProviderDetail,
+} from "../../../types/bridge";
+import { ProviderDetailPane } from "./ProviderDetailPane";
+
+const tauriMocks = vi.hoisted(() => ({
+  getCredentialStorageStatus: vi.fn(),
+  getProviderDetail: vi.fn(),
+  getProviderRegionOptions: vi.fn(),
+  getTokenAccountProviders: vi.fn(),
+}));
+
+vi.mock("../../../lib/tauri", () => ({
+  ...tauriMocks,
+  openProviderDashboard: vi.fn(),
+  openProviderStatusPage: vi.fn(),
+  refreshProviders: vi.fn(),
+  revokeProviderCredentials: vi.fn(),
+  setProviderGatewayUrl: vi.fn(),
+  triggerProviderLogin: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+vi.mock("../../../hooks/useLocale", () => ({
+  useLocale: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("./sections/IdentitySection", () => ({ IdentitySection: () => null }));
+vi.mock("./sections/DataSourceSection", () => ({ DataSourceSection: () => null }));
+vi.mock("./sections/UsageSection", () => ({ UsageSection: () => null }));
+vi.mock("./sections/PaceSection", () => ({ PaceSection: () => null }));
+vi.mock("./sections/CostSection", () => ({ CostSection: () => null }));
+vi.mock("./sections/QuickActionsSection", () => ({ QuickActionsSection: () => null }));
+vi.mock("./sections/charts/ChartsSection", () => ({ ChartsSection: () => null }));
+vi.mock("./sections/RegionSection", () => ({ RegionSection: () => null }));
+vi.mock("./sections/credentials/GeminiCliCreds", () => ({ GeminiCliCreds: () => null }));
+vi.mock("./sections/credentials/VertexAiCreds", () => ({ VertexAiCreds: () => null }));
+vi.mock("./sections/credentials/JetBrainsCreds", () => ({ JetBrainsCreds: () => null }));
+vi.mock("./sections/credentials/KiroCreds", () => ({ KiroCreds: () => null }));
+vi.mock("./sections/credentials/ClaudeCreds", () => ({ ClaudeCreds: () => null }));
+vi.mock("./sections/credentials/CodexUsageOptions", () => ({ CodexUsageOptions: () => null }));
+vi.mock("./sections/credentials/OpenAiExtras", () => ({ OpenAiExtras: () => null }));
+vi.mock("../tokens/TokenAccountsPanel", () => ({ TokenAccountsPanel: () => null }));
+vi.mock("./CookieSection", () => ({ CookieSection: () => null }));
+vi.mock("./sections/MenuBarMetricSection", () => ({ MenuBarMetricSection: () => null }));
+vi.mock("./ApiKeySection", () => ({
+  ApiKeySection: ({
+    onCredentialsChanged,
+  }: {
+    onCredentialsChanged?: () => void;
+  }) => <button onClick={onCredentialsChanged}>save-api-key</button>,
+}));
+
+const absentStatus: CredentialStorageStatus = {
+  apiKeys: { fileStatus: "missing", hasProviderCredentials: false },
+  manualCookies: { fileStatus: "missing", hasProviderCredentials: false },
+  tokenAccounts: { fileStatus: "missing", hasProviderCredentials: false },
+};
+
+const apiKeyPresentStatus: CredentialStorageStatus = {
+  ...absentStatus,
+  apiKeys: {
+    fileStatus: "protected:windows-dpapi-user",
+    hasProviderCredentials: true,
+  },
+};
+
+const providerDetail: ProviderDetail = {
+  id: "claude",
+  displayName: "Claude",
+  enabled: true,
+  accountId: null,
+  accounts: [],
+  email: null,
+  plan: null,
+  authType: null,
+  sourceLabel: null,
+  organization: null,
+  lastUpdated: null,
+  session: null,
+  weekly: null,
+  modelSpecific: null,
+  tertiary: null,
+  extraRateWindows: [],
+  cost: null,
+  pace: null,
+  lastError: null,
+  dashboardUrl: null,
+  statusPageUrl: null,
+  buyCreditsUrl: null,
+  hasSnapshot: true,
+  cookieSource: null,
+  region: null,
+};
+
+describe("ProviderDetailPane credential status refresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tauriMocks.getProviderDetail.mockResolvedValue(providerDetail);
+    tauriMocks.getProviderRegionOptions.mockResolvedValue([]);
+    tauriMocks.getTokenAccountProviders.mockResolvedValue([]);
+  });
+
+  it("refreshes storage labels and exposes revoke after an inline save", async () => {
+    tauriMocks.getCredentialStorageStatus
+      .mockResolvedValueOnce(absentStatus)
+      .mockResolvedValueOnce(apiKeyPresentStatus);
+
+    render(
+      <ProviderDetailPane
+        providerId="claude"
+        resetTimeRelative
+        providerMetrics={{}}
+        wayfinderGatewayUrl=""
+        settingsDisabled={false}
+        onSettingsChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getAllByText("CredentialStatusNotCreated")).toHaveLength(3),
+    );
+    expect(
+      screen.queryByRole("button", { name: "CredentialRevokeStored" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "save-api-key" }));
+
+    expect(
+      await screen.findByText(
+        "CredentialProtectedPrefix (windows-dpapi-user)",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "CredentialRevokeStored" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.credential-storage.test.ts
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.credential-storage.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { LocaleKey } from "../../../i18n/keys";
-import { storageLabel } from "./ProviderDetailPane";
+import {
+  shouldShowCredentialRevoke,
+  storageLabel,
+} from "./ProviderDetailPane";
 
 const t = (key: LocaleKey) => key;
 
@@ -39,5 +42,40 @@ describe("provider credential storage labels", () => {
         t,
       ),
     ).toBe("CredentialStatusUnreadable");
+  });
+
+  it("keeps revoke available when credential presence is unknown", () => {
+    expect(
+      shouldShowCredentialRevoke({
+        apiKeys: {
+          fileStatus: "unreadable",
+          hasProviderCredentials: null,
+        },
+        manualCookies: {
+          fileStatus: "unavailable",
+          hasProviderCredentials: null,
+        },
+        tokenAccounts: {
+          fileStatus: "unreadable",
+          hasProviderCredentials: null,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("hides revoke only when every store confirms absence", () => {
+    expect(
+      shouldShowCredentialRevoke({
+        apiKeys: { fileStatus: "missing", hasProviderCredentials: false },
+        manualCookies: {
+          fileStatus: "missing",
+          hasProviderCredentials: false,
+        },
+        tokenAccounts: {
+          fileStatus: "missing",
+          hasProviderCredentials: false,
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.credential-storage.test.ts
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.credential-storage.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import type { LocaleKey } from "../../../i18n/keys";
+import { storageLabel } from "./ProviderDetailPane";
+
+const t = (key: LocaleKey) => key;
+
+describe("provider credential storage labels", () => {
+  it("does not present another provider's protected file as this provider's credential", () => {
+    expect(
+      storageLabel(
+        {
+          fileStatus: "protected:windows-dpapi-user",
+          hasProviderCredentials: false,
+        },
+        t,
+      ),
+    ).toBe("CredentialStatusNotCreated");
+  });
+
+  it("shows protection only when this provider has a credential", () => {
+    expect(
+      storageLabel(
+        {
+          fileStatus: "protected:windows-dpapi-user",
+          hasProviderCredentials: true,
+        },
+        t,
+      ),
+    ).toBe("CredentialProtectedPrefix (windows-dpapi-user)");
+  });
+
+  it("does not claim absence when provider presence could not be read", () => {
+    expect(
+      storageLabel(
+        {
+          fileStatus: "protected:windows-dpapi-user",
+          hasProviderCredentials: null,
+        },
+        t,
+      ),
+    ).toBe("CredentialStatusUnreadable");
+  });
+});

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
@@ -185,19 +185,22 @@ export function ProviderDetailPane({
       if (credentialStatusEpochRef.current === credentialRequestEpoch) {
         setCredentialStatus(null);
       }
-    // A selection belongs to one provider; carrying it across panes would
-    // ask for an account that provider does not have.
-    setSelectedAccountId(null);
-    selectedAccountIdRef.current = null;
+      setSelectedAccountId(null);
+      selectedAccountIdRef.current = null;
     } finally {
       if (!signal?.stale) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
+    // ProvidersTab keeps one pane instance. A Claude directory-account tab
+    // must not be sent to the next provider as getProviderDetail(accountId).
+    setSelectedAccountId(null);
+    selectedAccountIdRef.current = null;
     if (!providerId) {
       setDetail(null);
       setRegionOptions([]);
+      setCredentialStatus(null);
       return;
     }
     // Clear stale detail immediately so we don't render the old provider
@@ -205,7 +208,7 @@ export function ProviderDetailPane({
     setRegionOptions([]);
     setCredentialStatus(null);
     const signal = { stale: false };
-    void load(providerId, signal, selectedAccountIdRef.current);
+    void load(providerId, signal, null);
     return () => { signal.stale = true; };
   }, [providerId, load]);
 

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type {
+  CredentialStoreStatus,
   CredentialStorageStatus,
   ProviderDetail,
   RegionOption,
@@ -144,7 +145,7 @@ export function ProviderDetailPane({
       const [next, regionOpts, storageStatus] = await Promise.all([
         getProviderDetail(id, accountId),
         getProviderRegionOptions(id),
-        getCredentialStorageStatus(),
+        getCredentialStorageStatus(id, accountId),
       ]);
       if (signal?.stale) return;
       setDetail(next);
@@ -541,18 +542,25 @@ function CredentialStorageSection({
   t: ReturnType<typeof useLocale>["t"];
 }) {
   if (!status) return null;
+  const hasProviderCredentials = [
+    status.apiKeys,
+    status.manualCookies,
+    status.tokenAccounts,
+  ].some((entry) => entry.hasProviderCredentials === true);
 
   return (
     <section className="provider-detail-section provider-detail-credential-storage">
       <div className="provider-detail-section__header">
         <h4>{t("CredentialStorageTitle")}</h4>
-        <button
-          className="credential-btn credential-btn--danger"
-          disabled={busy}
-          onClick={onRevoke}
-        >
-          {t("CredentialRevokeStored")}
-        </button>
+        {hasProviderCredentials && (
+          <button
+            className="credential-btn credential-btn--danger"
+            disabled={busy}
+            onClick={onRevoke}
+          >
+            {t("CredentialRevokeStored")}
+          </button>
+        )}
       </div>
       <dl className="provider-detail-grid provider-detail-grid--storage">
         <dt>{t("CredentialApiKeys")}</dt>
@@ -566,7 +574,25 @@ function CredentialStorageSection({
   );
 }
 
-function storageLabel(value: string, t: ReturnType<typeof useLocale>["t"]): string {
+export function storageLabel(
+  value: CredentialStoreStatus,
+  t: ReturnType<typeof useLocale>["t"],
+): string {
+  if (value.hasProviderCredentials === false) {
+    return t("CredentialStatusNotCreated");
+  }
+  if (value.hasProviderCredentials === null) {
+    return value.fileStatus === "unavailable"
+      ? t("CredentialStatusUnavailable")
+      : t("CredentialStatusUnreadable");
+  }
+  return credentialFileStatusLabel(value.fileStatus, t);
+}
+
+function credentialFileStatusLabel(
+  value: string,
+  t: ReturnType<typeof useLocale>["t"],
+): string {
   if (value.startsWith("protected:")) {
     return `${t("CredentialProtectedPrefix")} (${value.slice("protected:".length)})`;
   }

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
@@ -93,6 +93,9 @@ export function ProviderDetailPane({
   const [loginUrl, setLoginUrl] = useState<string | null>(null);
   const [gatewayDraft, setGatewayDraft] = useState(wayfinderGatewayUrl);
   const [gatewayError, setGatewayError] = useState<string | null>(null);
+  const activeProviderIdRef = useRef(providerId);
+  const credentialStatusEpochRef = useRef(0);
+  activeProviderIdRef.current = providerId;
 
   useEffect(() => {
     if (providerId === "wayfinder") setGatewayDraft(wayfinderGatewayUrl);
@@ -134,29 +137,54 @@ export function ProviderDetailPane({
   const selectedAccountIdRef = useRef<string | null>(null);
   selectedAccountIdRef.current = selectedAccountId;
 
+  const refreshCredentialStatus = useCallback(async (id: string) => {
+    const requestEpoch = ++credentialStatusEpochRef.current;
+    try {
+      const storageStatus = await getCredentialStorageStatus(id);
+      if (
+        activeProviderIdRef.current === id &&
+        credentialStatusEpochRef.current === requestEpoch
+      ) {
+        setCredentialStatus(storageStatus);
+      }
+    } catch (e) {
+      if (
+        activeProviderIdRef.current === id &&
+        credentialStatusEpochRef.current === requestEpoch
+      ) {
+        setError(String(e));
+      }
+    }
+  }, []);
+
   const load = useCallback(async (
     id: string,
     signal?: { stale: boolean },
     accountId: string | null = null,
   ) => {
+    const credentialRequestEpoch = ++credentialStatusEpochRef.current;
     setLoading(true);
     setError(null);
     try {
       const [next, regionOpts, storageStatus] = await Promise.all([
         getProviderDetail(id, accountId),
         getProviderRegionOptions(id),
-        getCredentialStorageStatus(id, accountId),
+        getCredentialStorageStatus(id),
       ]);
       if (signal?.stale) return;
       setDetail(next);
       setRegionOptions(regionOpts);
-      setCredentialStatus(storageStatus);
+      if (credentialStatusEpochRef.current === credentialRequestEpoch) {
+        setCredentialStatus(storageStatus);
+      }
     } catch (e) {
       if (signal?.stale) return;
       setError(String(e));
       setDetail(null);
       setRegionOptions([]);
-      setCredentialStatus(null);
+      if (credentialStatusEpochRef.current === credentialRequestEpoch) {
+        setCredentialStatus(null);
+      }
     // A selection belongs to one provider; carrying it across panes would
     // ask for an account that provider does not have.
     setSelectedAccountId(null);
@@ -439,16 +467,19 @@ export function ProviderDetailPane({
             key={`token-${detail.id}-${credentialRevision}`}
             providerId={detail.id}
             compact
+            onCredentialsChanged={() => void refreshCredentialStatus(detail.id)}
           />
         )}
         <ApiKeySection
           key={`api-${detail.id}-${credentialRevision}`}
           providerId={detail.id}
+          onCredentialsChanged={() => void refreshCredentialStatus(detail.id)}
         />
         <CookieSection
           key={`cookie-${detail.id}-${credentialRevision}`}
           providerId={detail.id}
           cookieDomain={cookieDomain}
+          onCredentialsChanged={() => void refreshCredentialStatus(detail.id)}
         />
         <ChartsSection
           providerId={detail.id}
@@ -542,11 +573,7 @@ function CredentialStorageSection({
   t: ReturnType<typeof useLocale>["t"];
 }) {
   if (!status) return null;
-  const hasProviderCredentials = [
-    status.apiKeys,
-    status.manualCookies,
-    status.tokenAccounts,
-  ].some((entry) => entry.hasProviderCredentials === true);
+  const hasProviderCredentials = shouldShowCredentialRevoke(status);
 
   return (
     <section className="provider-detail-section provider-detail-credential-storage">
@@ -571,6 +598,14 @@ function CredentialStorageSection({
         <dd>{storageLabel(status.tokenAccounts, t)}</dd>
       </dl>
     </section>
+  );
+}
+
+export function shouldShowCredentialRevoke(
+  status: CredentialStorageStatus,
+): boolean {
+  return [status.apiKeys, status.manualCookies, status.tokenAccounts].some(
+    (entry) => entry.hasProviderCredentials !== false,
   );
 }
 

--- a/apps/desktop-tauri/src/surfaces/settings/tokens/TokenAccountsPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tokens/TokenAccountsPanel.test.tsx
@@ -45,6 +45,12 @@ function emitLoginPhaseChanged(payload: unknown) {
   }
 }
 
+async function waitForLoginPhaseListener() {
+  await waitFor(() =>
+    expect(eventMocks.listeners.get("login-phase-changed")).toHaveLength(1),
+  );
+}
+
 describe("TokenAccountsPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -71,6 +77,7 @@ describe("TokenAccountsPanel", () => {
     );
 
     await screen.findByText("TokenAccountGithubLoginButton");
+    await waitForLoginPhaseListener();
 
     act(() => {
       emitLoginPhaseChanged({
@@ -101,6 +108,7 @@ describe("TokenAccountsPanel", () => {
     );
 
     await screen.findByText("TokenAccountGithubLoginButton");
+    await waitForLoginPhaseListener();
 
     act(() => {
       emitLoginPhaseChanged({
@@ -131,6 +139,7 @@ describe("TokenAccountsPanel", () => {
     );
 
     await screen.findByText("TokenAccountGithubLoginButton");
+    await waitForLoginPhaseListener();
     act(() => {
       emitLoginPhaseChanged({
         providerId: "copilot",
@@ -162,6 +171,7 @@ describe("TokenAccountsPanel", () => {
     );
 
     await screen.findByText("TokenAccountGithubLoginButton");
+    await waitForLoginPhaseListener();
     act(() => {
       emitLoginPhaseChanged({
         providerId: "copilot",
@@ -200,6 +210,7 @@ describe("TokenAccountsPanel", () => {
     );
 
     await screen.findByText("TokenAccountGithubLoginButton");
+    await waitForLoginPhaseListener();
 
     act(() => {
       emitLoginPhaseChanged({ providerId: "copilot", phase: "requesting" });
@@ -216,6 +227,7 @@ describe("TokenAccountsPanel", () => {
     );
 
     await screen.findByText("TokenAccountGithubLoginButton");
+    await waitForLoginPhaseListener();
 
     act(() => {
       emitLoginPhaseChanged({

--- a/apps/desktop-tauri/src/surfaces/settings/tokens/TokenAccountsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tokens/TokenAccountsPanel.tsx
@@ -19,6 +19,7 @@ import { CopyIconButton } from "../../../components/MenuCard";
 
 interface Props {
   providerId: string;
+  onCredentialsChanged?: () => void;
   /**
    * When `true`, renders a tight collapsible variant suitable for embedding
    * inside the Providers → detail pane (Phase 6e inline surface).
@@ -39,7 +40,11 @@ interface Props {
  *   - `Settings.tsx::TokenAccountsTab` (compact=false, standalone tab)
  *   - `ProviderDetailPane.tsx` (compact=true, inline in detail pane)
  */
-export function TokenAccountsPanel({ providerId, compact = false }: Props) {
+export function TokenAccountsPanel({
+  providerId,
+  compact = false,
+  onCredentialsChanged,
+}: Props) {
   const { t } = useLocale();
   const [data, setData] = useState<ProviderTokenAccountsBridge | null>(null);
   const [busy, setBusy] = useState(false);
@@ -118,6 +123,7 @@ export function TokenAccountsPanel({ providerId, compact = false }: Props) {
       setData(next);
       setAddLabel("");
       setAddToken("");
+      onCredentialsChanged?.();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -132,6 +138,7 @@ export function TokenAccountsPanel({ providerId, compact = false }: Props) {
     try {
       const next = await removeTokenAccount(providerId, accountId);
       setData(next);
+      onCredentialsChanged?.();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -164,6 +171,7 @@ export function TokenAccountsPanel({ providerId, compact = false }: Props) {
     try {
       await triggerProviderLogin(providerId);
       await load();
+      onCredentialsChanged?.();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -579,10 +579,17 @@ export interface SafeDiagnostics {
   refreshIntervalSecs: number;
 }
 
+export interface CredentialStoreStatus {
+  /** Protection/readability of the shared file for every provider. */
+  fileStatus: string;
+  /** Provider-specific entry presence; null when the file cannot be decoded. */
+  hasProviderCredentials: boolean | null;
+}
+
 export interface CredentialStorageStatus {
-  manualCookies: string;
-  apiKeys: string;
-  tokenAccounts: string;
+  manualCookies: CredentialStoreStatus;
+  apiKeys: CredentialStoreStatus;
+  tokenAccounts: CredentialStoreStatus;
 }
 
 // ── Update state types ───────────────────────────────────────────────

--- a/rust/src/settings/api_keys.rs
+++ b/rust/src/settings/api_keys.rs
@@ -58,6 +58,14 @@ impl ApiKeys {
         Self::try_load().unwrap_or_default()
     }
 
+    /// Load the store fallibly for read-only status/diagnostic callers.
+    ///
+    /// Unlike [`load`](Self::load), this preserves an unreadable result so a
+    /// caller cannot mistake decode failure for provider credential absence.
+    pub fn try_load_for_read() -> anyhow::Result<Self> {
+        Self::try_load()
+    }
+
     /// Load API keys for a read-modify-write cycle, failing closed.
     ///
     /// [`save`](Self::save) replaces the entire file, so mutating a store that

--- a/rust/src/settings/manual_cookies.rs
+++ b/rust/src/settings/manual_cookies.rs
@@ -42,6 +42,14 @@ impl ManualCookies {
         Self::try_load().unwrap_or_default()
     }
 
+    /// Load the store fallibly for read-only status/diagnostic callers.
+    ///
+    /// Unlike [`load`](Self::load), this preserves an unreadable result so a
+    /// caller cannot mistake decode failure for provider credential absence.
+    pub fn try_load_for_read() -> anyhow::Result<Self> {
+        Self::try_load()
+    }
+
     /// Load manual cookies for a read-modify-write cycle, failing closed.
     ///
     /// See [`ApiKeys::load_for_update`] — `save` replaces the whole file, so a


### PR DESCRIPTION
## Summary
- separate shared credential-file protection from selected-provider credential presence
- scope token-account presence to the selected account when one is provided
- show protected storage only when that provider has a credential and hide revoke when it has none
- preserve unreadable stores as unknown rather than reporting false absence
- add provider A/provider B, different-account, revoked, and unreadable regressions

## Validation
- `pnpm run build`
- `pnpm test -- --reporter=dot --silent` (68 files, 503 tests)
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` (496 tests)
- focused credential-status Rust tests
- `cargo clippy --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Linear: SBS-731