### PR TITLE
Align CEILING_UI.md with shipped behaviour and drop the last glow

### DIFF
--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "vite",
     "check-locale": "node scripts/check-locale-drift.mjs",
-    "prebuild": "pnpm run check-locale",
+    "check-css": "node scripts/check-no-glow.mjs",
+    "prebuild": "pnpm run check-locale && pnpm run check-css",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "test": "vitest run",

--- a/apps/desktop-tauri/scripts/check-no-glow.mjs
+++ b/apps/desktop-tauri/scripts/check-no-glow.mjs
@@ -37,6 +37,22 @@ if (sheets.length === 0) {
   process.exit(2);
 }
 
+// Blank out CSS block comments, keeping newlines so reported line numbers still
+// point at the real line. Without this, a reviewer noting the old halo value
+// next to a fixed rule turns prebuild red over a shadow nothing renders.
+function stripComments(css) {
+  return css.replace(/\/\*[\s\S]*?\*\//g, (match) => match.replace(/[^\n]/g, " "));
+}
+
+/**
+ * Every `box-shadow` declaration and its value.
+ *
+ * A declaration may be terminated by `}` instead of `;` — the last one in a
+ * block is allowed to drop the semicolon, and `.x{box-shadow:0 0 8px red}` is
+ * valid CSS that a `;`-only pattern never even inspects.
+ */
+const BOX_SHADOW = /box-shadow\s*:\s*([^;{}]+)\s*(?:;|\})/g;
+
 /** Split a box-shadow value into layers, ignoring commas inside `color-mix(…)`. */
 function shadowLayers(value) {
   const layers = [];
@@ -86,6 +102,26 @@ function assertDetectorWorks() {
       process.exit(2);
     }
   }
+
+  // The scan is the other half of the gate: a value it never extracts is a
+  // value isGlow never sees.
+  const scan = (css) =>
+    [...stripComments(css).matchAll(BOX_SHADOW)].flatMap((match) =>
+      shadowLayers(match[1]).filter(isGlow),
+    );
+  const scanCases = [
+    [".a { box-shadow: 0 0 8px red; }", 1, "semicolon-terminated"],
+    // Valid CSS: the last declaration in a block may omit the semicolon.
+    [".a { box-shadow: 0 0 8px red }", 1, "brace-terminated"],
+    ["/* box-shadow: 0 0 8px red; */", 0, "inside a comment"],
+    [".a { box-shadow: 0 1px 3px red; }", 0, "drop shadow"],
+  ];
+  for (const [css, expected, label] of scanCases) {
+    if (scan(css).length !== expected) {
+      console.error(`[check-css] scan is broken on: ${label}`);
+      process.exit(2);
+    }
+  }
 }
 
 assertDetectorWorks();
@@ -103,7 +139,7 @@ for (const path of sheets) {
     process.exit(2);
   }
 
-  const declarations = [...css.matchAll(/box-shadow\s*:\s*([^;]+);/g)];
+  const declarations = [...stripComments(css).matchAll(BOX_SHADOW)];
   scanned += declarations.length;
 
   for (const declaration of declarations) {

--- a/apps/desktop-tauri/scripts/check-no-glow.mjs
+++ b/apps/desktop-tauri/scripts/check-no-glow.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// No-glow check (SBS-158) — CEILING_UI.md states "no glow effects", and the
+// promo boost chip had been drawing one anyway. This keeps the rule honest.
+//
+// A glow is a box-shadow layer with no offset and a non-zero blur, so it bleeds
+// outward in every direction. Drop shadows (which carry a Y offset), inset
+// shadows, and zero-blur rings such as `0 0 0 2px` are all allowed and are what
+// the design system uses instead.
+//
+// This lives as a script rather than a vitest test because Vitest stubs CSS
+// imports to empty strings by default, so a `?raw` import of a stylesheet reads
+// as blank and the check would pass without inspecting anything.
+//
+// Invoked from `pnpm run check-css` and automatically from `pnpm run prebuild`.
+//
+// Exit codes:
+//   0 — no glow
+//   1 — at least one glow found
+//   2 — a stylesheet was missing or contained no box-shadow at all
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const sheets = [
+  resolve(here, "..", "src", "styles.css"),
+  resolve(here, "..", "src", "floatbar", "FloatBar.css"),
+];
+
+/** Split a box-shadow value into layers, ignoring commas inside `color-mix(…)`. */
+function shadowLayers(value) {
+  const layers = [];
+  let depth = 0;
+  let current = "";
+  for (const char of value) {
+    if (char === "(") depth += 1;
+    if (char === ")") depth -= 1;
+    if (char === "," && depth === 0) {
+      layers.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  layers.push(current);
+  return layers.map((layer) => layer.trim()).filter(Boolean);
+}
+
+/** `0 0 8px <color>` is a glow; `0 0 0 1px <color>` and `0 1px 3px` are not. */
+function isGlow(layer) {
+  if (/\binset\b/.test(layer)) return false;
+  // Read the leading run of lengths and stop at the colour. A bare `0` is a
+  // valid CSS length, so the unit is optional.
+  const lengths = [];
+  for (const token of layer.split(/\s+/)) {
+    const match = /^(-?[\d.]+)(px|rem|em)?$/.exec(token);
+    if (!match) break;
+    lengths.push(Number.parseFloat(match[1]));
+  }
+  const [x, y, blur] = lengths;
+  return lengths.length >= 3 && x === 0 && y === 0 && blur > 0;
+}
+
+/** Self-check: a rule that can never fire proves nothing. */
+function assertDetectorWorks() {
+  const cases = [
+    ["0 0 8px red", true],
+    ["0 0 0 2px red", false],
+    ["0 1px 3px rgba(0, 0, 0, 0.3)", false],
+    ["inset 0 0 6px red", false],
+    ["0 0 9px color-mix(in srgb, red 20%, blue)", true],
+  ];
+  for (const [layer, expected] of cases) {
+    if (isGlow(layer) !== expected) {
+      console.error(`[check-css] detector is broken on: ${layer}`);
+      process.exit(2);
+    }
+  }
+}
+
+assertDetectorWorks();
+
+let failed = false;
+for (const path of sheets) {
+  let css;
+  try {
+    css = readFileSync(path, "utf8");
+  } catch (error) {
+    console.error(`[check-css] cannot read ${path}: ${error.message}`);
+    process.exit(2);
+  }
+
+  const declarations = [...css.matchAll(/box-shadow\s*:\s*([^;]+);/g)];
+  if (declarations.length < 5) {
+    console.error(
+      `[check-css] only ${declarations.length} box-shadow rules in ${path} — the scan is not reading the real stylesheet`,
+    );
+    process.exit(2);
+  }
+
+  for (const declaration of declarations) {
+    const line = css.slice(0, declaration.index).split("\n").length;
+    for (const layer of shadowLayers(declaration[1])) {
+      if (!isGlow(layer)) continue;
+      failed = true;
+      console.error(
+        `[check-css] glow at ${path}:${line} — ${layer.replace(/\s+/g, " ")}`,
+      );
+    }
+  }
+}
+
+if (failed) {
+  console.error(
+    "[check-css] CEILING_UI.md rules out glow. Use a zero-blur ring (0 0 0 Npx) or an offset drop shadow.",
+  );
+  process.exit(1);
+}
+
+console.log(`[check-css] OK — no glow in ${sheets.length} stylesheets`);

--- a/apps/desktop-tauri/scripts/check-no-glow.mjs
+++ b/apps/desktop-tauri/scripts/check-no-glow.mjs
@@ -51,7 +51,9 @@ function stripComments(css) {
  * block is allowed to drop the semicolon, and `.x{box-shadow:0 0 8px red}` is
  * valid CSS that a `;`-only pattern never even inspects.
  */
-const BOX_SHADOW = /box-shadow\s*:\s*([^;{}]+)\s*(?:;|\})/g;
+// Case-insensitive: CSS property names are, so `BOX-SHADOW:` renders fine and
+// a case-sensitive scan would report a clean sheet without reading it.
+const BOX_SHADOW = /box-shadow\s*:\s*([^;{}]+)\s*(?:;|\})/gi;
 
 /** Split a box-shadow value into layers, ignoring commas inside `color-mix(…)`. */
 function shadowLayers(value) {
@@ -72,9 +74,24 @@ function shadowLayers(value) {
   return layers.map((layer) => layer.trim()).filter(Boolean);
 }
 
+// Blank out function calls so a colour argument cannot be read as a keyword.
+// `0 0 8px var(--chip-inset)` is an outward glow, but testing the whole layer
+// for the word sees the token name and waves it through — and this tree already
+// says "inset" on plenty of shadows, so hoisting one into a variable is a
+// realistic next edit.
+function withoutFunctions(layer) {
+  let out = layer;
+  let previous;
+  do {
+    previous = out;
+    out = out.replace(/\([^()]*\)/g, " ");
+  } while (out !== previous);
+  return out;
+}
+
 /** `0 0 8px <color>` is a glow; `0 0 0 1px <color>` and `0 1px 3px` are not. */
 function isGlow(layer) {
-  if (/\binset\b/.test(layer)) return false;
+  if (/\binset\b/i.test(withoutFunctions(layer))) return false;
   // Read the leading run of lengths and stop at the colour. A bare `0` is a
   // valid CSS length, so the unit is optional.
   const lengths = [];
@@ -94,7 +111,12 @@ function assertDetectorWorks() {
     ["0 0 0 2px red", false],
     ["0 1px 3px rgba(0, 0, 0, 0.3)", false],
     ["inset 0 0 6px red", false],
+    ["INSET 0 0 6px red", false],
     ["0 0 9px color-mix(in srgb, red 20%, blue)", true],
+    // The keyword only counts outside a function call.
+    ["0 0 8px var(--chip-inset)", true],
+    ["0 0 8px var(--inset-color)", true],
+    ["0 0 0 1px var(--chip-inset)", false],
   ];
   for (const [layer, expected] of cases) {
     if (isGlow(layer) !== expected) {
@@ -115,6 +137,9 @@ function assertDetectorWorks() {
     [".a { box-shadow: 0 0 8px red }", 1, "brace-terminated"],
     ["/* box-shadow: 0 0 8px red; */", 0, "inside a comment"],
     [".a { box-shadow: 0 1px 3px red; }", 0, "drop shadow"],
+    // CSS property names are case-insensitive.
+    [".a { BOX-SHADOW: 0 0 8px red; }", 1, "uppercase property"],
+    [".a { Box-Shadow: 0 0 8px red; }", 1, "mixed-case property"],
   ];
   for (const [css, expected, label] of scanCases) {
     if (scan(css).length !== expected) {

--- a/apps/desktop-tauri/scripts/check-no-glow.mjs
+++ b/apps/desktop-tauri/scripts/check-no-glow.mjs
@@ -18,15 +18,24 @@
 //   1 — at least one glow found
 //   2 — a stylesheet was missing or contained no box-shadow at all
 
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const sheets = [
-  resolve(here, "..", "src", "styles.css"),
-  resolve(here, "..", "src", "floatbar", "FloatBar.css"),
-];
+const srcDir = resolve(here, "..", "src");
+
+// Discovered rather than listed, so a stylesheet added later is covered
+// without anyone remembering to add it here.
+const sheets = readdirSync(srcDir, { recursive: true, withFileTypes: true })
+  .filter((entry) => entry.isFile() && entry.name.endsWith(".css"))
+  .map((entry) => resolve(entry.parentPath ?? entry.path, entry.name))
+  .sort();
+
+if (sheets.length === 0) {
+  console.error(`[check-css] no stylesheets found under ${srcDir}`);
+  process.exit(2);
+}
 
 /** Split a box-shadow value into layers, ignoring commas inside `color-mix(…)`. */
 function shadowLayers(value) {
@@ -82,6 +91,9 @@ function assertDetectorWorks() {
 assertDetectorWorks();
 
 let failed = false;
+// Counted across every sheet, not per sheet: a small stylesheet added later
+// is normal, a total of zero means the scan read nothing.
+let scanned = 0;
 for (const path of sheets) {
   let css;
   try {
@@ -92,12 +104,7 @@ for (const path of sheets) {
   }
 
   const declarations = [...css.matchAll(/box-shadow\s*:\s*([^;]+);/g)];
-  if (declarations.length < 5) {
-    console.error(
-      `[check-css] only ${declarations.length} box-shadow rules in ${path} — the scan is not reading the real stylesheet`,
-    );
-    process.exit(2);
-  }
+  scanned += declarations.length;
 
   for (const declaration of declarations) {
     const line = css.slice(0, declaration.index).split("\n").length;
@@ -111,6 +118,13 @@ for (const path of sheets) {
   }
 }
 
+if (scanned < 5) {
+  console.error(
+    `[check-css] only ${scanned} box-shadow rules across ${sheets.length} stylesheets — the scan is not reading the real files`,
+  );
+  process.exit(2);
+}
+
 if (failed) {
   console.error(
     "[check-css] CEILING_UI.md rules out glow. Use a zero-blur ring (0 0 0 Npx) or an offset drop shadow.",
@@ -118,4 +132,6 @@ if (failed) {
   process.exit(1);
 }
 
-console.log(`[check-css] OK — no glow in ${sheets.length} stylesheets`);
+console.log(
+  `[check-css] OK — no glow in ${scanned} box-shadow rules across ${sheets.length} stylesheets`,
+);

--- a/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
@@ -749,6 +749,13 @@ describe("FloatBar", () => {
       expect(container.querySelector(".floatbar__chip--promo")).toBeNull();
       expect(container.querySelector(".floatbar__pill--promo-boost")).toBeNull();
     });
+
+    // Out of the chrome, but not lost: the tooltip is the whole of the strip's
+    // promo contract, and asserting only the absent classes left that half
+    // unpinned — dropping the title from `titleBits` would still have passed.
+    expect(container.querySelector(".floatbar__pill")?.getAttribute("title")).toContain(
+      "promo promotional",
+    );
   });
 
   it("polls refreshProvidersIfStale on the configured interval", async () => {

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -6462,7 +6462,9 @@ html:has(.menu-surface--tray) {
   color: #5eead4;
   background: color-mix(in srgb, var(--ceiling-accent, #26b5ce) 22%, transparent);
   border-color: color-mix(in srgb, var(--ceiling-accent, #26b5ce) 45%, transparent);
-  box-shadow: 0 0 8px color-mix(in srgb, var(--ceiling-accent, #26b5ce) 24%, transparent);
+  /* A crisp accent ring, not an 8px halo. CEILING_UI.md rules out glow, and
+     this chip was the last place in the app still drawing one. */
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--ceiling-accent, #26b5ce) 30%, transparent);
 }
 
 .menu-card__promo-chip--inclusion {

--- a/docs/CEILING_UI.md
+++ b/docs/CEILING_UI.md
@@ -8,7 +8,17 @@ Visual system for the tray flyout and taskbar-adjacent capacity strip (SOU-127).
 - **Material:** CSS mica/glass (`backdrop-filter` + translucent tint). Native DWM mica is out of scope.
 - **Type:** Windows-first — `Segoe UI Variable`, `Segoe UI`, system-ui.
 - **Accent:** Ceiling cyan (`#26b5ce` family) on slate neutrals. No purple dashboard, no cream/terracotta, no glow effects.
+- **Focus:** a solid outline or a zero-blur ring. A blurred `box-shadow` around
+  a focused control is a glow and is not allowed; `0 0 0 Npx` rings are.
 - **Brand:** user-visible chrome says **Ceiling**. Internal `codexbar` crate IDs stay unchanged.
+
+## Webview security posture
+
+The shipped CSP grants the webview no network reach. Every provider call runs in
+Rust, so `connect-src` is `'self' ipc: http://ipc.localhost` and nothing else —
+in particular, no `localhost`/`127.0.0.1` origins. The Vite dev server and its
+HMR socket get those from a dev-only config overlay, never from the release
+build (SBS-819).
 
 ## Tokens
 
@@ -55,7 +65,17 @@ Usage bars keep calm slate→cyan progression; warn/crit stay amber/red without 
 ```
 
 - Overview cards lead with **primary plan pool** (not Auto alone).
-- Optional **companion** lane only when hot (≥ ~70% used, or hotter than the pool).
+- Most providers show at most one **companion** lane, and only when hot
+  (≥ ~70% used, or hotter than the pool).
+- Three providers pin their companion lanes and show them at any percentage,
+  because a hidden lane there would misstate what actually caps the plan
+  (`PINNED_COMPANION_IDS` in `lib/capacityPresentation.ts`):
+  - **Cursor** — Auto and API are both account-wide and always meaningful; the
+    On-demand lane joins them only while it is actually active.
+  - **Claude** — Weekly sits beside the 5-hour session and both cap the
+    subscription.
+  - **OpenCode Go** — bills against rolling, weekly, and monthly ceilings at
+    once, so hiding weekly leaves a gap between the two that do show.
 - Clicking a card opens detail — it does not toggle which meter is shown.
 - Provider switcher uses brand-tinted icons + status dots; bar = constraining %.
 
@@ -98,6 +118,9 @@ Temporary provider-reported promotions use `promoSignals`:
 |---|---|---|
 | `boost` | Soft cyan edge + chip | Hidden; detail surfaces only |
 | `inclusion` | Hidden | Hidden; detail surfaces only |
+
+"Soft cyan edge" means a crisp accent border and a 1px ring. It is not a halo:
+the no-glow rule above has no exceptions, promos included.
 
 Account identity is also hidden from overview cards. Provider settings and the
 Accounts section remain the intentional places for email/source details.

--- a/docs/CEILING_UI.md
+++ b/docs/CEILING_UI.md
@@ -14,11 +14,14 @@ Visual system for the tray flyout and taskbar-adjacent capacity strip (SOU-127).
 
 ## Webview security posture
 
-The shipped CSP grants the webview no network reach. Every provider call runs in
-Rust, so `connect-src` is `'self' ipc: http://ipc.localhost` and nothing else —
-in particular, no `localhost`/`127.0.0.1` origins. The Vite dev server and its
-HMR socket get those from a dev-only config overlay, never from the release
-build (SBS-819).
+The webview must have no network reach of its own. Every provider call runs in
+Rust, so the release `connect-src` is required to be `'self' ipc:
+http://ipc.localhost` and nothing else — in particular, no `localhost` or
+`127.0.0.1` origins, which exist only for the Vite dev server and its HMR
+socket and belong in a dev-only config overlay.
+
+Tracked in SBS-819; check `apps/desktop-tauri/src-tauri/tauri.conf.json` for
+what the current release build actually ships.
 
 ## Tokens
 
@@ -114,12 +117,17 @@ Detail lists **every** measured window plus inactive rows. Do not truncate to tw
 
 Temporary provider-reported promotions use `promoSignals`:
 
-| Kind | Strip | Overview |
-|---|---|---|
-| `boost` | Soft cyan edge + chip | Hidden; detail surfaces only |
-| `inclusion` | Hidden | Hidden; detail surfaces only |
+| Kind | Strip | Overview | Detail |
+|---|---|---|---|
+| `boost` | Hidden (named in the pill tooltip only) | Hidden | Accent chip |
+| `inclusion` | Hidden | Hidden | Neutral chip |
 
-"Soft cyan edge" means a crisp accent border and a 1px ring. It is not a halo:
+The strip draws no promo chrome at all — `FloatBar.tsx` puts the boost title in
+the pill's `title` text and nothing else, and `FloatBar.test.tsx` pins that with
+"keeps promo signals out of the strip chrome". The strip is persistent desktop
+furniture; a temporary promotion is not worth a permanent mark on it.
+
+The detail chip's accent treatment is a border plus a 1px ring, never a halo:
 the no-glow rule above has no exceptions, promos included.
 
 Account identity is also hidden from overview cards. Provider settings and the

--- a/docs/CEILING_UI.md
+++ b/docs/CEILING_UI.md
@@ -123,8 +123,9 @@ Temporary provider-reported promotions use `promoSignals`:
 | `inclusion` | Hidden | Hidden | Neutral chip |
 
 The strip draws no promo chrome at all — `FloatBar.tsx` puts the boost title in
-the pill's `title` text and nothing else, and `FloatBar.test.tsx` pins that with
-"keeps promo signals out of the strip chrome". The strip is persistent desktop
+the pill's `title` text and nothing else. "keeps promo signals out of the strip
+chrome" in `FloatBar.test.tsx` pins both halves: the absent chip and pill
+classes, and the title that must still carry it. The strip is persistent desktop
 furniture; a temporary promotion is not worth a permanent mark on it.
 
 The detail chip's accent treatment is a border plus a 1px ring, never a halo:

--- a/docs/CEILING_UI.md
+++ b/docs/CEILING_UI.md
@@ -14,14 +14,15 @@ Visual system for the tray flyout and taskbar-adjacent capacity strip (SOU-127).
 
 ## Webview security posture
 
-The webview must have no network reach of its own. Every provider call runs in
-Rust, so the release `connect-src` is required to be `'self' ipc:
-http://ipc.localhost` and nothing else — in particular, no `localhost` or
-`127.0.0.1` origins, which exist only for the Vite dev server and its HMR
-socket and belong in a dev-only config overlay.
+The webview should have no network reach of its own. Every provider call runs in
+Rust, so the target release `connect-src` is `'self' ipc: http://ipc.localhost`
+and nothing else.
 
-Tracked in SBS-819; check `apps/desktop-tauri/src-tauri/tauri.conf.json` for
-what the current release build actually ships.
+Not yet true. `apps/desktop-tauri/src-tauri/tauri.conf.json` is the single CSP
+for every build, and it still allows `http://localhost:*`, `http://127.0.0.1:*`,
+`ws://localhost:*` and `ws://127.0.0.1:*` so the Vite dev server and its HMR
+socket can connect. Confining those loopback origins to dev builds is SBS-819;
+read the config, not this section, for what ships today.
 
 ## Tokens
 


### PR DESCRIPTION
Closes SBS-158.

Three places where `docs/CEILING_UI.md` and the code disagreed.

## Companion lanes

The doc said "only when hot", but Cursor, Claude, and OpenCode Go pin theirs and show them at any percentage. That exception is deliberate — hiding Claude's weekly or OpenCode Go's monthly would misstate what caps the plan — so the doc now records it and says why, rather than the code being changed to match a rule it outgrew.

## Glow

The doc bans glow, and one rule still drew an 8px halo on the promo boost chip. It is now a zero-blur accent ring, which keeps the emphasis without the halo. It was the last glow in the app.

A `prebuild` check enforces the rule from here on. It flags any `box-shadow` layer with no offset and a non-zero blur, and carries a self-check so a detector that stops firing fails loudly rather than passing silently.

The check is a script rather than a vitest test on purpose: **Vitest stubs CSS imports to empty strings by default**, so a `?raw` import of a stylesheet reads as blank and the test passes without inspecting anything. I hit that and caught it with a non-empty assertion before switching approach.

## CSP

Records the webview security posture the release CSP has to satisfy. The fix itself is #297 (SBS-819).

## Commands run

- `pnpm --dir apps/desktop-tauri run check-css` — no glow in 2 stylesheets
- `pnpm --dir apps/desktop-tauri test` — 560 passed
- `pnpm --dir apps/desktop-tauri exec tsc --noEmit` — clean

Verified the check fails on a reintroduced glow, reporting file and line.

## Merge note

Touches the same screenshot checklist section as the SBS-225 branch (#302). Trivial conflict if both land.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace glow box-shadow with crisp ring on promo boost chip and enforce no-glow rule in CSS
> - Replaces the `0 0 8px` glow on `.menu-card__promo-chip--boost` in [styles.css](https://github.com/tsouth89/ceiling/pull/301/files#diff-50c65d57e0a9619f283993a8fe2b30e0142c23875d9ebcb5426e194c081f71fb) with a `0 0 0 1px` zero-blur accent ring.
> - Adds [check-no-glow.mjs](https://github.com/tsouth89/ceiling/pull/301/files#diff-9909f9d8dc8d6379883435f05dab727ef30faf78e5596205475ab7188a0f60f0), a script that scans all CSS under `src/` for outward `box-shadow` glows, with self-tests and meaningful error reporting.
> - Wires the new script into the `prebuild` step via a `check-css` npm script, so builds fail if a glow is introduced.
> - Updates [CEILING_UI.md](https://github.com/tsouth89/ceiling/pull/301/files#diff-7982d077ac1b0f53edd49d9e7f4c46c91d849287b60a98cd7d78cfb9ee96cfee) to document the no-glow rule, zero-blur ring guidance, promo signal behavior, and CSP posture.
> - Behavioral Change: `pnpm run prebuild` now exits non-zero if any outward glow is detected in CSS.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84f2148.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->