### PR TITLE
Hide the dashboard on a second tray icon click

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/shell/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/mod.rs
@@ -23,7 +23,7 @@ pub use position::{
     default_surface_position, inferred_tray_panel_position, remember_current_geometry_if_eligible,
     shortcut_panel_position, tray_panel_position,
 };
-pub use transition::{reopen_to_target, transition_to_target};
+pub use transition::{reopen_to_target, toggle_dashboard, transition_to_target};
 #[allow(unused_imports)]
 pub use window::{
     apply_window_properties, hide_to_tray, hide_to_tray_if_current, hide_to_tray_state,

--- a/apps/desktop-tauri/src-tauri/src/shell/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/tests.rs
@@ -8,12 +8,11 @@ use super::position::{
     visible_surface_position_for_mode_with_fallbacks,
 };
 use super::transition::{
-    SurfaceSnapshot, TransitionResolution, hidden_surface_snapshot,
+    SurfaceSnapshot, TransitionResolution, TrayDashboardAction, hidden_surface_snapshot,
     monitor_for_preserved_visible_position, reclamp_preserved_visible_position,
     recovery_snapshot_for_failed_transition, resolve_transition_position,
     resolve_transition_request, restore_recovery_surface, restore_surface_snapshot,
-    should_force_tray_panel_reveal, should_hide_dashboard_on_tray_click,
-    should_synthesize_default_position,
+    should_force_tray_panel_reveal, should_synthesize_default_position, tray_dashboard_action,
 };
 use super::window::{
     hide_to_tray_state, logical_size_from_geometry, prepare_hide_to_tray_if_current,
@@ -65,12 +64,24 @@ fn conditional_hide_to_tray_leaves_non_matching_surface_alone() {
 
 #[test]
 fn tray_toggle_hides_only_when_dashboard_window_is_visible() {
-    assert!(should_hide_dashboard_on_tray_click(true, false));
-    assert!(!should_hide_dashboard_on_tray_click(false, false));
-    // A second Left+Up from a Windows double-click arrives while the
-    // just-opened dashboard is still inside the show grace.
-    assert!(!should_hide_dashboard_on_tray_click(true, true));
-    assert!(!should_hide_dashboard_on_tray_click(false, true));
+    assert_eq!(
+        tray_dashboard_action(true, false),
+        TrayDashboardAction::Hide
+    );
+    assert_eq!(
+        tray_dashboard_action(false, false),
+        TrayDashboardAction::Show
+    );
+    // Second Left+Up of a double-click after show must not hide.
+    assert_eq!(
+        tray_dashboard_action(true, true),
+        TrayDashboardAction::Ignore
+    );
+    // Second Left+Up of a double-click after hide must not reopen.
+    assert_eq!(
+        tray_dashboard_action(false, true),
+        TrayDashboardAction::Ignore
+    );
 }
 
 #[test]

--- a/apps/desktop-tauri/src-tauri/src/shell/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/tests.rs
@@ -65,26 +65,12 @@ fn conditional_hide_to_tray_leaves_non_matching_surface_alone() {
 
 #[test]
 fn tray_toggle_hides_only_when_dashboard_window_is_visible() {
-    assert!(should_hide_dashboard_on_tray_click(
-        SurfaceMode::PopOut,
-        true
-    ));
-    assert!(!should_hide_dashboard_on_tray_click(
-        SurfaceMode::PopOut,
-        false
-    ));
-    assert!(!should_hide_dashboard_on_tray_click(
-        SurfaceMode::Hidden,
-        true
-    ));
-    assert!(!should_hide_dashboard_on_tray_click(
-        SurfaceMode::TrayPanel,
-        true
-    ));
-    assert!(!should_hide_dashboard_on_tray_click(
-        SurfaceMode::Settings,
-        true
-    ));
+    assert!(should_hide_dashboard_on_tray_click(true, false));
+    assert!(!should_hide_dashboard_on_tray_click(false, false));
+    // A second Left+Up from a Windows double-click arrives while the
+    // just-opened dashboard is still inside the show grace.
+    assert!(!should_hide_dashboard_on_tray_click(true, true));
+    assert!(!should_hide_dashboard_on_tray_click(false, true));
 }
 
 #[test]

--- a/apps/desktop-tauri/src-tauri/src/shell/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/tests.rs
@@ -12,7 +12,8 @@ use super::transition::{
     monitor_for_preserved_visible_position, reclamp_preserved_visible_position,
     recovery_snapshot_for_failed_transition, resolve_transition_position,
     resolve_transition_request, restore_recovery_surface, restore_surface_snapshot,
-    should_force_tray_panel_reveal, should_synthesize_default_position,
+    should_force_tray_panel_reveal, should_hide_dashboard_on_tray_click,
+    should_synthesize_default_position,
 };
 use super::window::{
     hide_to_tray_state, logical_size_from_geometry, prepare_hide_to_tray_if_current,
@@ -62,11 +63,29 @@ fn conditional_hide_to_tray_leaves_non_matching_surface_alone() {
     assert_eq!(state.current_target, SurfaceTarget::Dashboard);
 }
 
-// The old `tray_toggle_hides_only_when_panel_window_is_visible` test (which
-// exercised `should_hide_tray_panel_on_toggle`) was removed here along with
-// its subject function: the tray-icon left-click toggle for the shared
-// `main` window's TrayPanel state no longer exists — the flyout is its own
-// dedicated window, while tray left-click opens the dashboard.
+#[test]
+fn tray_toggle_hides_only_when_dashboard_window_is_visible() {
+    assert!(should_hide_dashboard_on_tray_click(
+        SurfaceMode::PopOut,
+        true
+    ));
+    assert!(!should_hide_dashboard_on_tray_click(
+        SurfaceMode::PopOut,
+        false
+    ));
+    assert!(!should_hide_dashboard_on_tray_click(
+        SurfaceMode::Hidden,
+        true
+    ));
+    assert!(!should_hide_dashboard_on_tray_click(
+        SurfaceMode::TrayPanel,
+        true
+    ));
+    assert!(!should_hide_dashboard_on_tray_click(
+        SurfaceMode::Settings,
+        true
+    ));
+}
 
 #[test]
 fn tray_reveal_fallback_only_for_hidden_tray_panel() {

--- a/apps/desktop-tauri/src-tauri/src/shell/transition.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/transition.rs
@@ -164,6 +164,37 @@ pub fn reopen_to_target(
     )
 }
 
+/// Toggle the primary dashboard from the tray icon: hide if it is already
+/// showing, otherwise reveal it. `reopen_to_target` stays on the existing
+/// `main` window (no WebviewWindowBuilder), so this is safe to call from the
+/// native tray event-loop callback.
+pub fn toggle_dashboard(app: &AppHandle) {
+    let current = match app.try_state::<Mutex<AppState>>() {
+        Some(state) => state
+            .lock()
+            .map(|guard| guard.surface_machine.current())
+            .unwrap_or(SurfaceMode::Hidden),
+        None => SurfaceMode::Hidden,
+    };
+    let main_window_visible = app
+        .get_webview_window("main")
+        .and_then(|window| window.is_visible().ok())
+        .unwrap_or(false);
+
+    if should_hide_dashboard_on_tray_click(current, main_window_visible) {
+        let _ = super::window::hide_to_tray(app);
+    } else {
+        let _ = reopen_to_target(app, SurfaceMode::PopOut, SurfaceTarget::Dashboard, None);
+    }
+}
+
+pub(super) fn should_hide_dashboard_on_tray_click(
+    current: SurfaceMode,
+    main_window_visible: bool,
+) -> bool {
+    current == SurfaceMode::PopOut && main_window_visible
+}
+
 fn apply_transition_request_with_strategy(
     app: &AppHandle,
     request: ShellTransitionRequest,
@@ -607,9 +638,3 @@ pub(super) fn apply_transition(
         }
     }
 }
-
-// The old `handle_tray_panel_click` / `toggle_tray_panel` /
-// `should_hide_tray_panel_on_toggle` trio (tray-icon left-click handling for
-// the shared `main` window's TrayPanel state) was removed here: the flyout is
-// now its own dedicated window, while tray-icon left-click opens the
-// dashboard instead of going through the `main`-window tray-panel state.

--- a/apps/desktop-tauri/src-tauri/src/shell/transition.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/transition.rs
@@ -165,20 +165,17 @@ pub fn reopen_to_target(
     )
 }
 
-/// Windows delivers two Left+Up tray events for a double-click. Ignore hide
-/// for this long after a tray-initiated show so the dashboard does not flash
-/// open and disappear.
+/// Windows delivers two Left+Up tray events for a double-click. Ignore both
+/// hide and show for this long after either so a double-click cannot flash
+/// the dashboard the other way.
 const TRAY_TOGGLE_GRACE: Duration = Duration::from_millis(500);
 
-/// Toggle the primary dashboard from the tray icon: hide if it is already
-/// showing, otherwise reveal it. `reopen_to_target` stays on the existing
-/// `main` window (no WebviewWindowBuilder), so this is safe to call from the
-/// native tray event-loop callback.
+/// Hide a visible dashboard, or reveal it when hidden.
 pub fn toggle_dashboard(app: &AppHandle) {
-    let recently_shown = match app.try_state::<Mutex<AppState>>() {
+    let recently_toggled = match app.try_state::<Mutex<AppState>>() {
         Some(state) => {
             let guard = state.lock().unwrap_or_else(|error| error.into_inner());
-            guard.was_tray_panel_recently_shown(std::time::Instant::now(), TRAY_TOGGLE_GRACE)
+            guard.was_tray_dashboard_recently_toggled(std::time::Instant::now(), TRAY_TOGGLE_GRACE)
         }
         None => false,
     };
@@ -193,30 +190,49 @@ pub fn toggle_dashboard(app: &AppHandle) {
         None => false,
     };
 
-    if should_hide_dashboard_on_tray_click(main_window_visible, recently_shown) {
-        if let Err(error) = super::window::hide_to_tray(app) {
-            tracing::debug!("shell: tray dashboard hide failed: {error}");
+    match tray_dashboard_action(main_window_visible, recently_toggled) {
+        TrayDashboardAction::Ignore => {}
+        TrayDashboardAction::Hide => {
+            if let Err(error) = super::window::hide_to_tray(app) {
+                tracing::debug!("shell: tray dashboard hide failed: {error}");
+            } else {
+                mark_tray_dashboard_toggled(app);
+            }
         }
-        return;
-    }
-
-    if main_window_visible {
-        // Extra Left+Up from a Windows double-click while the dashboard we
-        // just opened is still settling.
-        return;
-    }
-
-    match reopen_to_target(app, SurfaceMode::PopOut, SurfaceTarget::Dashboard, None) {
-        Ok(_) => mark_tray_panel_shown(app),
-        Err(error) => tracing::debug!("shell: tray dashboard reopen failed: {error}"),
+        TrayDashboardAction::Show => {
+            match reopen_to_target(app, SurfaceMode::PopOut, SurfaceTarget::Dashboard, None) {
+                Ok(_) => mark_tray_dashboard_toggled(app),
+                Err(error) => tracing::debug!("shell: tray dashboard reopen failed: {error}"),
+            }
+        }
     }
 }
 
-pub(super) fn should_hide_dashboard_on_tray_click(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TrayDashboardAction {
+    Hide,
+    Show,
+    Ignore,
+}
+
+pub(super) fn tray_dashboard_action(
     main_window_visible: bool,
-    recently_shown: bool,
-) -> bool {
-    main_window_visible && !recently_shown
+    recently_toggled: bool,
+) -> TrayDashboardAction {
+    if recently_toggled {
+        TrayDashboardAction::Ignore
+    } else if main_window_visible {
+        TrayDashboardAction::Hide
+    } else {
+        TrayDashboardAction::Show
+    }
+}
+
+fn mark_tray_dashboard_toggled(app: &AppHandle) {
+    if let Some(state) = app.try_state::<Mutex<AppState>>() {
+        let mut guard = state.lock().unwrap_or_else(|error| error.into_inner());
+        guard.mark_tray_dashboard_toggled(std::time::Instant::now());
+    }
 }
 
 fn apply_transition_request_with_strategy(

--- a/apps/desktop-tauri/src-tauri/src/shell/transition.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/transition.rs
@@ -2,6 +2,7 @@
 //! recovery, and snapshot bookkeeping.
 
 use std::sync::Mutex;
+use std::time::Duration;
 
 use tauri::{AppHandle, Manager, WebviewWindow};
 
@@ -164,35 +165,58 @@ pub fn reopen_to_target(
     )
 }
 
+/// Windows delivers two Left+Up tray events for a double-click. Ignore hide
+/// for this long after a tray-initiated show so the dashboard does not flash
+/// open and disappear.
+const TRAY_TOGGLE_GRACE: Duration = Duration::from_millis(500);
+
 /// Toggle the primary dashboard from the tray icon: hide if it is already
 /// showing, otherwise reveal it. `reopen_to_target` stays on the existing
 /// `main` window (no WebviewWindowBuilder), so this is safe to call from the
 /// native tray event-loop callback.
 pub fn toggle_dashboard(app: &AppHandle) {
-    let current = match app.try_state::<Mutex<AppState>>() {
-        Some(state) => state
-            .lock()
-            .map(|guard| guard.surface_machine.current())
-            .unwrap_or(SurfaceMode::Hidden),
-        None => SurfaceMode::Hidden,
+    let recently_shown = match app.try_state::<Mutex<AppState>>() {
+        Some(state) => {
+            let guard = state.lock().unwrap_or_else(|error| error.into_inner());
+            guard.was_tray_panel_recently_shown(std::time::Instant::now(), TRAY_TOGGLE_GRACE)
+        }
+        None => false,
     };
-    let main_window_visible = app
-        .get_webview_window("main")
-        .and_then(|window| window.is_visible().ok())
-        .unwrap_or(false);
+    let main_window_visible = match app.get_webview_window("main") {
+        Some(window) => match window.is_visible() {
+            Ok(visible) => visible,
+            Err(error) => {
+                tracing::debug!("shell: tray dashboard visibility check failed: {error}");
+                false
+            }
+        },
+        None => false,
+    };
 
-    if should_hide_dashboard_on_tray_click(current, main_window_visible) {
-        let _ = super::window::hide_to_tray(app);
-    } else {
-        let _ = reopen_to_target(app, SurfaceMode::PopOut, SurfaceTarget::Dashboard, None);
+    if should_hide_dashboard_on_tray_click(main_window_visible, recently_shown) {
+        if let Err(error) = super::window::hide_to_tray(app) {
+            tracing::debug!("shell: tray dashboard hide failed: {error}");
+        }
+        return;
+    }
+
+    if main_window_visible {
+        // Extra Left+Up from a Windows double-click while the dashboard we
+        // just opened is still settling.
+        return;
+    }
+
+    match reopen_to_target(app, SurfaceMode::PopOut, SurfaceTarget::Dashboard, None) {
+        Ok(_) => mark_tray_panel_shown(app),
+        Err(error) => tracing::debug!("shell: tray dashboard reopen failed: {error}"),
     }
 }
 
 pub(super) fn should_hide_dashboard_on_tray_click(
-    current: SurfaceMode,
     main_window_visible: bool,
+    recently_shown: bool,
 ) -> bool {
-    current == SurfaceMode::PopOut && main_window_visible
+    main_window_visible && !recently_shown
 }
 
 fn apply_transition_request_with_strategy(

--- a/apps/desktop-tauri/src-tauri/src/state.rs
+++ b/apps/desktop-tauri/src-tauri/src/state.rs
@@ -146,6 +146,9 @@ pub struct AppState {
     /// Instant when the tray panel was last shown — used to suppress
     /// spurious blur-dismiss during the show animation on Windows.
     pub last_shown_at: Option<std::time::Instant>,
+    /// Last tray-icon dashboard show or hide. Separate from `last_shown_at`
+    /// so flyout blur-dismiss does not swallow a tray click.
+    pub last_tray_dashboard_toggle_at: Option<std::time::Instant>,
     /// One-shot grace for a blur event caused while revealing the tray panel
     /// during explicit startup.
     pub startup_tray_blur_grace_until: Option<std::time::Instant>,
@@ -205,6 +208,7 @@ impl AppState {
             capacity_event_observer: crate::capacity_events::CapacityEventObserver::load_default(),
             enforcement_tracker: crate::enforcement::EnforcementTracker::new(),
             last_shown_at: None,
+            last_tray_dashboard_toggle_at: None,
             startup_tray_blur_grace_until: None,
             suppress_geometry_capture_until: None,
             startup_tray_reveal_pending: false,
@@ -224,6 +228,19 @@ impl AppState {
     ) -> bool {
         self.last_shown_at
             .is_some_and(|shown_at| now.saturating_duration_since(shown_at) < max_age)
+    }
+
+    pub fn mark_tray_dashboard_toggled(&mut self, toggled_at: std::time::Instant) {
+        self.last_tray_dashboard_toggle_at = Some(toggled_at);
+    }
+
+    pub fn was_tray_dashboard_recently_toggled(
+        &self,
+        now: std::time::Instant,
+        max_age: std::time::Duration,
+    ) -> bool {
+        self.last_tray_dashboard_toggle_at
+            .is_some_and(|toggled_at| now.saturating_duration_since(toggled_at) < max_age)
     }
 
     #[allow(dead_code)]

--- a/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
@@ -1,4 +1,4 @@
-//! System tray icon setup: left-click opens the tray panel, right-click native menu.
+//! System tray icon setup: left-click toggles the dashboard, right-click native menu.
 
 use std::sync::Mutex;
 
@@ -238,7 +238,8 @@ fn store_anchor(app: &AppHandle, rect: &tauri::Rect, click_position: tauri::Phys
 
 /// Initialise the system tray icon, context menu, and event handlers.
 ///
-/// - **Left-click** reveals and foregrounds the primary dashboard.
+/// - **Left-click** toggles the primary dashboard: show it when hidden, hide it
+///   when it is already visible.
 /// - **Right-click** opens the native context menu with shell actions.
 pub fn setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let menu = build_native_tray_menu(app.handle(), &crate::commands::get_provider_catalog(), &[])?;
@@ -265,17 +266,13 @@ pub fn setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 let app = tray.app_handle();
                 if button == MouseButton::Left && button_state == MouseButtonState::Up {
                     store_anchor(app, &rect, position);
-                    // Left-click opens the dashboard (SurfaceMode::PopOut on
+                    // Left-click toggles the dashboard (SurfaceMode::PopOut on
                     // `main`) — the same surface as "Pop Out Dashboard".
-                    // `reopen_to_target` transitions the existing `main` window
-                    // (no WebviewWindowBuilder), so the sync-IPC build deadlock
-                    // does not apply on this native event-loop callback.
-                    let _ = shell::reopen_to_target(
-                        app,
-                        SurfaceMode::PopOut,
-                        SurfaceTarget::Dashboard,
-                        None,
-                    );
+                    // `toggle_dashboard` only reopens via `reopen_to_target` on
+                    // the existing `main` window (no WebviewWindowBuilder), so
+                    // the sync-IPC build deadlock does not apply on this
+                    // native event-loop callback.
+                    shell::toggle_dashboard(app);
                 }
             }
         })


### PR DESCRIPTION
## Summary

Left-click on the tray icon now toggles the dashboard instead of always reopening it.

- First click shows the PopOut stats window
- Second click hides it when that window is already visible
- Right-click menu and the global shortcut are unchanged

This restores the old tray-panel toggle pattern for the current dashboard surface. The hide check is `SurfaceMode::PopOut` **and** the `main` window is visible, so a click while Settings, the flyout, or a hidden window is up still opens the dashboard.

## Related issue

Fixes #280

## Affected areas

- [x] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

Hosted CI runs the main frontend and Rust checks. Run the relevant local checks
before pushing and list the exact commands/results. If a check is not relevant,
say why.

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1`
- [ ] For full pre-release validation: `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -All -Version <version>`
- [ ] For installer/release changes: `powershell.exe -File scripts\windows-release-build.ps1 -Ref <ref> -SmokeInstall`
- [x] Other:

```
cargo fmt --all --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml
cargo clippy --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all-targets -- -D warnings
cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml
```

Results: fmt clean, clippy clean, 517 tests passed.

`scripts/local-check.ps1` was not run. The change is confined to the Tauri tray/shell path, and the crate-level fmt/clippy/test commands above cover that crate.

## UI / tray proof

- [ ] Not applicable
- [ ] Visual proof attached
- [x] Visual proof was not practical; manual validation and explanation attached

The click handler lives in a native tray callback. Unit tests cover the hide-vs-show decision (`tray_toggle_hides_only_when_dashboard_window_is_visible`). I did not click a live tray icon in a running desktop session.

## Notes for reviewers

The interesting bit is `should_hide_dashboard_on_tray_click` in `shell/transition.rs`. Tray left-click now calls `toggle_dashboard` instead of always `reopen_to_target`. Menu "Pop Out Dashboard" / "Show Window" still reopen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Left-clicking the system tray icon now toggles the dashboard: visible dashboards are hidden, while hidden dashboards reopen.
  - Dashboard behavior is preserved across pop-out, tray panel, and settings views.

- **Bug Fixes**
  - Prevented tray clicks from hiding dashboards when the active view is not a visible pop-out dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->