### PR TITLE
Add an activity heatmap to the Charts tab

### DIFF
--- a/apps/desktop-tauri/src-tauri/permissions/commands.toml
+++ b/apps/desktop-tauri/src-tauri/permissions/commands.toml
@@ -64,6 +64,7 @@ commands.allow = [
   "get_quota_run_efficiency",
   "get_provider_local_usage_summary",
   "get_local_api_value_totals",
+  "get_local_activity_heatmap",
   "get_cursor_model_activity",
   "export_cost_csv",
   "reorder_providers",

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -8,7 +8,7 @@
 use chrono::{DateTime, Datelike, Local, LocalResult, NaiveDate, TimeZone, Timelike, Utc};
 use codexbar::core::OpenAIDashboardCacheStore;
 use codexbar::cost_scanner::{
-    CostScanner, CostSummary, CostUsageReport, CurrentUsageWindow, get_cost_usage_report,
+    CostScanner, CostSummary, CostUsageReport, CurrentUsageWindow, get_cost_usage_report_hourly,
     get_cost_usage_report_scoped, get_cost_usage_report_with_windows,
 };
 use codexbar::locale::{self, LocaleKey};
@@ -1275,7 +1275,7 @@ where
     let per_provider = API_VALUE_PROVIDERS
         .iter()
         .filter_map(|provider_id| {
-            let report = get_cost_usage_report(provider_id, ACTIVITY_HEATMAP_DAYS)?;
+            let report = get_cost_usage_report_hourly(provider_id, ACTIVITY_HEATMAP_DAYS)?;
             Some(activity_hours_for_provider(provider_id, &report))
         })
         .collect();

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -8,8 +8,8 @@
 use chrono::{DateTime, Datelike, Local, LocalResult, NaiveDate, TimeZone, Timelike, Utc};
 use codexbar::core::OpenAIDashboardCacheStore;
 use codexbar::cost_scanner::{
-    CostScanner, CostSummary, CostUsageReport, CurrentUsageWindow, get_cost_usage_report_scoped,
-    get_cost_usage_report_with_windows,
+    CostScanner, CostSummary, CostUsageReport, CurrentUsageWindow, get_cost_usage_report,
+    get_cost_usage_report_scoped, get_cost_usage_report_with_windows,
 };
 use codexbar::locale::{self, LocaleKey};
 use serde::{Deserialize, Serialize};
@@ -1098,6 +1098,194 @@ fn period_from_daily_series(
     }
 }
 
+/// One provider's activity in a single local clock-hour.
+///
+/// Hours with no activity are omitted rather than sent as zeros: a 30-day grid
+/// is 720 cells per provider, and the UI fills the gaps itself.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityHourPoint {
+    pub provider_id: String,
+    /// Local calendar date, `YYYY-MM-DD`.
+    pub date: String,
+    /// Local hour of day, 0-23.
+    pub hour: u32,
+    /// Estimated API value in USD from priced models in this hour. Unpriced
+    /// models contribute tokens but no dollars, exactly as elsewhere.
+    pub api_value_usd: f64,
+    /// Provider-normalized processed tokens.
+    pub tokens: u64,
+    /// Usage records in this hour. Dollars can be dominated by one big call,
+    /// so this is the honest answer to "when am I actually working".
+    pub calls: u64,
+}
+
+/// Local activity by calendar day and clock hour, for the heatmap card.
+///
+/// Everything here is derived from transcript timestamps already on disk. No
+/// new data is collected and nothing leaves the machine.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityHeatmap {
+    /// Every local calendar day in range, oldest first, including empty days,
+    /// so the calendar renders a continuous strip.
+    pub days: Vec<String>,
+    /// Providers that contributed at least one hour, for the filter chips.
+    pub provider_ids: Vec<String>,
+    /// Non-empty hour buckets, oldest first.
+    pub hours: Vec<ActivityHourPoint>,
+    /// UTC offset of the clock these buckets use, for example `UTC-07:00`.
+    /// Shown so a heatmap read on a different machine is not misread.
+    pub timezone_label: String,
+}
+
+/// Days of history the heatmap covers. Matches the cost scanner's own 30-day
+/// retention, so the card never claims a range the underlying scan cannot fill.
+const ACTIVITY_HEATMAP_DAYS: u32 = 30;
+const ACTIVITY_HEATMAP_TTL: Duration = Duration::from_secs(5 * 60);
+
+struct CachedActivityHeatmap {
+    loaded_at: Instant,
+    heatmap: ActivityHeatmap,
+}
+
+fn activity_heatmap_cache() -> &'static Mutex<Option<CachedActivityHeatmap>> {
+    static CACHE: OnceLock<Mutex<Option<CachedActivityHeatmap>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(None))
+}
+
+/// Local activity by day and hour across every provider with local logs.
+///
+/// This is a second pass over the same transcripts the API-value card reads, so
+/// results are cached for the same five minutes the chart caches use. Callers
+/// that need fresh numbers after a scan should let the TTL lapse rather than
+/// forcing a rescan on every tab switch.
+#[tauri::command]
+pub async fn get_local_activity_heatmap() -> Result<ActivityHeatmap, String> {
+    if let Ok(guard) = activity_heatmap_cache().lock()
+        && let Some(cached) = guard.as_ref()
+        && cached.loaded_at.elapsed() < ACTIVITY_HEATMAP_TTL
+    {
+        return Ok(cached.heatmap.clone());
+    }
+
+    // A worker panic must surface as an error: "unavailable" and "no activity"
+    // look identical on a heatmap otherwise.
+    let heatmap = tauri::async_runtime::spawn_blocking(|| load_activity_heatmap(Local::now()))
+        .await
+        .map_err(|err| {
+            tracing::warn!("Activity heatmap worker failed: {}", err);
+            "Unable to read local activity.".to_string()
+        })?;
+
+    if let Ok(mut guard) = activity_heatmap_cache().lock() {
+        *guard = Some(CachedActivityHeatmap {
+            loaded_at: Instant::now(),
+            heatmap: heatmap.clone(),
+        });
+    }
+    Ok(heatmap)
+}
+
+/// The day axis: `ACTIVITY_HEATMAP_DAYS` local calendar days ending on `today`,
+/// oldest first. Built from the calendar rather than from the scan, so an idle
+/// machine still renders a full grid instead of collapsing to nothing.
+fn activity_heatmap_days(today: NaiveDate) -> Vec<String> {
+    (0..ACTIVITY_HEATMAP_DAYS as i64)
+        .rev()
+        .map(|offset| {
+            (today - chrono::Duration::days(offset))
+                .format("%Y-%m-%d")
+                .to_string()
+        })
+        .collect()
+}
+
+/// Hour rows for one provider's report.
+fn activity_hours_for_provider(
+    provider_id: &str,
+    report: &CostUsageReport,
+) -> Vec<ActivityHourPoint> {
+    report
+        .hourly_activity
+        .iter()
+        .filter_map(|point| {
+            let tokens = point.summary.normalized_tokens(provider_id).processed();
+            let calls: u64 = point
+                .summary
+                .by_model_tokens
+                .values()
+                .map(|counts| counts.calls)
+                .sum();
+            // An hour that produced no tokens, dollars, or calls is not
+            // activity; keeping it would darken the grid for nothing.
+            (tokens > 0 || calls > 0 || point.summary.total_cost_usd > 0.0).then(|| {
+                ActivityHourPoint {
+                    provider_id: provider_id.to_string(),
+                    date: point.date.format("%Y-%m-%d").to_string(),
+                    hour: point.hour,
+                    api_value_usd: point.summary.total_cost_usd,
+                    tokens,
+                    calls,
+                }
+            })
+        })
+        .collect()
+}
+
+/// Merge each provider's rows into one timeline.
+///
+/// Providers are scanned one after another, so the concatenation is only
+/// sorted within a provider; the card reads it as a single series. A provider
+/// that contributed no hours is left out of `provider_ids` so the filter chips
+/// never offer a control that can only ever blank the grid.
+fn assemble_activity_heatmap(
+    days: Vec<String>,
+    per_provider: Vec<Vec<ActivityHourPoint>>,
+    timezone_label: String,
+) -> ActivityHeatmap {
+    let mut provider_ids = Vec::new();
+    let mut hours = Vec::new();
+    for rows in per_provider {
+        if let Some(first) = rows.first() {
+            provider_ids.push(first.provider_id.clone());
+        }
+        hours.extend(rows);
+    }
+    hours.sort_by(|left, right| {
+        (&left.date, left.hour, &left.provider_id).cmp(&(
+            &right.date,
+            right.hour,
+            &right.provider_id,
+        ))
+    });
+
+    ActivityHeatmap {
+        days,
+        provider_ids,
+        hours,
+        timezone_label,
+    }
+}
+
+fn load_activity_heatmap<Tz: TimeZone>(now: DateTime<Tz>) -> ActivityHeatmap
+where
+    Tz::Offset: std::fmt::Display,
+{
+    let per_provider = API_VALUE_PROVIDERS
+        .iter()
+        .filter_map(|provider_id| {
+            let report = get_cost_usage_report(provider_id, ACTIVITY_HEATMAP_DAYS)?;
+            Some(activity_hours_for_provider(provider_id, &report))
+        })
+        .collect();
+    assemble_activity_heatmap(
+        activity_heatmap_days(now.date_naive()),
+        per_provider,
+        format!("UTC{}", now.offset()),
+    )
+}
+
 /// One model's local Cursor activity. This is code-contribution activity from
 /// Cursor's on-disk tracking, NOT tokens or dollars (Cursor logs neither).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1950,11 +2138,12 @@ fn load_openai_dashboard_chart_data(
 #[cfg(test)]
 mod tests {
     use super::{
-        ChartAccountScope, CostFetchFailure, LocalEffortCost, LocalModelCost, LocalPlanUsage,
-        LocalProjectCost, LocalTokenBreakdown, LocalUsageWindowRequest, ProviderLocalUsageSummary,
-        api_value_period, chart_cache_key, comparison_period_specs,
-        cost_fetch_failure_allows_early_retry, daily_series_from_report, effort_breakdown,
-        format_cost_csv, local_midnight_in_tz, local_usage_summary_from_report,
+        ACTIVITY_HEATMAP_DAYS, ActivityHourPoint, ChartAccountScope, CostFetchFailure,
+        LocalEffortCost, LocalModelCost, LocalPlanUsage, LocalProjectCost, LocalTokenBreakdown,
+        LocalUsageWindowRequest, ProviderLocalUsageSummary, activity_heatmap_days,
+        activity_hours_for_provider, api_value_period, assemble_activity_heatmap, chart_cache_key,
+        comparison_period_specs, cost_fetch_failure_allows_early_retry, daily_series_from_report,
+        effort_breakdown, format_cost_csv, local_midnight_in_tz, local_usage_summary_from_report,
         local_yesterday_window_utc, localized_estimate_note, model_breakdown,
         parse_api_value_custom_range, period_from_daily_series, pricing_coverage_tokens,
         project_breakdown, resolve_chart_account_scope, spend_budget_period_details,
@@ -1963,7 +2152,9 @@ mod tests {
     use crate::commands::is_provider_cache_fresh;
     use chrono::{Local, LocalResult, NaiveDate, NaiveTime, TimeZone, Timelike, Utc};
     use codexbar::core::{CodexIdentity, ConfiguredAccounts, DirectoryAccount};
-    use codexbar::cost_scanner::{CostSummary, CostUsageReport, ModelTokenCounts};
+    use codexbar::cost_scanner::{
+        CostSummary, CostUsageReport, HourlyActivityPoint, ModelTokenCounts,
+    };
     use codexbar::settings::Language;
     use std::path::PathBuf;
     use std::time::{Duration, Instant};
@@ -2496,6 +2687,7 @@ mod tests {
             today: CostSummary::default(),
             latest_session: None,
             current_windows: Default::default(),
+            hourly_activity: Vec::new(),
         };
         report
             .current_windows
@@ -2912,5 +3104,110 @@ mod tests {
         );
         assert!(!period.has_data);
         assert_eq!(period.api_value_usd, 0.0);
+    }
+
+    /// SBS-277: the day axis comes from the calendar, not from the scan, so an
+    /// idle machine still renders a full grid instead of collapsing to nothing.
+    #[test]
+    fn activity_heatmap_days_span_a_full_window_oldest_first() {
+        let days = activity_heatmap_days(NaiveDate::from_ymd_opt(2026, 8, 15).unwrap());
+
+        assert_eq!(days.len(), ACTIVITY_HEATMAP_DAYS as usize);
+        assert_eq!(days.first().unwrap(), "2026-07-17");
+        assert_eq!(days.last().unwrap(), "2026-08-15");
+        let mut sorted = days.clone();
+        sorted.sort();
+        assert_eq!(sorted, days, "days read oldest first");
+    }
+
+    fn hourly_point(hour: u32, summary: CostSummary) -> HourlyActivityPoint {
+        HourlyActivityPoint {
+            date: NaiveDate::from_ymd_opt(2026, 8, 15).unwrap(),
+            hour,
+            summary,
+        }
+    }
+
+    /// An hour with no tokens, dollars, or calls is not activity. Emitting it
+    /// would darken a cell that should read as idle.
+    #[test]
+    fn activity_hours_drop_empty_buckets_and_normalize_tokens() {
+        let mut busy = CostSummary {
+            total_cost_usd: 1.25,
+            input_tokens: 1_000,
+            output_tokens: 200,
+            // Codex folds cache reads into its input count, so processed tokens
+            // must not add these twice.
+            cached_tokens: 800,
+            ..Default::default()
+        };
+        busy.by_model_tokens.insert(
+            "gpt-5.1-codex".to_string(),
+            ModelTokenCounts {
+                input_tokens: 1_000,
+                output_tokens: 200,
+                calls: 3,
+                ..Default::default()
+            },
+        );
+        let report = CostUsageReport {
+            hourly_activity: vec![
+                hourly_point(9, busy),
+                hourly_point(10, CostSummary::default()),
+            ],
+            ..Default::default()
+        };
+
+        let hours = activity_hours_for_provider("codex", &report);
+
+        assert_eq!(hours.len(), 1, "the empty 10:00 bucket is dropped");
+        let point = &hours[0];
+        assert_eq!(point.hour, 9);
+        assert_eq!(point.provider_id, "codex");
+        assert_eq!(point.date, "2026-08-15");
+        assert_eq!(point.calls, 3);
+        assert!((point.api_value_usd - 1.25).abs() < f64::EPSILON);
+        // 200 fresh input + 200 output + 800 cache read, each counted once.
+        assert_eq!(point.tokens, 1_200);
+    }
+
+    #[test]
+    fn activity_heatmap_merges_providers_into_one_sorted_timeline() {
+        let row = |provider_id: &str, date: &str, hour: u32| ActivityHourPoint {
+            provider_id: provider_id.to_string(),
+            date: date.to_string(),
+            hour,
+            api_value_usd: 1.0,
+            tokens: 10,
+            calls: 1,
+        };
+
+        let heatmap = assemble_activity_heatmap(
+            vec!["2026-08-14".to_string(), "2026-08-15".to_string()],
+            vec![
+                vec![
+                    row("codex", "2026-08-15", 9),
+                    row("codex", "2026-08-14", 22),
+                ],
+                // A provider with nothing to show must not appear as a chip.
+                Vec::new(),
+                vec![row("grok", "2026-08-14", 22)],
+            ],
+            "UTC+00:00".to_string(),
+        );
+
+        assert_eq!(heatmap.provider_ids, vec!["codex", "grok"]);
+        assert_eq!(
+            heatmap
+                .hours
+                .iter()
+                .map(|point| (point.date.as_str(), point.hour, point.provider_id.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("2026-08-14", 22, "codex"),
+                ("2026-08-14", 22, "grok"),
+                ("2026-08-15", 9, "codex"),
+            ],
+        );
     }
 }

--- a/apps/desktop-tauri/src-tauri/src/main.rs
+++ b/apps/desktop-tauri/src-tauri/src/main.rs
@@ -197,6 +197,7 @@ fn main() {
             commands::get_quota_run_efficiency,
             commands::get_provider_local_usage_summary,
             commands::get_local_api_value_totals,
+            commands::get_local_activity_heatmap,
             commands::get_cursor_model_activity,
             commands::export_cost_csv,
             commands::reorder_providers,

--- a/apps/desktop-tauri/src/components/ActivityHeatmapCard.test.tsx
+++ b/apps/desktop-tauri/src/components/ActivityHeatmapCard.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActivityHeatmap, ActivityHourPoint } from "../types/bridge";
+
+const getLocalActivityHeatmap = vi.fn();
+vi.mock("../lib/tauri", () => ({
+  getLocalActivityHeatmap: () => getLocalActivityHeatmap(),
+}));
+
+const { ActivityHeatmapCard } = await import("./ActivityHeatmapCard");
+
+const hour = (over: Partial<ActivityHourPoint> = {}): ActivityHourPoint => ({
+  providerId: "codex",
+  date: "2026-08-15",
+  hour: 9,
+  apiValueUsd: 4,
+  tokens: 1000,
+  calls: 2,
+  ...over,
+});
+
+const heatmap = (over: Partial<ActivityHeatmap> = {}): ActivityHeatmap => ({
+  days: ["2026-08-14", "2026-08-15"],
+  providerIds: ["codex", "claude"],
+  hours: [hour(), hour({ providerId: "claude", date: "2026-08-14", hour: 22 })],
+  timezoneLabel: "UTC-07:00",
+  ...over,
+});
+
+const activeDayCells = () =>
+  [...document.querySelectorAll(".activity-card__cell--day")].filter(
+    (cell) => cell.getAttribute("data-level") !== "0",
+  ).length;
+
+describe("ActivityHeatmapCard", () => {
+  beforeEach(() => {
+    getLocalActivityHeatmap.mockReset();
+  });
+
+  it("draws a cell per day in range and lights the active ones", async () => {
+    getLocalActivityHeatmap.mockResolvedValue(heatmap());
+    render(<ActivityHeatmapCard />);
+
+    await waitFor(() => expect(screen.getByText("When you work")).toBeInTheDocument());
+    expect(document.querySelectorAll(".activity-card__cell--day")).toHaveLength(2);
+    expect(activeDayCells()).toBe(2);
+    // The clock the buckets use is disclosed, not assumed.
+    expect(screen.getByText(/UTC-07:00/)).toBeInTheDocument();
+  });
+
+  it("drops a provider's hours when its chip is switched off", async () => {
+    getLocalActivityHeatmap.mockResolvedValue(heatmap());
+    render(<ActivityHeatmapCard />);
+    await waitFor(() => expect(activeDayCells()).toBe(2));
+
+    fireEvent.click(screen.getByRole("button", { name: /Claude/ }));
+
+    await waitFor(() => expect(activeDayCells()).toBe(1));
+  });
+
+  /// Regression: an empty visible set used to mean "no filter", so turning
+  /// every chip off showed every provider instead of an empty grid.
+  it("empties the grid when every provider is switched off", async () => {
+    getLocalActivityHeatmap.mockResolvedValue(heatmap());
+    render(<ActivityHeatmapCard />);
+    await waitFor(() => expect(activeDayCells()).toBe(2));
+
+    fireEvent.click(screen.getByRole("button", { name: /Claude/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Codex/ }));
+
+    await waitFor(() => expect(activeDayCells()).toBe(0));
+    // And it says why the grid is empty, rather than blaming the machine.
+    expect(screen.getByText(/Every provider is hidden/)).toBeInTheDocument();
+  });
+
+  it("says the window is empty when there is genuinely no activity", async () => {
+    getLocalActivityHeatmap.mockResolvedValue(
+      heatmap({ providerIds: [], hours: [] }),
+    );
+    render(<ActivityHeatmapCard />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/No local activity in this window yet/)).toBeInTheDocument(),
+    );
+  });
+
+  it("surfaces a failed read instead of drawing an empty grid", async () => {
+    getLocalActivityHeatmap.mockRejectedValue(new Error("scan died"));
+    render(<ActivityHeatmapCard />);
+
+    await waitFor(() => expect(screen.getByText("scan died")).toBeInTheDocument());
+    expect(document.querySelectorAll(".activity-card__cell--day")).toHaveLength(0);
+  });
+});

--- a/apps/desktop-tauri/src/components/ActivityHeatmapCard.tsx
+++ b/apps/desktop-tauri/src/components/ActivityHeatmapCard.tsx
@@ -145,6 +145,9 @@ export function ActivityHeatmapCard() {
   }
 
   const hasActivity = rows.length > 0;
+  // An empty grid because every chip is off is a different thing from an empty
+  // grid because the machine was idle, and saying the wrong one reads as a bug.
+  const allProvidersHidden = providerIds.length > 0 && visibleProviders.length === 0;
 
   return (
     <section className="activity-card" aria-label="Activity heatmap">
@@ -203,7 +206,9 @@ export function ActivityHeatmapCard() {
       <div className="activity-card__plots" ref={hostRef}>
         {!hasActivity && (
           <p className="activity-card__status" role="status">
-            No local activity in this window yet.
+            {allProvidersHidden
+              ? "Every provider is hidden. Turn one back on above."
+              : "No local activity in this window yet."}
           </p>
         )}
 

--- a/apps/desktop-tauri/src/components/ActivityHeatmapCard.tsx
+++ b/apps/desktop-tauri/src/components/ActivityHeatmapCard.tsx
@@ -1,0 +1,315 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { getLocalActivityHeatmap } from "../lib/tauri";
+import type { ActivityHeatmap } from "../types/bridge";
+import { getProviderIcon } from "./providers/providerIcons";
+import {
+  chartTooltipPosition,
+  type ChartTooltipPosition,
+} from "./charts/chartTooltip";
+import {
+  WEEKDAY_LABELS,
+  buildCalendar,
+  buildWeekHourGrid,
+  formatHourLabel,
+  peakHour,
+  peakWeekday,
+  selectProviders,
+  totalValue,
+  type ActivityMetric,
+} from "../lib/activityHeatmap";
+
+const METRICS: { key: ActivityMetric; label: string }[] = [
+  { key: "apiValue", label: "API value" },
+  { key: "tokens", label: "Tokens" },
+];
+
+/** Hour ticks every six hours keeps 24 columns legible at panel width. */
+const HOUR_TICKS = [0, 6, 12, 18];
+
+function formatUsd(value: number): string {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+}
+
+function formatTokens(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function formatMetric(value: number, metric: ActivityMetric): string {
+  return metric === "apiValue" ? formatUsd(value) : `${formatTokens(value)} tokens`;
+}
+
+function providerLabel(providerId: string): string {
+  return providerId.charAt(0).toUpperCase() + providerId.slice(1);
+}
+
+/** "Aug 15" for cell labels; the year is already implied by a 30-day window. */
+function shortDate(date: string): string {
+  const [year, month, day] = date.split("-").map(Number);
+  if (!year || !month || !day) return date;
+  return new Date(year, month - 1, day).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function tauriErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return String(err ?? "");
+}
+
+type Tooltip = ChartTooltipPosition & { text: string };
+
+/**
+ * When the machine is actually busy, from local transcript timestamps (SBS-277).
+ *
+ * Two views over the same data: a 30-day calendar strip for "which days", and a
+ * weekday-by-hour grid for "which hours". Both use one sequential ramp, and
+ * every cell carries its exact figure in text so the reading never depends on
+ * telling two shades apart.
+ */
+export function ActivityHeatmapCard() {
+  const [heatmap, setHeatmap] = useState<ActivityHeatmap | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [metric, setMetric] = useState<ActivityMetric>("apiValue");
+  const [excluded, setExcluded] = useState<string[]>([]);
+  const [tooltip, setTooltip] = useState<Tooltip | null>(null);
+  const hostRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    setLoading(true);
+    setError(null);
+    getLocalActivityHeatmap()
+      .then((data) => {
+        if (live) setHeatmap(data);
+      })
+      .catch((err: unknown) => {
+        if (live) setError(tauriErrorMessage(err) || "Unable to read local activity.");
+      })
+      .finally(() => {
+        if (live) setLoading(false);
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  const providerIds = heatmap?.providerIds ?? [];
+  // Chips toggle providers off, so a provider that appears after a rescan is
+  // visible by default rather than silently filtered out.
+  const visibleProviders = useMemo(
+    () => providerIds.filter((id) => !excluded.includes(id)),
+    [providerIds, excluded],
+  );
+
+  const rows = useMemo(
+    () => selectProviders(heatmap?.hours ?? [], visibleProviders),
+    [heatmap, visibleProviders],
+  );
+
+  const calendar = useMemo(
+    () => buildCalendar(heatmap?.days ?? [], rows, metric),
+    [heatmap, rows, metric],
+  );
+  const grid = useMemo(() => buildWeekHourGrid(rows, metric), [rows, metric]);
+  const busiestHour = useMemo(() => peakHour(rows, metric), [rows, metric]);
+  const busiestWeekday = useMemo(() => peakWeekday(rows, metric), [rows, metric]);
+  const total = useMemo(() => totalValue(rows, metric), [rows, metric]);
+
+  const showTooltip = (event: React.MouseEvent<HTMLElement>, text: string) => {
+    const host = hostRef.current;
+    if (!host) return;
+    setTooltip({ text, ...chartTooltipPosition(event.clientX, event.clientY, host.getBoundingClientRect()) });
+  };
+  const hideTooltip = () => setTooltip(null);
+
+  if (loading) {
+    return (
+      <section className="activity-card" aria-label="Activity heatmap">
+        <p className="activity-card__status">Reading local activity…</p>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="activity-card" aria-label="Activity heatmap">
+        <p className="activity-card__status">{error}</p>
+      </section>
+    );
+  }
+
+  const hasActivity = rows.length > 0;
+
+  return (
+    <section className="activity-card" aria-label="Activity heatmap">
+      <header className="activity-card__header">
+        <div>
+          <h3 className="activity-card__title">When you work</h3>
+          <p className="activity-card__subtitle">
+            Last {calendar.length} days of local activity, {heatmap?.timezoneLabel ?? "local time"}
+          </p>
+        </div>
+        <div className="activity-card__switch" role="group" aria-label="Metric">
+          {METRICS.map((option) => (
+            <button
+              key={option.key}
+              type="button"
+              className="activity-card__switch-btn"
+              data-active={metric === option.key ? "true" : "false"}
+              aria-pressed={metric === option.key}
+              onClick={() => setMetric(option.key)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {providerIds.length > 1 && (
+        <div className="activity-card__providers" role="group" aria-label="Providers">
+          {providerIds.map((id) => {
+            const on = !excluded.includes(id);
+            return (
+              <button
+                key={id}
+                type="button"
+                className="activity-card__provider-chip"
+                data-active={on ? "true" : "false"}
+                aria-pressed={on}
+                onClick={() =>
+                  setExcluded((prev) =>
+                    prev.includes(id) ? prev.filter((entry) => entry !== id) : [...prev, id],
+                  )
+                }
+              >
+                <span
+                  className="activity-card__provider-dot"
+                  style={{ background: getProviderIcon(id).brandColor }}
+                  aria-hidden
+                />
+                {providerLabel(id)}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="activity-card__plots" ref={hostRef}>
+        {!hasActivity && (
+          <p className="activity-card__status" role="status">
+            No local activity in this window yet.
+          </p>
+        )}
+
+        <div className="activity-card__section">
+          <div className="activity-card__section-head">
+            <span className="activity-card__section-title">By day</span>
+            <span className="activity-card__section-note">
+              {formatMetric(total, metric)} total
+            </span>
+          </div>
+          <div
+            className="activity-card__days"
+            role="img"
+            aria-label={`Daily activity for the last ${calendar.length} days`}
+          >
+            {calendar.map((cell) => {
+              const label = `${shortDate(cell.date)}: ${formatMetric(cell.value, metric)}, ${cell.calls} calls`;
+              return (
+                <div
+                  key={cell.date}
+                  className="activity-card__cell activity-card__cell--day"
+                  data-level={cell.level}
+                  title={label}
+                  onMouseMove={(event) => showTooltip(event, label)}
+                  onMouseLeave={hideTooltip}
+                />
+              );
+            })}
+          </div>
+          {calendar.length > 0 && (
+            <div className="activity-card__days-axis" aria-hidden>
+              <span>{shortDate(calendar[0].date)}</span>
+              <span>{shortDate(calendar[calendar.length - 1].date)}</span>
+            </div>
+          )}
+        </div>
+
+        <div className="activity-card__section">
+          <div className="activity-card__section-head">
+            <span className="activity-card__section-title">By hour</span>
+            <span className="activity-card__section-note">
+              {busiestHour && busiestWeekday
+                ? `Busiest ${WEEKDAY_LABELS[busiestWeekday.weekday]}, around ${formatHourLabel(busiestHour.hour)}`
+                : "No peak yet"}
+            </span>
+          </div>
+          <div className="activity-card__grid-wrap">
+            <div className="activity-card__hour-axis" aria-hidden>
+              {HOUR_TICKS.map((hour) => (
+                <span key={hour} style={{ gridColumn: `${hour + 1} / span 6` }}>
+                  {formatHourLabel(hour)}
+                </span>
+              ))}
+            </div>
+            <div
+              className="activity-card__grid"
+              role="img"
+              aria-label="Activity by weekday and hour of day"
+            >
+              {grid.map((row, weekday) => (
+                <div className="activity-card__grid-row" key={weekday}>
+                  <span className="activity-card__weekday" aria-hidden>
+                    {WEEKDAY_LABELS[weekday]}
+                  </span>
+                  {row.map((cell) => {
+                    const label = `${WEEKDAY_LABELS[weekday]} ${formatHourLabel(cell.hour)}: ${formatMetric(cell.value, metric)}, ${cell.calls} calls`;
+                    return (
+                      <div
+                        key={cell.hour}
+                        className="activity-card__cell activity-card__cell--hour"
+                        data-level={cell.level}
+                        title={label}
+                        onMouseMove={(event) => showTooltip(event, label)}
+                        onMouseLeave={hideTooltip}
+                      />
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {tooltip && (
+          <div
+            className="chart__tooltip activity-card__tooltip"
+            style={{ left: tooltip.x, top: tooltip.y }}
+            data-align={tooltip.alignment}
+          >
+            {tooltip.text}
+          </div>
+        )}
+      </div>
+
+      <footer className="activity-card__footer">
+        <span className="activity-card__legend-label">Less</span>
+        <span className="activity-card__legend-swatches" aria-hidden>
+          {[0, 1, 2, 3, 4].map((level) => (
+            <span key={level} className="activity-card__cell" data-level={level} />
+          ))}
+        </span>
+        <span className="activity-card__legend-label">More</span>
+        <span className="activity-card__footer-note">
+          From local transcript timestamps. Nothing leaves this machine.
+        </span>
+      </footer>
+    </section>
+  );
+}

--- a/apps/desktop-tauri/src/lib/activityHeatmap.test.ts
+++ b/apps/desktop-tauri/src/lib/activityHeatmap.test.ts
@@ -143,12 +143,16 @@ describe("buildWeekHourGrid", () => {
 describe("selectProviders", () => {
   const hours = [point({ providerId: "codex" }), point({ providerId: "claude" })];
 
-  it("returns everything when nothing is selected", () => {
-    expect(selectProviders(hours, [])).toHaveLength(2);
+  it("filters to the visible providers", () => {
+    expect(selectProviders(hours, ["claude"]).map((row) => row.providerId)).toEqual(["claude"]);
+    expect(selectProviders(hours, ["codex", "claude"])).toHaveLength(2);
   });
 
-  it("filters to the selected providers", () => {
-    expect(selectProviders(hours, ["claude"]).map((row) => row.providerId)).toEqual(["claude"]);
+  // Turning every chip off must empty the grid. Treating an empty list as
+  // "no filter" showed every provider instead, which reads as the filter
+  // being broken.
+  it("shows nothing when no provider is visible", () => {
+    expect(selectProviders(hours, [])).toEqual([]);
   });
 });
 

--- a/apps/desktop-tauri/src/lib/activityHeatmap.test.ts
+++ b/apps/desktop-tauri/src/lib/activityHeatmap.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import type { ActivityHourPoint } from "../types/bridge";
+import {
+  bandThresholds,
+  buildCalendar,
+  buildWeekHourGrid,
+  formatHourLabel,
+  intensityLevel,
+  parseLocalDate,
+  peakHour,
+  peakWeekday,
+  selectProviders,
+  totalValue,
+} from "./activityHeatmap";
+
+const point = (over: Partial<ActivityHourPoint>): ActivityHourPoint => ({
+  providerId: "codex",
+  date: "2026-08-10",
+  hour: 9,
+  apiValueUsd: 1,
+  tokens: 100,
+  calls: 1,
+  ...over,
+});
+
+describe("parseLocalDate", () => {
+  // `new Date("2026-08-15")` is UTC midnight, which is Aug 14 anywhere west of
+  // Greenwich. That would shift every cell one column.
+  it("reads the date on the local clock, not UTC", () => {
+    const parsed = parseLocalDate("2026-08-15");
+    expect(parsed?.getFullYear()).toBe(2026);
+    expect(parsed?.getMonth()).toBe(7);
+    expect(parsed?.getDate()).toBe(15);
+  });
+
+  it("rejects malformed dates", () => {
+    expect(parseLocalDate("")).toBeNull();
+    expect(parseLocalDate("not-a-date")).toBeNull();
+  });
+});
+
+describe("intensity banding", () => {
+  it("bands by quartile so one big session cannot flatten the rest", () => {
+    // A linear scale against the 1000 peak would put all eight ordinary values
+    // in the bottom band and show nothing about the ordinary days.
+    const bands = bandThresholds([1, 2, 3, 4, 5, 6, 7, 8, 1000]);
+    expect(bands).toEqual([3, 5, 7]);
+    expect(intensityLevel(1, bands)).toBe(1);
+    expect(intensityLevel(4, bands)).toBe(2);
+    expect(intensityLevel(6, bands)).toBe(3);
+    expect(intensityLevel(1000, bands)).toBe(4);
+  });
+
+  it("treats zero and negative as no activity", () => {
+    const bands = bandThresholds([5, 10, 15]);
+    expect(intensityLevel(0, bands)).toBe(0);
+    expect(intensityLevel(-1, bands)).toBe(0);
+  });
+
+  it("holds a flat distribution mid-scale instead of all-peak", () => {
+    const bands = bandThresholds([7, 7, 7, 7]);
+    expect(intensityLevel(7, bands)).toBe(2);
+  });
+
+  it("ignores empty cells when choosing the bands", () => {
+    expect(bandThresholds([0, 0, 0])).toEqual([0, 0, 0]);
+    // Only 4 and 8 are active, so the quartiles sit on those two values alone
+    // rather than being dragged toward zero by the empty cells.
+    expect(bandThresholds([0, 0, 4, 8])).toEqual([4, 8, 8]);
+  });
+});
+
+describe("buildCalendar", () => {
+  const days = ["2026-08-08", "2026-08-09", "2026-08-10"];
+
+  it("keeps empty days so the grid stays continuous", () => {
+    const cells = buildCalendar(days, [point({ date: "2026-08-10" })], "apiValue");
+    expect(cells.map((cell) => cell.date)).toEqual(days);
+    expect(cells[0].level).toBe(0);
+    expect(cells[0].value).toBe(0);
+    expect(cells[2].level).toBeGreaterThan(0);
+  });
+
+  it("sums every hour of a day, across providers", () => {
+    const cells = buildCalendar(
+      days,
+      [
+        point({ date: "2026-08-09", hour: 9, apiValueUsd: 2, calls: 3 }),
+        point({ date: "2026-08-09", hour: 14, apiValueUsd: 5, calls: 4 }),
+        point({ providerId: "claude", date: "2026-08-09", hour: 14, apiValueUsd: 1, calls: 1 }),
+      ],
+      "apiValue",
+    );
+    expect(cells[1].value).toBe(8);
+    expect(cells[1].calls).toBe(8);
+  });
+
+  it("switches metric without touching the shape", () => {
+    const hours = [point({ date: "2026-08-10", apiValueUsd: 2, tokens: 900 })];
+    expect(buildCalendar(days, hours, "apiValue")[2].value).toBe(2);
+    expect(buildCalendar(days, hours, "tokens")[2].value).toBe(900);
+  });
+});
+
+describe("buildWeekHourGrid", () => {
+  it("is always a full 7 x 24 grid", () => {
+    const grid = buildWeekHourGrid([], "apiValue");
+    expect(grid).toHaveLength(7);
+    expect(grid.every((row) => row.length === 24)).toBe(true);
+    expect(grid.flat().every((cell) => cell.level === 0)).toBe(true);
+  });
+
+  it("folds the same weekday and hour across weeks into one cell", () => {
+    // 2026-08-03 and 2026-08-10 are both Mondays.
+    const grid = buildWeekHourGrid(
+      [
+        point({ date: "2026-08-03", hour: 15, apiValueUsd: 4, calls: 2 }),
+        point({ date: "2026-08-10", hour: 15, apiValueUsd: 6, calls: 3 }),
+      ],
+      "apiValue",
+    );
+    const monday = grid[1];
+    expect(monday[15].value).toBe(10);
+    expect(monday[15].calls).toBe(5);
+    expect(monday[14].value).toBe(0);
+  });
+
+  it("bands across the whole grid, not per row", () => {
+    // A quiet Sunday must stay visibly quieter than a busy Monday.
+    const grid = buildWeekHourGrid(
+      [
+        point({ date: "2026-08-09", hour: 2, apiValueUsd: 1 }),
+        point({ date: "2026-08-10", hour: 2, apiValueUsd: 50 }),
+        point({ date: "2026-08-11", hour: 2, apiValueUsd: 100 }),
+        point({ date: "2026-08-12", hour: 2, apiValueUsd: 200 }),
+      ],
+      "apiValue",
+    );
+    expect(grid[0][2].level).toBeLessThan(grid[3][2].level);
+  });
+});
+
+describe("selectProviders", () => {
+  const hours = [point({ providerId: "codex" }), point({ providerId: "claude" })];
+
+  it("returns everything when nothing is selected", () => {
+    expect(selectProviders(hours, [])).toHaveLength(2);
+  });
+
+  it("filters to the selected providers", () => {
+    expect(selectProviders(hours, ["claude"]).map((row) => row.providerId)).toEqual(["claude"]);
+  });
+});
+
+describe("peaks", () => {
+  const hours = [
+    point({ date: "2026-08-10", hour: 9, apiValueUsd: 3 }),
+    point({ date: "2026-08-11", hour: 22, apiValueUsd: 11 }),
+    point({ date: "2026-08-12", hour: 22, apiValueUsd: 4 }),
+  ];
+
+  it("finds the busiest clock hour and weekday", () => {
+    expect(peakHour(hours, "apiValue")).toEqual({ hour: 22, value: 15 });
+    // 2026-08-11 is a Tuesday.
+    expect(peakWeekday(hours, "apiValue")).toEqual({ weekday: 2, value: 11 });
+  });
+
+  it("reports the earlier hour on an exact tie", () => {
+    const tied = [
+      point({ date: "2026-08-10", hour: 20, apiValueUsd: 5 }),
+      point({ date: "2026-08-10", hour: 8, apiValueUsd: 5 }),
+    ];
+    expect(peakHour(tied, "apiValue")?.hour).toBe(8);
+  });
+
+  it("has no peak without activity", () => {
+    expect(peakHour([], "apiValue")).toBeNull();
+    expect(peakWeekday([], "apiValue")).toBeNull();
+    expect(peakHour([point({ apiValueUsd: 0 })], "apiValue")).toBeNull();
+  });
+});
+
+describe("totalValue", () => {
+  it("sums the selected metric", () => {
+    const hours = [point({ apiValueUsd: 1.5, tokens: 10 }), point({ apiValueUsd: 2.5, tokens: 20 })];
+    expect(totalValue(hours, "apiValue")).toBe(4);
+    expect(totalValue(hours, "tokens")).toBe(30);
+  });
+});
+
+describe("formatHourLabel", () => {
+  it("reads as a wall clock", () => {
+    expect(formatHourLabel(0)).toBe("12 AM");
+    expect(formatHourLabel(9)).toBe("9 AM");
+    expect(formatHourLabel(12)).toBe("12 PM");
+    expect(formatHourLabel(23)).toBe("11 PM");
+  });
+});

--- a/apps/desktop-tauri/src/lib/activityHeatmap.ts
+++ b/apps/desktop-tauri/src/lib/activityHeatmap.ts
@@ -1,0 +1,218 @@
+/**
+ * Pure aggregation behind the activity heatmap card (SBS-277).
+ *
+ * The backend sends one row per (provider, local day, local hour) that saw
+ * activity. Everything here reshapes those rows into the two grids the card
+ * draws and decides each cell's intensity band. Kept out of the component so
+ * the banding rules are testable without rendering.
+ */
+
+import type { ActivityHeatmap, ActivityHourPoint } from "../types/bridge";
+
+export type ActivityMetric = "apiValue" | "tokens";
+
+/** 0 means no activity; 1-4 are the sequential ramp's steps. */
+export type IntensityLevel = 0 | 1 | 2 | 3 | 4;
+
+export type CellTotals = {
+  value: number;
+  calls: number;
+};
+
+export type CalendarCell = CellTotals & {
+  /** Local calendar date as `YYYY-MM-DD`. */
+  date: string;
+  level: IntensityLevel;
+};
+
+export type HourCell = CellTotals & {
+  /** 0 = Sunday, matching `Date.prototype.getDay`. */
+  weekday: number;
+  /** Local hour of day, 0-23. */
+  hour: number;
+  level: IntensityLevel;
+};
+
+/** Quartile cut points over the active cells, low to high. */
+export type Bands = [number, number, number];
+
+const EMPTY: CellTotals = { value: 0, calls: 0 };
+
+export const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/** Read the selected metric off a backend row. */
+function metricValue(point: ActivityHourPoint, metric: ActivityMetric): number {
+  return metric === "apiValue" ? point.apiValueUsd : point.tokens;
+}
+
+/**
+ * Parse `YYYY-MM-DD` as a local calendar date.
+ *
+ * `new Date("2026-08-15")` is parsed as UTC midnight and can land on the
+ * previous day west of Greenwich, which would shift the whole calendar by a
+ * column. Building from parts keeps the date on the local clock the backend
+ * already bucketed by.
+ */
+export function parseLocalDate(date: string): Date | null {
+  const [year, month, day] = date.split("-").map(Number);
+  if (!year || !month || !day) return null;
+  const parsed = new Date(year, month - 1, day);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/**
+ * Quartile cut points over active cells only.
+ *
+ * Activity is heavily skewed: one long session can be worth more than the rest
+ * of the month. Linear banding against the peak would paint every ordinary day
+ * at level 1 and tell the reader nothing, so the bands follow the distribution
+ * instead.
+ */
+export function bandThresholds(values: number[]): Bands {
+  const active = values.filter((value) => value > 0).sort((left, right) => left - right);
+  if (active.length === 0) return [0, 0, 0];
+  const at = (quantile: number) =>
+    active[Math.min(active.length - 1, Math.floor(quantile * active.length))];
+  return [at(0.25), at(0.5), at(0.75)];
+}
+
+export function intensityLevel(value: number, bands: Bands): IntensityLevel {
+  if (value <= 0) return 0;
+  const [low, mid, high] = bands;
+  // A flat distribution has no bands to show. Painting every active cell at the
+  // top would read as "every day was a peak", so hold them mid-scale.
+  if (low === high) return 2;
+  if (value <= low) return 1;
+  if (value <= mid) return 2;
+  if (value <= high) return 3;
+  return 4;
+}
+
+function addTotals(target: Map<string, CellTotals>, key: string, value: number, calls: number) {
+  const current = target.get(key) ?? { value: 0, calls: 0 };
+  target.set(key, { value: current.value + value, calls: current.calls + calls });
+}
+
+/** Rows for the selected providers; an empty selection means every provider. */
+export function selectProviders(
+  hours: ActivityHourPoint[],
+  providerIds: string[],
+): ActivityHourPoint[] {
+  if (providerIds.length === 0) return hours;
+  const wanted = new Set(providerIds);
+  return hours.filter((point) => wanted.has(point.providerId));
+}
+
+/**
+ * One cell per local calendar day, oldest first, gaps included.
+ *
+ * `days` comes from the backend so a month with no activity at all still draws
+ * a full grid rather than collapsing to nothing.
+ */
+export function buildCalendar(
+  days: string[],
+  hours: ActivityHourPoint[],
+  metric: ActivityMetric,
+): CalendarCell[] {
+  const totals = new Map<string, CellTotals>();
+  for (const point of hours) {
+    addTotals(totals, point.date, metricValue(point, metric), point.calls);
+  }
+  const bands = bandThresholds(days.map((date) => totals.get(date)?.value ?? 0));
+  return days.map((date) => {
+    const cell = totals.get(date) ?? EMPTY;
+    return { date, ...cell, level: intensityLevel(cell.value, bands) };
+  });
+}
+
+/**
+ * Weekday x hour grid: 7 rows of 24 cells, Sunday first.
+ *
+ * This is the peak-hours view. Bands are computed across the whole grid so a
+ * quiet Sunday reads as quiet next to a busy Wednesday, rather than each row
+ * being normalized against itself.
+ */
+export function buildWeekHourGrid(
+  hours: ActivityHourPoint[],
+  metric: ActivityMetric,
+): HourCell[][] {
+  const totals = new Map<string, CellTotals>();
+  for (const point of hours) {
+    const date = parseLocalDate(point.date);
+    if (!date) continue;
+    addTotals(
+      totals,
+      `${date.getDay()}:${point.hour}`,
+      metricValue(point, metric),
+      point.calls,
+    );
+  }
+  const bands = bandThresholds([...totals.values()].map((cell) => cell.value));
+  return WEEKDAY_LABELS.map((_, weekday) =>
+    Array.from({ length: 24 }, (_, hour) => {
+      const cell = totals.get(`${weekday}:${hour}`) ?? EMPTY;
+      return { weekday, hour, ...cell, level: intensityLevel(cell.value, bands) };
+    }),
+  );
+}
+
+/** Total for the selected metric across every cell. */
+export function totalValue(hours: ActivityHourPoint[], metric: ActivityMetric): number {
+  return hours.reduce((sum, point) => sum + metricValue(point, metric), 0);
+}
+
+/**
+ * Busiest clock hour across the whole range, or `null` with no activity.
+ *
+ * Stated in words next to the grid so the peak is never carried by color
+ * alone.
+ */
+export function peakHour(
+  hours: ActivityHourPoint[],
+  metric: ActivityMetric,
+): { hour: number; value: number } | null {
+  const totals = new Map<number, number>();
+  for (const point of hours) {
+    totals.set(point.hour, (totals.get(point.hour) ?? 0) + metricValue(point, metric));
+  }
+  let best: { hour: number; value: number } | null = null;
+  // Ascending hour order so an exact tie reports the earlier hour rather than
+  // whichever the map happened to yield first.
+  for (const hour of [...totals.keys()].sort((left, right) => left - right)) {
+    const value = totals.get(hour) ?? 0;
+    if (value > 0 && (best === null || value > best.value)) best = { hour, value };
+  }
+  return best;
+}
+
+/** Busiest weekday across the whole range, or `null` with no activity. */
+export function peakWeekday(
+  hours: ActivityHourPoint[],
+  metric: ActivityMetric,
+): { weekday: number; value: number } | null {
+  const totals = new Map<number, number>();
+  for (const point of hours) {
+    const date = parseLocalDate(point.date);
+    if (!date) continue;
+    const weekday = date.getDay();
+    totals.set(weekday, (totals.get(weekday) ?? 0) + metricValue(point, metric));
+  }
+  let best: { weekday: number; value: number } | null = null;
+  for (const weekday of [...totals.keys()].sort((left, right) => left - right)) {
+    const value = totals.get(weekday) ?? 0;
+    if (value > 0 && (best === null || value > best.value)) best = { weekday, value };
+  }
+  return best;
+}
+
+/** `14` reads as "2 PM"; used in labels and tooltips, never just a color. */
+export function formatHourLabel(hour: number): string {
+  const suffix = hour < 12 ? "AM" : "PM";
+  const display = hour % 12 === 0 ? 12 : hour % 12;
+  return `${display} ${suffix}`;
+}
+
+/** True when the payload has nothing worth drawing. */
+export function isEmptyHeatmap(heatmap: ActivityHeatmap | null): boolean {
+  return !heatmap || heatmap.hours.length === 0;
+}

--- a/apps/desktop-tauri/src/lib/activityHeatmap.ts
+++ b/apps/desktop-tauri/src/lib/activityHeatmap.ts
@@ -93,12 +93,17 @@ function addTotals(target: Map<string, CellTotals>, key: string, value: number, 
   target.set(key, { value: current.value + value, calls: current.calls + calls });
 }
 
-/** Rows for the selected providers; an empty selection means every provider. */
+/**
+ * Rows for the visible providers.
+ *
+ * An empty list means nothing is visible, not everything. The caller passes the
+ * true visible set, so treating empty as "no filter" would make turning every
+ * provider chip off show every provider instead of an empty grid.
+ */
 export function selectProviders(
   hours: ActivityHourPoint[],
   providerIds: string[],
 ): ActivityHourPoint[] {
-  if (providerIds.length === 0) return hours;
   const wanted = new Set(providerIds);
   return hours.filter((point) => wanted.has(point.providerId));
 }

--- a/apps/desktop-tauri/src/lib/tauri.ts
+++ b/apps/desktop-tauri/src/lib/tauri.ts
@@ -16,6 +16,7 @@ import type {
   ProviderDetail,
   ProviderLocalUsageSummary,
   LocalApiValueProvider,
+  ActivityHeatmap,
   CursorActivitySnapshot,
   ProviderSummary,
   ProviderUsageSnapshot,
@@ -289,6 +290,11 @@ export function getLocalApiValueTotals(options?: {
     });
   }
   return invoke<LocalApiValueProvider[]>("get_local_api_value_totals");
+}
+
+/** Local activity by calendar day and clock hour, for the heatmap card. */
+export function getLocalActivityHeatmap(): Promise<ActivityHeatmap> {
+  return invoke<ActivityHeatmap>("get_local_activity_heatmap");
 }
 
 export function getCursorModelActivity(): Promise<CursorActivitySnapshot> {

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -175,6 +175,18 @@
   --chart-tooltip-border: rgba(255, 255, 255, 0.12);
   --chart-tooltip-text: #f5f5f7;
 
+  /* Activity heatmap ramp (SBS-277). Sequential = one hue (the Ceiling cyan),
+     stepped by lightness, never a rainbow. Each mode gets its own steps rather
+     than a flipped copy: on a dark surface "more" is brighter, on a light one
+     "more" is darker. Both ramps clear monotone-lightness, adjacent-step, and
+     2:1 light-end contrast against their own card surface — re-validate before
+     changing any step. */
+  --heatmap-0: rgba(255, 255, 255, 0.055);
+  --heatmap-1: #1d6a7c;
+  --heatmap-2: #2691a8;
+  --heatmap-3: #35b8d1;
+  --heatmap-4: #6fdcef;
+
   /* Tray popover — Windows mica/glass approximation (CSS backdrop-filter). */
   --menu-popover-bg: var(--ceiling-glass-bg);
   --menu-popover-divider: rgba(255, 255, 255, 0.10);
@@ -332,6 +344,13 @@
   --chart-tooltip-bg: rgba(255, 255, 255, 0.96);
   --chart-tooltip-border: rgba(15, 23, 42, 0.10);
   --chart-tooltip-text: #0f172a;
+
+  /* Light-mode heatmap steps: same hue, darkening with intensity. */
+  --heatmap-0: rgba(15, 23, 42, 0.055);
+  --heatmap-1: #57aec2;
+  --heatmap-2: #2b8ba3;
+  --heatmap-3: #16697e;
+  --heatmap-4: #0a4a5a;
 
   --menu-popover-bg: var(--ceiling-glass-bg);
   --menu-popover-divider: rgba(15, 23, 42, 0.08);
@@ -8773,6 +8792,232 @@ body:has(.dashboard-shell) #root {
     justify-content: center;
   }
 }
+
+/* ── Activity heatmap (SBS-277) ─────────────────────────────────────────── */
+.activity-card {
+  margin-top: 10px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--ceiling-glass-border) 75%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--text-primary) 2.5%, transparent);
+}
+.activity-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.activity-card__header > :first-child {
+  flex: 1 1 180px;
+  min-width: 0;
+}
+.activity-card__title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+}
+.activity-card__subtitle {
+  margin: 2px 0 0;
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+.activity-card__switch {
+  display: inline-flex;
+  padding: 2px;
+  border: 1px solid color-mix(in srgb, var(--ceiling-glass-border) 70%, transparent);
+  border-radius: 8px;
+  gap: 2px;
+  flex: 0 0 auto;
+}
+.activity-card__switch-btn {
+  padding: 3px 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.activity-card__switch-btn[data-active="true"] {
+  background: color-mix(in srgb, var(--text-primary) 12%, transparent);
+  color: var(--text-primary);
+}
+.activity-card__providers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+.activity-card__provider-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  border: 1px solid color-mix(in srgb, var(--ceiling-glass-border) 70%, transparent);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.activity-card__provider-chip[data-active="true"] {
+  background: color-mix(in srgb, var(--text-primary) 10%, transparent);
+  color: var(--text-primary);
+}
+/* A chip that is off must not read as "this provider has no data", so drop the
+   dot's saturation rather than hiding the chip. */
+.activity-card__provider-chip[data-active="false"] .activity-card__provider-dot {
+  filter: grayscale(1);
+  opacity: 0.5;
+}
+.activity-card__provider-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+.activity-card__plots {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.activity-card__section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 5px;
+}
+.activity-card__section-title {
+  color: var(--text-primary);
+  font-size: 10.5px;
+  font-weight: 600;
+}
+.activity-card__section-note {
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+.activity-card__cell {
+  border-radius: 2px;
+  background: var(--heatmap-0);
+}
+/* The 2px grid gap between cells is the separator: without it, neighbouring
+   steps merge into one blob at the top of the ramp, where they are closest. */
+.activity-card__cell[data-level="1"] {
+  background: var(--heatmap-1);
+}
+.activity-card__cell[data-level="2"] {
+  background: var(--heatmap-2);
+}
+.activity-card__cell[data-level="3"] {
+  background: var(--heatmap-3);
+}
+.activity-card__cell[data-level="4"] {
+  background: var(--heatmap-4);
+}
+.activity-card__days {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  gap: 2px;
+}
+.activity-card__cell--day {
+  height: 26px;
+}
+.activity-card__days-axis {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 9.5px;
+}
+.activity-card__grid-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+/* Hour ticks sit above the 24 hour columns, offset by the weekday gutter plus
+   the one grid gap after it, so a tick lands on the column it names. */
+.activity-card__hour-axis {
+  display: grid;
+  /* Same column gap as the data rows, or the ticks drift off their columns as
+     the card widens. */
+  grid-template-columns: repeat(24, 1fr);
+  gap: 2px;
+  margin-left: calc(26px + 2px);
+  color: var(--text-muted);
+  font-size: 9.5px;
+}
+.activity-card__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.activity-card__grid-row {
+  display: grid;
+  grid-template-columns: 26px repeat(24, 1fr);
+  gap: 2px;
+  align-items: center;
+}
+.activity-card__weekday {
+  color: var(--text-muted);
+  font-size: 9.5px;
+  line-height: 1;
+}
+.activity-card__cell--hour {
+  height: 13px;
+}
+.activity-card__cell:hover {
+  outline: 1px solid var(--text-primary);
+  outline-offset: 0;
+  cursor: crosshair;
+}
+.activity-card__tooltip {
+  /* The grid rows are short, so anchor the tooltip to the pointer rather than
+     letting the default -100% offset push it off the top of the card. */
+  transform: translate(-50%, -130%);
+}
+.activity-card__tooltip[data-align="start"] {
+  transform: translate(-8%, -130%);
+}
+.activity-card__tooltip[data-align="end"] {
+  transform: translate(-92%, -130%);
+}
+.activity-card__footer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+  color: var(--text-secondary);
+  font-size: 9.5px;
+}
+.activity-card__legend-swatches {
+  display: inline-flex;
+  gap: 2px;
+}
+.activity-card__legend-swatches .activity-card__cell {
+  width: 11px;
+  height: 11px;
+}
+.activity-card__footer-note {
+  margin-left: auto;
+  color: var(--text-muted);
+  text-align: right;
+}
+.activity-card__status {
+  margin: 8px 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
 .quota-history {
   display: grid;
   gap: 12px;

--- a/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/ChartsPanel.tsx
@@ -7,6 +7,7 @@ import { providerSupportsChartData } from "../lib/providerCharts";
 import { ChartsSection } from "./settings/providers/sections/charts/ChartsSection";
 import ProviderComparison from "./ProviderComparison";
 import { TotalApiValueCard } from "../components/TotalApiValueCard";
+import { ActivityHeatmapCard } from "../components/ActivityHeatmapCard";
 import {
   accountIdentityLabel,
   hasMultipleAccounts,
@@ -108,6 +109,7 @@ export default function ChartsPanel({
     return (
       <div className="charts-panel">
         <TotalApiValueCard />
+        <ActivityHeatmapCard />
         <div className="charts-empty">
           <strong>{t("ChartsNoChartsTitle")}</strong>
           {t("ChartsNoChartsBody")}
@@ -123,6 +125,7 @@ export default function ChartsPanel({
   return (
     <div className="charts-panel">
       <TotalApiValueCard />
+      <ActivityHeatmapCard />
       {tabCount > 1 && (
         <div className="charts-provider-tabs" {...tabListProps} aria-label={t("ChartsProviderTabs")}>
           {comparisonProviders && (

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -782,6 +782,33 @@ export interface LocalApiValueDay {
   tokens: number;
 }
 
+/** One provider's activity in a single local clock-hour. */
+export interface ActivityHourPoint {
+  providerId: string;
+  /** Local calendar date as `YYYY-MM-DD`. */
+  date: string;
+  /** Local hour of day, 0-23. */
+  hour: number;
+  /** Estimated API value in USD from priced models in this hour. */
+  apiValueUsd: number;
+  /** Provider-normalized processed tokens. */
+  tokens: number;
+  /** Usage records in this hour. */
+  calls: number;
+}
+
+/** Local activity by calendar day and clock hour, for the heatmap card. */
+export interface ActivityHeatmap {
+  /** Every local calendar day in range, oldest first, empty days included. */
+  days: string[];
+  /** Providers that contributed at least one hour. */
+  providerIds: string[];
+  /** Non-empty hour buckets, oldest first. */
+  hours: ActivityHourPoint[];
+  /** UTC offset of the clock these buckets use, for example `UTC-07:00`. */
+  timezoneLabel: string;
+}
+
 export interface CursorModelActivity {
   /** Model id from Cursor's tracking (e.g. "grok-4.5", "default" for Auto). */
   model: string;

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -5,7 +5,7 @@
 //!
 //! Scans local JSONL log files to aggregate token usage and calculate costs
 
-use chrono::{DateTime, Duration, Local, NaiveDate, Utc};
+use chrono::{DateTime, Duration, Local, NaiveDate, Timelike, Utc};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
@@ -111,6 +111,25 @@ pub struct CostUsageReport {
     /// Exact token totals and priced cost for caller-supplied reset windows,
     /// keyed by ID.
     pub current_windows: HashMap<String, CostSummary>,
+    /// Local clock-hour buckets for the peak-hours heatmap, oldest first.
+    /// Hours with no activity are absent rather than zero-filled.
+    pub hourly_activity: Vec<HourlyActivityPoint>,
+}
+
+/// One local clock-hour of observed activity.
+///
+/// This is a strict refinement of `daily_costs`: a record is only credited to
+/// an hour when its local day is already inside the scanned range, so summing
+/// the hours of a day always reproduces that day's total. Buckets use the
+/// machine's local clock, because "when do I actually code" is a question about
+/// wall-clock hours, not UTC.
+#[derive(Debug, Clone)]
+pub struct HourlyActivityPoint {
+    /// Local calendar date.
+    pub date: NaiveDate,
+    /// Local hour of day, 0-23.
+    pub hour: u32,
+    pub summary: CostSummary,
 }
 
 /// A provider reset window whose local-log usage should be aggregated exactly.
@@ -1378,6 +1397,27 @@ fn add_to_current_windows<F>(
     }
 }
 
+/// Local clock-hour buckets, keyed by `(local date, hour of day)`.
+type HourlySummaries = HashMap<(NaiveDate, u32), CostSummary>;
+
+/// Credit one record to its local clock-hour bucket.
+///
+/// Mirrors [`add_to_current_windows`], but buckets are created on demand: an
+/// idle machine keeps an empty map instead of 720 zeroed summaries. Callers
+/// must only reach this once they know the record's day is in range, so the
+/// hourly series never drifts from `daily_costs`.
+fn add_to_hourly<F>(hourly: &mut HourlySummaries, timestamp: Option<DateTime<Utc>>, mut add: F)
+where
+    F: FnMut(&mut CostSummary),
+{
+    let Some(local) = timestamp.map(|value| value.with_timezone(&Local)) else {
+        return;
+    };
+    add(hourly
+        .entry((local.date_naive(), local.hour()))
+        .or_default());
+}
+
 fn empty_daily_summaries(days: u32) -> HashMap<String, CostSummary> {
     let today = Local::now().date_naive();
     (0..days)
@@ -1441,6 +1481,7 @@ fn merge_summary(target: &mut CostSummary, source: &CostSummary) {
 
 fn finish_report(
     mut daily: HashMap<String, CostSummary>,
+    hourly: HourlySummaries,
     days: u32,
     latest_session: Option<CostSummary>,
     sessions: (u32, u32, u32),
@@ -1490,6 +1531,16 @@ fn finish_report(
         .collect();
     daily_costs.sort_by(|left, right| left.0.cmp(&right.0));
 
+    let mut hourly_activity: Vec<HourlyActivityPoint> = hourly
+        .into_iter()
+        .map(|((date, hour), summary)| HourlyActivityPoint {
+            date,
+            hour,
+            summary,
+        })
+        .collect();
+    hourly_activity.sort_by_key(|point| (point.date, point.hour));
+
     CostUsageReport {
         daily_costs,
         today: today_summary,
@@ -1497,6 +1548,7 @@ fn finish_report(
         thirty_days: period_summary,
         latest_session,
         current_windows,
+        hourly_activity,
     }
 }
 
@@ -1514,6 +1566,7 @@ struct CodexReportRollups<'a> {
     today: NaiveDate,
     seven_day_start: NaiveDate,
     daily: HashMap<String, CostSummary>,
+    hourly: HourlySummaries,
     current_windows: HashMap<String, CostSummary>,
     latest: Option<(std::time::SystemTime, CostSummary)>,
     today_sessions: u32,
@@ -1537,6 +1590,7 @@ impl<'a> CodexReportRollups<'a> {
             today,
             seven_day_start: today - Duration::days(6),
             daily: empty_daily_summaries(days),
+            hourly: HourlySummaries::new(),
             current_windows: empty_current_window_summaries(windows),
             latest: None,
             today_sessions: 0,
@@ -1595,6 +1649,11 @@ impl<'a> CodexReportRollups<'a> {
             if let Some(cost) = add_codex_record_to_summary(day_summary, record) {
                 day_summary.total_cost_usd += cost;
             }
+            add_to_hourly(&mut self.hourly, record.timestamp, |summary| {
+                if let Some(cost) = add_codex_record_to_summary(summary, record) {
+                    summary.total_cost_usd += cost;
+                }
+            });
             if let Some(date) = CostUsageDayRange::parse_day_key(&record.day_key) {
                 contributed_today |= date == self.today;
                 contributed_seven_days |= date >= self.seven_day_start;
@@ -1622,6 +1681,7 @@ impl<'a> CodexReportRollups<'a> {
     fn finish(self, days: u32) -> CostUsageReport {
         finish_report(
             self.daily,
+            self.hourly,
             days,
             self.latest.map(|(_, summary)| summary),
             (
@@ -1695,6 +1755,9 @@ fn scan_codex_report(
     }
     for summary in report.current_windows.values_mut() {
         codex_cost_speed::apply_speed_to_summary(summary, scanner.codex_speed);
+    }
+    for point in report.hourly_activity.iter_mut() {
+        codex_cost_speed::apply_speed_to_summary(&mut point.summary, scanner.codex_speed);
     }
     for (_day, cost) in report.daily_costs.iter_mut() {
         *cost *= scanner.codex_speed.multiplier();
@@ -1788,14 +1851,15 @@ fn scan_grok_report(
     windows: &[CurrentUsageWindow],
 ) -> CostUsageReport {
     let mut daily = empty_daily_summaries(days);
+    let mut hourly = HourlySummaries::new();
     let mut current_windows = empty_current_window_summaries(windows);
     // Honour an injected home so tests need not export `GROK_HOME`.
     let ambient = scanner.ambient_home_override.clone();
     let Some(sessions_root) = grok_sessions_dir(ambient.as_deref()) else {
-        return finish_report(daily, days, None, (0, 0, 0), None, current_windows);
+        return finish_report(daily, hourly, days, None, (0, 0, 0), None, current_windows);
     };
     if !sessions_root.exists() {
-        return finish_report(daily, days, None, (0, 0, 0), None, current_windows);
+        return finish_report(daily, hourly, days, None, (0, 0, 0), None, current_windows);
     }
 
     let today = Local::now().date_naive();
@@ -1836,6 +1900,9 @@ fn scan_grok_report(
                 let day = date.format("%Y-%m-%d").to_string();
                 if let Some(day_summary) = daily.get_mut(&day) {
                     add_grok_record_to_summary(day_summary, record);
+                    add_to_hourly(&mut hourly, record.timestamp, |summary| {
+                        add_grok_record_to_summary(summary, record)
+                    });
                 }
                 contributed_today |= date == today;
                 contributed_seven_days |= date >= seven_day_start;
@@ -1871,6 +1938,7 @@ fn scan_grok_report(
 
     finish_report(
         daily,
+        hourly,
         days,
         latest.map(|(_, summary)| summary),
         (today_sessions, seven_day_sessions, period_sessions),
@@ -1886,6 +1954,7 @@ fn scan_claude_report(
 ) -> CostUsageReport {
     let projects_dirs = scanner.get_claude_projects_dirs();
     let mut daily = empty_daily_summaries(days);
+    let mut hourly = HourlySummaries::new();
     let mut current_windows = empty_current_window_summaries(windows);
 
     let today = Local::now().date_naive();
@@ -1902,7 +1971,7 @@ fn scan_claude_report(
     files.sort();
     files.dedup();
     if files.is_empty() {
-        return finish_report(daily, days, None, (0, 0, 0), None, current_windows);
+        return finish_report(daily, hourly, days, None, (0, 0, 0), None, current_windows);
     }
 
     let mut seen = HashSet::new();
@@ -1932,6 +2001,9 @@ fn scan_claude_report(
                 let day = date.format("%Y-%m-%d").to_string();
                 if let Some(day_summary) = daily.get_mut(&day) {
                     add_claude_record_to_summary(day_summary, &record);
+                    add_to_hourly(&mut hourly, record.timestamp, |summary| {
+                        add_claude_record_to_summary(summary, &record)
+                    });
                 }
                 contributed_today |= date == today;
                 contributed_seven_days |= date >= seven_day_start;
@@ -1965,6 +2037,7 @@ fn scan_claude_report(
 
     finish_report(
         daily,
+        hourly,
         days,
         latest.map(|(_, summary)| summary),
         (today_sessions, seven_day_sessions, period_sessions),
@@ -2987,5 +3060,108 @@ mod tests {
         assert!(mixed.thirty_days.unknown_models.contains("grok-4.5"));
         // Priced model remains priced / not unknown.
         assert!(!mixed.thirty_days.unknown_models.contains("grok-4.5-build"));
+    }
+
+    /// Buckets are keyed by the machine's local clock, not UTC, and are created
+    /// only for hours that saw activity. A record with no timestamp cannot be
+    /// placed on a clock and must be dropped rather than landing in an
+    /// arbitrary hour.
+    #[test]
+    fn add_to_hourly_buckets_by_local_clock_hour() {
+        let mut hourly = HourlySummaries::new();
+        let at = |offset_hours: i64| Some(Utc::now() - Duration::hours(offset_hours));
+        let local_key = |timestamp: Option<DateTime<Utc>>| {
+            let local = timestamp.unwrap().with_timezone(&Local);
+            (local.date_naive(), local.hour())
+        };
+
+        add_to_hourly(&mut hourly, at(2), |summary| summary.input_tokens += 10);
+        add_to_hourly(&mut hourly, at(2), |summary| summary.input_tokens += 5);
+        add_to_hourly(&mut hourly, at(5), |summary| summary.input_tokens += 7);
+        add_to_hourly(&mut hourly, None, |summary| summary.input_tokens += 999);
+
+        assert_eq!(hourly.len(), 2);
+        assert_eq!(hourly[&local_key(at(2))].input_tokens, 15);
+        assert_eq!(hourly[&local_key(at(5))].input_tokens, 7);
+        assert!(!hourly.values().any(|summary| summary.input_tokens == 999));
+    }
+
+    /// SBS-277: the heatmap must be a strict refinement of the daily series.
+    /// Every hour bucket sums back to the day it belongs to, so the calendar
+    /// view and the peak-hours view can never disagree about a total.
+    #[test]
+    fn hourly_activity_sums_back_to_the_daily_totals() {
+        // Derive fixtures from the current local clock so the test holds in any
+        // timezone: both records stay inside the two-day scan range whatever
+        // the machine's offset, and the expected hours come from the same
+        // conversion the scanner performs.
+        let recent = Utc::now() - Duration::hours(2);
+        let earlier = Utc::now() - Duration::hours(5);
+        let line = |timestamp: DateTime<Utc>, input: u32| {
+            format!(
+                r#"{{"timestamp":"{}","type":"event_msg","payload":{{"type":"token_count","info":{{"last_token_usage":{{"input_tokens":{input},"cached_input_tokens":0,"output_tokens":0}}}}}}}}"#,
+                timestamp.to_rfc3339()
+            )
+        };
+
+        let today = Local::now().date_naive();
+        let home = tempfile::tempdir().unwrap();
+        let day_dir = home
+            .path()
+            .join("sessions")
+            .join(today.format("%Y").to_string())
+            .join(today.format("%m").to_string())
+            .join(today.format("%d").to_string());
+        std::fs::create_dir_all(&day_dir).unwrap();
+        std::fs::write(
+            day_dir.join(format!(
+                "rollout-{}-33333333-3333-3333-3333-333333333333.jsonl",
+                today.format("%Y-%m-%d")
+            )),
+            format!("{}\n{}\n", line(earlier, 300), line(recent, 1200)),
+        )
+        .unwrap();
+
+        let report = scan_codex_report(
+            &CostScanner::scoped_to(2, home.path().to_path_buf()),
+            2,
+            &[],
+        );
+
+        let expected: Vec<(NaiveDate, u32)> = [earlier, recent]
+            .iter()
+            .map(|timestamp| {
+                let local = timestamp.with_timezone(&Local);
+                (local.date_naive(), local.hour())
+            })
+            .collect();
+        let actual: Vec<(NaiveDate, u32)> = report
+            .hourly_activity
+            .iter()
+            .map(|point| (point.date, point.hour))
+            .collect();
+        assert_eq!(actual, expected, "hours are emitted oldest first");
+
+        // Each hour carries only its own record.
+        let tokens: Vec<u64> = report
+            .hourly_activity
+            .iter()
+            .map(|point| point.summary.input_tokens)
+            .collect();
+        assert_eq!(tokens, vec![300, 1200]);
+
+        // The invariant: hours reconstruct the day, and the period, exactly.
+        let hourly_total: u64 = tokens.iter().sum();
+        assert_eq!(hourly_total, report.thirty_days.input_tokens);
+        let hourly_cost: f64 = report
+            .hourly_activity
+            .iter()
+            .map(|point| point.summary.total_cost_usd)
+            .sum();
+        let daily_cost: f64 = report.daily_costs.iter().map(|(_, cost)| cost).sum();
+        assert!(
+            (hourly_cost - daily_cost).abs() < 1e-9,
+            "hourly {hourly_cost} vs daily {daily_cost}"
+        );
     }
 }

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -621,6 +621,13 @@ pub struct CostScanner {
     /// resolve the wrong home. Injecting the value keeps it thread-local to the
     /// scanner. Production leaves this `None` and reads the real environment.
     ambient_home_override: Option<PathBuf>,
+    /// Whether to bucket records by local clock-hour as well as by day.
+    ///
+    /// Off by default. Filling the hourly buckets means running each record's
+    /// full accounting a second time, and only the activity heatmap reads them
+    /// — the charts, the reset windows, and the API-value card do not, and
+    /// those run on every refresh over transcript trees that reach gigabytes.
+    collect_hourly: bool,
 }
 
 impl CostScanner {
@@ -638,6 +645,7 @@ impl CostScanner {
             codex_speed: CodexCostSpeed::resolve(None),
             account_homes_override: None,
             ambient_home_override: None,
+            collect_hourly: false,
         }
     }
 
@@ -649,6 +657,7 @@ impl CostScanner {
             codex_speed: CodexCostSpeed::resolve(speed_override),
             account_homes_override: None,
             ambient_home_override: None,
+            collect_hourly: false,
         }
     }
 
@@ -660,7 +669,14 @@ impl CostScanner {
             codex_speed: CodexCostSpeed::resolve(None),
             account_homes_override: None,
             ambient_home_override: None,
+            collect_hourly: false,
         }
+    }
+
+    /// Also bucket records by local clock-hour (the activity heatmap).
+    pub fn with_hourly_activity(mut self) -> Self {
+        self.collect_hourly = true;
+        self
     }
 
     /// Stand in for the ambient config home on an already-built scanner.
@@ -681,6 +697,7 @@ impl CostScanner {
             codex_speed: CodexCostSpeed::resolve(None),
             account_homes_override: Some(homes),
             ambient_home_override: Some(ambient),
+            collect_hourly: false,
         }
     }
 
@@ -1339,6 +1356,23 @@ pub fn get_cost_usage_report(provider: &str, days: u32) -> Option<CostUsageRepor
     get_cost_usage_report_with_windows(provider, days, &[])
 }
 
+/// As [`get_cost_usage_report`], but also fills [`CostUsageReport::hourly_activity`].
+///
+/// Separate entry point because bucketing every record by clock-hour runs its
+/// accounting a second time. Only the activity heatmap needs it; the charts,
+/// reset windows, and API-value card all scan the same trees on every refresh
+/// and would pay for buckets they never read.
+pub fn get_cost_usage_report_hourly(provider: &str, days: u32) -> Option<CostUsageReport> {
+    let days = days.max(1);
+    let scanner = CostScanner::new(days).with_hourly_activity();
+    match provider {
+        "codex" => Some(scan_codex_report(&scanner, days, &[])),
+        "claude" => Some(scan_claude_report(&scanner, days, &[])),
+        "grok" => Some(scan_grok_report(&scanner, days, &[])),
+        _ => None,
+    }
+}
+
 pub fn get_cost_usage_report_with_windows(
     provider: &str,
     days: u32,
@@ -1406,10 +1440,17 @@ type HourlySummaries = HashMap<(NaiveDate, u32), CostSummary>;
 /// idle machine keeps an empty map instead of 720 zeroed summaries. Callers
 /// must only reach this once they know the record's day is in range, so the
 /// hourly series never drifts from `daily_costs`.
-fn add_to_hourly<F>(hourly: &mut HourlySummaries, timestamp: Option<DateTime<Utc>>, mut add: F)
-where
+fn add_to_hourly<F>(
+    enabled: bool,
+    hourly: &mut HourlySummaries,
+    timestamp: Option<DateTime<Utc>>,
+    mut add: F,
+) where
     F: FnMut(&mut CostSummary),
 {
+    if !enabled {
+        return;
+    }
     let Some(local) = timestamp.map(|value| value.with_timezone(&Local)) else {
         return;
     };
@@ -1567,6 +1608,7 @@ struct CodexReportRollups<'a> {
     seven_day_start: NaiveDate,
     daily: HashMap<String, CostSummary>,
     hourly: HourlySummaries,
+    collect_hourly: bool,
     current_windows: HashMap<String, CostSummary>,
     latest: Option<(std::time::SystemTime, CostSummary)>,
     today_sessions: u32,
@@ -1583,6 +1625,7 @@ impl<'a> CodexReportRollups<'a> {
         range: &'a CostUsageDayRange,
         windows: &'a [CurrentUsageWindow],
         today: NaiveDate,
+        collect_hourly: bool,
     ) -> Self {
         Self {
             range,
@@ -1591,6 +1634,7 @@ impl<'a> CodexReportRollups<'a> {
             seven_day_start: today - Duration::days(6),
             daily: empty_daily_summaries(days),
             hourly: HourlySummaries::new(),
+            collect_hourly,
             current_windows: empty_current_window_summaries(windows),
             latest: None,
             today_sessions: 0,
@@ -1649,11 +1693,16 @@ impl<'a> CodexReportRollups<'a> {
             if let Some(cost) = add_codex_record_to_summary(day_summary, record) {
                 day_summary.total_cost_usd += cost;
             }
-            add_to_hourly(&mut self.hourly, record.timestamp, |summary| {
-                if let Some(cost) = add_codex_record_to_summary(summary, record) {
-                    summary.total_cost_usd += cost;
-                }
-            });
+            add_to_hourly(
+                self.collect_hourly,
+                &mut self.hourly,
+                record.timestamp,
+                |summary| {
+                    if let Some(cost) = add_codex_record_to_summary(summary, record) {
+                        summary.total_cost_usd += cost;
+                    }
+                },
+            );
             if let Some(date) = CostUsageDayRange::parse_day_key(&record.day_key) {
                 contributed_today |= date == self.today;
                 contributed_seven_days |= date >= self.seven_day_start;
@@ -1703,7 +1752,7 @@ fn scan_codex_report(
     let today = Local::now().date_naive();
     let start = codex_period_start(today, days);
     let range = CostUsageDayRange::new(start, today);
-    let mut rollups = CodexReportRollups::new(days, &range, windows, today);
+    let mut rollups = CodexReportRollups::new(days, &range, windows, today, scanner.collect_hourly);
 
     for sessions_dir in scanner.get_codex_sessions_dirs() {
         if !sessions_dir.exists() {
@@ -1900,9 +1949,12 @@ fn scan_grok_report(
                 let day = date.format("%Y-%m-%d").to_string();
                 if let Some(day_summary) = daily.get_mut(&day) {
                     add_grok_record_to_summary(day_summary, record);
-                    add_to_hourly(&mut hourly, record.timestamp, |summary| {
-                        add_grok_record_to_summary(summary, record)
-                    });
+                    add_to_hourly(
+                        scanner.collect_hourly,
+                        &mut hourly,
+                        record.timestamp,
+                        |summary| add_grok_record_to_summary(summary, record),
+                    );
                 }
                 contributed_today |= date == today;
                 contributed_seven_days |= date >= seven_day_start;
@@ -2001,9 +2053,12 @@ fn scan_claude_report(
                 let day = date.format("%Y-%m-%d").to_string();
                 if let Some(day_summary) = daily.get_mut(&day) {
                     add_claude_record_to_summary(day_summary, &record);
-                    add_to_hourly(&mut hourly, record.timestamp, |summary| {
-                        add_claude_record_to_summary(summary, &record)
-                    });
+                    add_to_hourly(
+                        scanner.collect_hourly,
+                        &mut hourly,
+                        record.timestamp,
+                        |summary| add_claude_record_to_summary(summary, &record),
+                    );
                 }
                 contributed_today |= date == today;
                 contributed_seven_days |= date >= seven_day_start;
@@ -3075,10 +3130,22 @@ mod tests {
             (local.date_naive(), local.hour())
         };
 
-        add_to_hourly(&mut hourly, at(2), |summary| summary.input_tokens += 10);
-        add_to_hourly(&mut hourly, at(2), |summary| summary.input_tokens += 5);
-        add_to_hourly(&mut hourly, at(5), |summary| summary.input_tokens += 7);
-        add_to_hourly(&mut hourly, None, |summary| summary.input_tokens += 999);
+        add_to_hourly(true, &mut hourly, at(2), |summary| {
+            summary.input_tokens += 10
+        });
+        add_to_hourly(true, &mut hourly, at(2), |summary| {
+            summary.input_tokens += 5
+        });
+        add_to_hourly(true, &mut hourly, at(5), |summary| {
+            summary.input_tokens += 7
+        });
+        add_to_hourly(true, &mut hourly, None, |summary| {
+            summary.input_tokens += 999
+        });
+        // Gated off, so the scans that never read these buckets pay nothing.
+        add_to_hourly(false, &mut hourly, at(9), |summary| {
+            summary.input_tokens += 1
+        });
 
         assert_eq!(hourly.len(), 2);
         assert_eq!(hourly[&local_key(at(2))].input_tokens, 15);
@@ -3122,8 +3189,25 @@ mod tests {
         )
         .unwrap();
 
-        let report = scan_codex_report(
+        // The charts, reset windows, and API-value card all scan the same
+        // trees on every refresh. They must not pay for buckets they never
+        // read, so hourly work only happens when a caller asks for it.
+        let without_hourly = scan_codex_report(
             &CostScanner::scoped_to(2, home.path().to_path_buf()),
+            2,
+            &[],
+        );
+        assert!(
+            without_hourly.hourly_activity.is_empty(),
+            "hourly bucketing is opt-in"
+        );
+        assert_eq!(
+            without_hourly.thirty_days.input_tokens, 1_500,
+            "and opting out changes nothing else"
+        );
+
+        let report = scan_codex_report(
+            &CostScanner::scoped_to(2, home.path().to_path_buf()).with_hourly_activity(),
             2,
             &[],
         );


### PR DESCRIPTION
Closes SBS-277.

Answers "when do I actually code and spend" from timestamps already on disk. No new data is collected and nothing leaves the machine.

## Backend

The cost scanner now buckets records by local clock-hour alongside the existing per-day buckets, in the same pass, so no extra transcript read is needed.

The hourly series is a strict refinement of `daily_costs`: a record is only credited to an hour once its day is already in range, so the calendar view and the peak-hours view can never disagree about a total. A test asserts that invariant end to end.

New `get_local_activity_heatmap` command, cached for five minutes, machine-wide across Codex / Claude / Grok.

## UI

Two views over one sequential ramp: a 30-day strip and a weekday-by-hour grid.

Intensity bands follow the **quartiles of active cells** rather than a linear scale against the peak. One long session would otherwise flatten every ordinary day into the lowest band and show nothing.

Each cell carries its exact figure in text, and the busiest day and hour are stated in words, so nothing is readable only by shade.

## Colour

Single-hue sequential ramp on the Ceiling cyan, with separate steps chosen per theme rather than a flipped copy. Both ramps were validated against the real composited card surface and pass monotone-lightness, adjacent-step, and 2:1 light-end contrast (2.50:1 dark, 2.25:1 light).

## Commands run

- `cargo test --manifest-path rust/Cargo.toml` — 951 passed (1 pre-existing unrelated PTY failure, see below)
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` — 536 passed
- `cargo clippy` both manifests with `-D warnings` — clean
- `cargo fmt --all` both manifests
- `pnpm --dir apps/desktop-tauri test` — 579 passed
- `pnpm --dir apps/desktop-tauri exec tsc --noEmit` — clean

`cli::tty_runner::tests::test_run_sends_script_through_pty` fails on my machine on a clean checkout of `main` too — a broken `cmd` shim in the local npm dir, unrelated to this change.

## Layout check

Rendered the card standalone against the real stylesheet in both themes and measured it: hour ticks align to their columns within 0.02px, nothing overflows the card, and the grid holds from 320px to 460px wide.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add an activity heatmap to the Charts tab
> - Adds a new `ActivityHeatmapCard` component to the Charts panel showing 30 days of local API activity, visualized as a day-strip and a weekday-by-hour grid with provider filter chips, metric toggle (API value vs tokens), and hover tooltips.
> - Introduces `get_local_activity_heatmap` as a new Tauri IPC command backed by `get_cost_usage_report_hourly` in [cost_scanner.rs](https://github.com/tsouth89/ceiling/pull/298/files#diff-bc7d350083eb010be1a8c98f6e01a43aefe35e00cc24d09331934e936017a785), which adds opt-in hourly bucketing to the existing cost scanner for Codex, Claude, and Grok providers.
> - Results are cached for 5 minutes on the backend; failures surface as "Unable to read local activity."
> - Pure frontend helpers in [activityHeatmap.ts](https://github.com/tsouth89/ceiling/pull/298/files#diff-8c7cee74527f36fa5e9345e593c61c4d379f0b3ec05ceaca80a96ff7d39f8efe) handle quartile-based intensity banding, local-date parsing, and aggregation from hour points to calendar and grid cells.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e36927.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->