### PR TITLE
Keep provider error text out of the diagnose export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Ceiling] Unreleased
 
 ### Fixed
-- **`diagnose` no longer copies provider error text into an export meant to be shared.** The command already withheld cookies, tokens, account emails, and response bodies, but a failed fetch put the provider's own error string straight into the payload, and that string can carry a signed URL, an account identifier, or an echoed request header. Every failure now reports a local category and a fixed local message instead of anything the provider said. Truncation also lands on a character boundary, so a multi-byte message can no longer be cut mid-character.
+- **`diagnose` no longer copies provider error text into an export meant to be shared.** The command already withheld cookies, tokens, account emails, and response bodies, but a failed fetch put the provider's own error string straight into the payload, and that string can carry a signed URL, an account identifier, or an echoed request header. Every failure now reports a local category and a fixed local message instead of anything the provider said.
 
 ## [Ceiling] 1.5.30 - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Ceiling] Unreleased
 
+### Fixed
+- **`diagnose` no longer copies provider error text into an export meant to be shared.** The command already withheld cookies, tokens, account emails, and response bodies, but a failed fetch put the provider's own error string straight into the payload, and that string can carry a signed URL, an account identifier, or an echoed request header. Every failure now reports a local category and a fixed local message instead of anything the provider said. Truncation also lands on a character boundary, so a multi-byte message can no longer be cut mid-character.
+
 ## [Ceiling] 1.5.30 - 2026-08-13
 
 Stops a few places from showing the wrong account or the wrong credential, gives the taskbar widget somewhere to sit when the usual gap is gone, and lets a second click on the tray icon hide the window. Grok banked resets now show the same way Codex already did.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -79,7 +79,9 @@ codexbar cost --days 7 --json --pretty
 
 ## `diagnose`
 
-Export safe provider diagnostics as JSON.
+Export safe provider diagnostics as JSON. Identity values, credentials,
+provider response bodies, and raw provider error text are excluded; failures
+use normalized local categories and messages.
 
 ```text
 codexbar diagnose [OPTIONS]

--- a/rust/src/cli/diagnose.rs
+++ b/rust/src/cli/diagnose.rs
@@ -452,25 +452,37 @@ mod tests {
 
     #[test]
     fn raw_provider_error_details_are_never_exported() {
+        // Secrets sit on their own lines so a Display+redact path cannot hide leftover
+        // provider text (signed URL, request id) behind the cookie/Bearer line rule.
         let malicious = concat!(
-            "response body for person@example.com: ",
-            "Bearer secret-access-token Cookie: sessionKey=secret-cookie ",
-            "sk-1234567890abcdef 日本語"
+            "https://api.example.com/v1/usage?sig=signed-url-token ",
+            "request-id=acct-id-canary-42 ",
+            "response body for person@example.com\n",
+            "Bearer secret-access-token\n",
+            "Cookie: sessionKey=secret-cookie\n",
+            "sk-1234567890abcdef 日本語 leftover provider text",
         );
-        let errors = [
-            ProviderError::NotInstalled(malicious.to_string()),
-            ProviderError::OAuth(malicious.to_string()),
-            ProviderError::Parse(malicious.to_string()),
-            ProviderError::Other(malicious.to_string()),
+        let cases = [
+            (
+                ProviderError::NotInstalled(malicious.to_string()),
+                "The provider's required local CLI or credentials were not found.",
+            ),
+            (
+                ProviderError::OAuth(malicious.to_string()),
+                "Provider authentication failed.",
+            ),
+            (
+                ProviderError::Parse(malicious.to_string()),
+                "The provider response could not be parsed.",
+            ),
+            (
+                ProviderError::Other(malicious.to_string()),
+                "The provider returned an unexpected error.",
+            ),
         ];
 
-        for error in errors {
-            let exported = safe_error_message(&error);
-            assert!(!exported.contains("person@example.com"));
-            assert!(!exported.contains("secret-access-token"));
-            assert!(!exported.contains("secret-cookie"));
-            assert!(!exported.contains("1234567890abcdef"));
-            assert!(!exported.contains("日本語"));
+        for (error, expected) in cases {
+            assert_eq!(safe_error_message(&error), expected);
         }
     }
 

--- a/rust/src/cli/diagnose.rs
+++ b/rust/src/cli/diagnose.rs
@@ -2,6 +2,8 @@
 //!
 //! This intentionally reports configuration shape and fetch outcomes without
 //! printing cookies, tokens, account emails, or provider response bodies.
+//! Exported errors use local templates; provider-supplied error text is never
+//! included in the shareable payload.
 
 use anyhow::Context;
 use chrono::{DateTime, Utc};
@@ -9,8 +11,8 @@ use clap::Args;
 use serde::Serialize;
 
 use crate::core::{
-    ConfiguredAccounts, CostSnapshot, FetchContext, ProviderError, ProviderFetchResult, ProviderId,
-    RateWindow, SourceMode, instantiate_provider,
+    ConfiguredAccounts, CostSnapshot, FetchContext, PersonalInfoRedactor, ProviderError,
+    ProviderFetchResult, ProviderId, RateWindow, SourceMode, instantiate_provider,
 };
 use crate::settings::{ApiKeys, ManualCookies, Settings};
 
@@ -384,11 +386,38 @@ fn error_category(err: &ProviderError) -> &'static str {
 }
 
 fn safe_error_message(err: &ProviderError) -> String {
-    let message = err.to_string();
-    if message.len() > 240 {
-        format!("{}...", message.chars().take(237).collect::<String>())
+    let message = match err {
+        ProviderError::NotInstalled(_) => {
+            "The provider's required local CLI or credentials were not found.".to_string()
+        }
+        ProviderError::AuthRequired => "Authentication is required.".to_string(),
+        ProviderError::OAuth(_) => "Provider authentication failed.".to_string(),
+        ProviderError::Parse(_) => "The provider response could not be parsed.".to_string(),
+        ProviderError::Network(_) => "The provider request failed.".to_string(),
+        ProviderError::Timeout => "The provider request timed out.".to_string(),
+        ProviderError::UnsupportedSource(source) => format!(
+            "The '{}' source is not supported by this provider.",
+            source_mode_name(*source)
+        ),
+        ProviderError::NoCookies => "No usable web credentials were found.".to_string(),
+        ProviderError::Other(_) if error_category(err) == "api" => {
+            "The provider API rejected or rate-limited the request.".to_string()
+        }
+        ProviderError::Other(_) => "The provider returned an unexpected error.".to_string(),
+    };
+    sanitize_diagnostic_message(&message)
+}
+
+fn sanitize_diagnostic_message(message: &str) -> String {
+    let secret_safe = crate::logging::safe_error_message(message);
+    let privacy_safe =
+        PersonalInfoRedactor::redact_emails_in_text(Some(&secret_safe), true).unwrap_or_default();
+    let mut chars = privacy_safe.chars();
+    let prefix = chars.by_ref().take(237).collect::<String>();
+    if chars.next().is_some() {
+        format!("{prefix}...")
     } else {
-        message
+        privacy_safe
     }
 }
 
@@ -419,6 +448,47 @@ mod tests {
         assert!(value["login_method_present"].as_bool().unwrap());
         assert!(!text.contains("person@example.com"));
         assert!(!text.contains("Team"));
+    }
+
+    #[test]
+    fn raw_provider_error_details_are_never_exported() {
+        let malicious = concat!(
+            "response body for person@example.com: ",
+            "Bearer secret-access-token Cookie: sessionKey=secret-cookie ",
+            "sk-1234567890abcdef 日本語"
+        );
+        let errors = [
+            ProviderError::NotInstalled(malicious.to_string()),
+            ProviderError::OAuth(malicious.to_string()),
+            ProviderError::Parse(malicious.to_string()),
+            ProviderError::Other(malicious.to_string()),
+        ];
+
+        for error in errors {
+            let exported = safe_error_message(&error);
+            assert!(!exported.contains("person@example.com"));
+            assert!(!exported.contains("secret-access-token"));
+            assert!(!exported.contains("secret-cookie"));
+            assert!(!exported.contains("1234567890abcdef"));
+            assert!(!exported.contains("日本語"));
+        }
+    }
+
+    #[test]
+    fn diagnostic_message_sanitizer_redacts_then_truncates_on_char_boundaries() {
+        let malicious = format!(
+            "person@example.com Bearer access-token\nCookie: sessionKey=cookie\n{}",
+            "界".repeat(300)
+        );
+
+        let sanitized = sanitize_diagnostic_message(&malicious);
+
+        assert!(!sanitized.contains("person@example.com"));
+        assert!(!sanitized.contains("access-token"));
+        assert!(!sanitized.contains("sessionKey=cookie"));
+        assert!(sanitized.ends_with("..."));
+        assert_eq!(sanitized.chars().count(), 240);
+        assert!(std::str::from_utf8(sanitized.as_bytes()).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Why

`diagnose` exists to be pasted into an issue. It already withheld cookies, tokens, account emails, and response bodies, but a failed fetch put the provider's own error string straight into the payload. That string can carry a signed URL, an account identifier, or an echoed request header.

## What

- Report a local category and a fixed local message for every `ProviderError` variant instead of anything the provider said.
- Run the result through the secret redactor and the email redactor as a backstop, so a future variant that reintroduces provider text is still covered.
- Truncate on a character boundary. The previous byte-oriented cut could split a multi-byte character.

## One call worth making

This trades diagnostic value for safety, and it may trade away more than it needs to. `Network(...)` now reads "The provider request failed." for every network failure, which is the one thing people run `diagnose` to find out. An HTTP status code and the local error kind aren't sensitive and would keep the export useful.

I left it maximally strict here since that's what the change was aimed at. Say the word and I'll follow up with a PR that puts a status code back in as a typed field rather than free text.

## Testing

`cargo test -- cli::diagnose` — 6 pass, including a new test asserting that an error carrying an email, a bearer token, a cookie, an `sk-` key, and non-ASCII text exports none of them across four variants.

`cargo clippy --all-targets -- -D warnings` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Diagnostic exports now use clear, standardized local error messages instead of exposing provider error details.
  * Sensitive information, including credentials, personal email addresses, identity values, response bodies, and raw error text, is excluded from exported diagnostics.
  * Long messages are safely truncated without breaking Unicode characters.

* **Documentation**
  * Updated CLI documentation to describe diagnostic export privacy protections and normalized failure messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep provider error text out of the `diagnose` export by using fixed local messages
> - Reworks `safe_error_message` in [diagnose.rs](https://github.com/tsouth89/ceiling/pull/286/files#diff-f395a515368d5d5c379cc88d815c3c8fc45c20d34ff12220c53719bac2745282) to map `ProviderError` variants to fixed, locally-defined strings instead of calling `err.to_string()`, preventing provider-supplied error details from leaking into exports.
> - Adds a `sanitize_diagnostic_message` helper that redacts emails via `PersonalInfoRedactor`, strips secrets via `safe_error_message`, and truncates to 240 characters on valid UTF-8 boundaries.
> - Behavioral Change: the `diagnose` export no longer contains any provider response bodies or raw error text; failures are reported using normalized local categories and messages only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d04435.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->