### PR TITLE
Drop localhost CSP wildcards from release builds

### DIFF
--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -12,7 +12,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "tauri:dev": "tauri dev",
+    "tauri:dev": "tauri dev --config src-tauri/tauri.dev.conf.json",
     "tauri:build": "tauri build --no-bundle",
     "tauri:build:windows-cross": "../../scripts/macos-windows-cross-build.sh",
     "tauri:build:debug": "tauri build --debug --no-bundle"

--- a/apps/desktop-tauri/src-tauri/tauri.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' ipc: http://ipc.localhost; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
     }
   },
   "bundle": {

--- a/apps/desktop-tauri/src-tauri/tauri.dev.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.dev.conf.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "security": {
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
+    }
+  }
+}

--- a/apps/desktop-tauri/src/test/tauriCsp.test.ts
+++ b/apps/desktop-tauri/src/test/tauriCsp.test.ts
@@ -25,15 +25,21 @@ const parseCsp = (csp: string): Directives =>
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
 /**
- * Host of a CSP source, or the source unchanged when it has no host.
+ * Host of a CSP source, lowercased, or the source unchanged when it has no
+ * host.
  *
- * Anything after the host is dropped, not just a port. Trimming only a
+ * Everything after the host is dropped, not just a port: trimming only a
  * trailing `:port` left `http://localhost:1420/` reading as the host
- * `localhost:1420/`, which is in no set and would have let a permissive
- * shipped CSP through the checks below.
+ * `localhost:1420/`, which is in no set.
+ *
+ * Schemes and hosts are case-insensitive in CSP, and a scheme may contain
+ * `+`, `-`, and `.` (RFC 3986), so `HTTP://LOCALHOST:1420` and
+ * `custom+scheme://127.0.0.1` are loopback too. Every miss here quietly
+ * disarms the checks below, so the parsing is deliberately permissive about
+ * how a source is spelled.
  */
 const sourceHost = (source: string): string => {
-  const withoutScheme = source.replace(/^[a-z]+:\/\//, "");
+  const withoutScheme = source.toLowerCase().replace(/^[a-z][a-z0-9+.-]*:\/\//, "");
   // A bracketed IPv6 literal is full of colons, so take the bracket group whole.
   const bracketed = /^\[[^\]]*\]/.exec(withoutScheme);
   return bracketed ? bracketed[0] : withoutScheme.replace(/[:/?#].*$/, "");
@@ -55,6 +61,12 @@ describe("loopback detection", () => {
       "ws://localhost",
       "http://[::1]:8080",
       "127.0.0.1",
+      // Schemes and hosts are case-insensitive in CSP.
+      "HTTP://localhost:1420",
+      "http://LOCALHOST:1420",
+      // A scheme may carry +, -, and . (RFC 3986).
+      "custom+scheme://127.0.0.1",
+      "my-app.v2://localhost",
     ]) {
       expect({ [source]: isLoopbackSource(source) }).toEqual({ [source]: true });
     }
@@ -95,6 +107,18 @@ describe("dev CSP overlay", () => {
       "ws://localhost:*",
       "ws://127.0.0.1:*",
     ]);
+  });
+
+  // Dev has to be a superset. If the shipped CSP later needs a real origin,
+  // adding it there alone leaves dev unable to reach it, and the two checks
+  // above would both still pass: one only inspects loopback, the other only
+  // compares the directives that are not connect-src.
+  it("offers everything the shipped CSP allows", () => {
+    const devSources = new Set(devCsp.get("connect-src") ?? []);
+    const missing = (shippedCsp.get("connect-src") ?? []).filter(
+      (source) => !devSources.has(source),
+    );
+    expect(missing).toEqual([]);
   });
 
   it("differs from the shipped CSP only in connect-src", () => {

--- a/apps/desktop-tauri/src/test/tauriCsp.test.ts
+++ b/apps/desktop-tauri/src/test/tauriCsp.test.ts
@@ -24,15 +24,48 @@ const parseCsp = (csp: string): Directives =>
 // match the host exactly instead of substring-searching for "localhost".
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
-const isLoopbackSource = (source: string) =>
-  LOOPBACK_HOSTS.has(
-    source
-      .replace(/^[a-z]+:\/\//, "")
-      .replace(/:[*\d]+$/, ""),
-  );
+/**
+ * Host of a CSP source, or the source unchanged when it has no host.
+ *
+ * Anything after the host is dropped, not just a port. Trimming only a
+ * trailing `:port` left `http://localhost:1420/` reading as the host
+ * `localhost:1420/`, which is in no set and would have let a permissive
+ * shipped CSP through the checks below.
+ */
+const sourceHost = (source: string): string => {
+  const withoutScheme = source.replace(/^[a-z]+:\/\//, "");
+  // A bracketed IPv6 literal is full of colons, so take the bracket group whole.
+  const bracketed = /^\[[^\]]*\]/.exec(withoutScheme);
+  return bracketed ? bracketed[0] : withoutScheme.replace(/[:/?#].*$/, "");
+};
+
+const isLoopbackSource = (source: string) => LOOPBACK_HOSTS.has(sourceHost(source));
 
 const shippedCsp = parseCsp(shipped.app.security.csp);
 const devCsp = parseCsp(devOverlay.app.security.csp);
+
+describe("loopback detection", () => {
+  // The detector is the whole gate, so a hole in it silently disarms every
+  // check below. A trailing path used to defeat it.
+  it("sees loopback however the source is written", () => {
+    for (const source of [
+      "http://localhost:*",
+      "http://localhost:1420/",
+      "http://127.0.0.1:3000/api",
+      "ws://localhost",
+      "http://[::1]:8080",
+      "127.0.0.1",
+    ]) {
+      expect({ [source]: isLoopbackSource(source) }).toEqual({ [source]: true });
+    }
+  });
+
+  it("leaves the IPC origin and keywords alone", () => {
+    for (const source of ["'self'", "ipc:", "http://ipc.localhost", "https://api.openai.com"]) {
+      expect({ [source]: isLoopbackSource(source) }).toEqual({ [source]: false });
+    }
+  });
+});
 
 describe("shipped Tauri CSP", () => {
   it("grants the webview no access to loopback ports", () => {

--- a/apps/desktop-tauri/src/test/tauriCsp.test.ts
+++ b/apps/desktop-tauri/src/test/tauriCsp.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+// Imported rather than read from disk: the frontend has no @types/node, and
+// importing the real config files is what makes this a regression test instead
+// of a copy of the strings.
+import shipped from "../../src-tauri/tauri.conf.json";
+import devOverlay from "../../src-tauri/tauri.dev.conf.json";
+import packageJson from "../../package.json";
+
+type Directives = Map<string, string[]>;
+
+const parseCsp = (csp: string): Directives =>
+  new Map(
+    csp
+      .split(";")
+      .map((directive) => directive.trim())
+      .filter(Boolean)
+      .map((directive) => {
+        const [name, ...sources] = directive.split(/\s+/);
+        return [name, sources] as [string, string[]];
+      }),
+  );
+
+// `http://ipc.localhost` is Tauri's Windows IPC origin, not a loopback port, so
+// match the host exactly instead of substring-searching for "localhost".
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+const isLoopbackSource = (source: string) =>
+  LOOPBACK_HOSTS.has(
+    source
+      .replace(/^[a-z]+:\/\//, "")
+      .replace(/:[*\d]+$/, ""),
+  );
+
+const shippedCsp = parseCsp(shipped.app.security.csp);
+const devCsp = parseCsp(devOverlay.app.security.csp);
+
+describe("shipped Tauri CSP", () => {
+  it("grants the webview no access to loopback ports", () => {
+    expect(shippedCsp.get("connect-src")?.filter(isLoopbackSource)).toEqual([]);
+  });
+
+  it("still allows the IPC transports the app needs", () => {
+    expect(shippedCsp.get("connect-src")).toEqual(["'self'", "ipc:", "http://ipc.localhost"]);
+  });
+
+  it("has no loopback source in any other directive", () => {
+    for (const [name, sources] of shippedCsp) {
+      expect({ [name]: sources.filter(isLoopbackSource) }).toEqual({ [name]: [] });
+    }
+  });
+});
+
+describe("dev CSP overlay", () => {
+  it("is wired into the tauri:dev script", () => {
+    expect(packageJson.scripts["tauri:dev"]).toContain("--config src-tauri/tauri.dev.conf.json");
+  });
+
+  it("re-opens loopback so Vite and its HMR socket work", () => {
+    expect(devCsp.get("connect-src")?.filter(isLoopbackSource)).toEqual([
+      "http://localhost:*",
+      "http://127.0.0.1:*",
+      "ws://localhost:*",
+      "ws://127.0.0.1:*",
+    ]);
+  });
+
+  it("differs from the shipped CSP only in connect-src", () => {
+    const withoutConnectSrc = (directives: Directives) =>
+      Object.fromEntries([...directives].filter(([name]) => name !== "connect-src"));
+
+    expect(withoutConnectSrc(devCsp)).toEqual(withoutConnectSrc(shippedCsp));
+  });
+});


### PR DESCRIPTION
Closes SBS-819 (split out of SBS-158).

## What changed

The shipped `connect-src` allowed http/ws to `localhost` and `127.0.0.1` on any port. Those four entries exist only for the Vite dev server and its HMR socket, and they shipped in release builds too.

The webview needs no network access at runtime. There is no `fetch`, `XMLHttpRequest`, `WebSocket`, or `EventSource` anywhere in `apps/desktop-tauri/src`; every provider call runs in Rust, including the Wayfinder gateway on `127.0.0.1:8088` (`rust/src/providers/wayfinder.rs`).

- `tauri.conf.json` (the release default) is now `connect-src 'self' ipc: http://ipc.localhost`.
- New `src-tauri/tauri.dev.conf.json` holds the permissive dev overlay.
- `tauri:dev` merges it with `--config`.

## Impact

Any script execution inside the webview could previously reach every loopback port on the machine. Low likelihood given `script-src 'self'`, but free to remove.

## Commands run

- `pnpm --dir apps/desktop-tauri test` — 566 passed
- `pnpm --dir apps/desktop-tauri exec tsc --noEmit` — clean

## Tests

`src/test/tauriCsp.test.ts` asserts the shipped config carries no loopback `connect-src` entry, that the dev overlay still does, that `tauri:dev` is wired to it, and that the two differ only in `connect-src`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop localhost CSP wildcards from release builds of the desktop Tauri app
> - Removes `http://localhost:*`, `http://127.0.0.1:*`, `ws://localhost:*`, and `ws://127.0.0.1:*` from `connect-src` in [tauri.conf.json](https://github.com/tsouth89/ceiling/pull/297/files#diff-92f1d66a188d04417516678b256f39ee1ffd3e5ea14a0b93a74472d6d64e0179); only `'self'`, `ipc:`, and `http://ipc.localhost` remain in production builds.
> - Moves the loopback entries into a new dev-only config overlay at [tauri.dev.conf.json](https://github.com/tsouth89/ceiling/pull/297/files#diff-473e7cbce9108c5da612cc3ae9f4b77f96dc7847087032768adea2398714be51), applied by passing `--config src-tauri/tauri.dev.conf.json` to the `tauri:dev` script.
> - Adds a Vitest suite in [tauriCsp.test.ts](https://github.com/tsouth89/ceiling/pull/297/files#diff-5f722fe98acd7c388040eede05e846a324a648670ee592f2bdc5f0eb7dac3e20) that asserts the shipped CSP contains no loopback sources, the dev overlay is a strict superset, and the `tauri:dev` script references the overlay config.
> - Risk: any production webview code that previously made HTTP/WS requests to localhost will now be blocked by CSP.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f937507.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Strengthened the desktop app’s Content Security Policy by restricting scripts, connections, embedded content, and other resource sources.
  - Production builds now prevent unintended connections to local development services while preserving required IPC communication.

- **Development**
  - Added a dedicated development configuration supporting local development workflows and hot-module reload connections without affecting production security settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->