### PR TITLE
Honor enabled providers for default `codexbar usage` (SBS-855)

### DIFF
--- a/rust/src/cli/usage.rs
+++ b/rust/src/cli/usage.rs
@@ -7,6 +7,7 @@ use crate::core::{
     ConfiguredAccounts, CostSnapshot, FetchContext, ProviderFetchResult, ProviderId, RateWindow,
     SourceMode, UsagePace, UsageSnapshot, instantiate_provider,
 };
+use crate::settings::Settings;
 use crate::status::{ProviderStatus as StatusInfo, StatusLevel, fetch_provider_status};
 
 pub const PROVIDER_ARG_HELP: &str = "Provider to query (for example: codex, claude, gemini, antigravity/agy, nanogpt, deepseek, codebuff, windsurf, all, both)";
@@ -92,6 +93,8 @@ pub enum ProviderSelection {
     Single(ProviderId),
     Both,
     All,
+    /// Providers enabled in Settings (the documented default).
+    Enabled,
 }
 
 impl ProviderSelection {
@@ -109,15 +112,21 @@ impl ProviderSelection {
                     )
                 }
             }
-            None => Ok(ProviderSelection::Single(ProviderId::Claude)), // Default to Claude
+            None => Ok(ProviderSelection::Enabled),
         }
     }
 
     pub fn as_list(&self) -> Vec<ProviderId> {
+        self.as_list_from(&Settings::load())
+    }
+
+    /// Resolve providers against an explicit Settings snapshot.
+    pub fn as_list_from(&self, settings: &Settings) -> Vec<ProviderId> {
         match self {
             ProviderSelection::Single(id) => vec![*id],
             ProviderSelection::Both => vec![ProviderId::Codex, ProviderId::Claude],
             ProviderSelection::All => ProviderId::all().to_vec(),
+            ProviderSelection::Enabled => settings.get_enabled_provider_ids(),
         }
     }
 }
@@ -163,7 +172,9 @@ impl UsageCommand {
     fn from_args(args: UsageArgs) -> anyhow::Result<Self> {
         let format = effective_format(&args);
         let source_mode = SourceMode::parse(&args.source).unwrap_or(SourceMode::Auto);
-        let providers = ProviderSelection::from_arg(args.provider.as_deref())?.as_list();
+        let settings = Settings::load();
+        let providers =
+            ProviderSelection::from_arg(args.provider.as_deref())?.as_list_from(&settings);
 
         Ok(Self {
             format,
@@ -642,5 +653,73 @@ mod tests {
         let output = render_progress_bar(80.0, 10, false);
         assert!(!output.contains('\u{1b}'));
         assert_eq!(output, "[████████░░]");
+    }
+
+    fn settings_with_enabled(ids: &[&str]) -> Settings {
+        Settings {
+            enabled_providers: ids.iter().map(|id| (*id).to_string()).collect(),
+            ..Settings::default()
+        }
+    }
+
+    #[test]
+    fn default_selection_uses_enabled_providers_from_settings() {
+        let settings = settings_with_enabled(&["grok", "cursor"]);
+        let selected = ProviderSelection::from_arg(None)
+            .unwrap()
+            .as_list_from(&settings);
+
+        assert_eq!(selected, vec![ProviderId::Cursor, ProviderId::Grok]);
+        assert_ne!(selected, vec![ProviderId::Claude]);
+    }
+
+    #[test]
+    fn default_selection_on_default_settings_is_not_claude_only() {
+        let settings = Settings::default();
+        let selected = ProviderSelection::from_arg(None)
+            .unwrap()
+            .as_list_from(&settings);
+
+        assert_eq!(
+            selected,
+            vec![
+                ProviderId::Codex,
+                ProviderId::Claude,
+                ProviderId::Cursor,
+                ProviderId::Grok
+            ]
+        );
+        assert_ne!(selected, vec![ProviderId::Claude]);
+    }
+
+    #[test]
+    fn all_selection_includes_every_provider_regardless_of_settings() {
+        let settings = settings_with_enabled(&["grok"]);
+        let selected = ProviderSelection::from_arg(Some("all"))
+            .unwrap()
+            .as_list_from(&settings);
+
+        assert_eq!(selected, ProviderId::all().to_vec());
+        assert!(selected.len() > settings.get_enabled_provider_ids().len());
+    }
+
+    #[test]
+    fn single_selection_stays_single_regardless_of_settings() {
+        let settings = settings_with_enabled(&["grok", "cursor"]);
+        let selected = ProviderSelection::from_arg(Some("claude"))
+            .unwrap()
+            .as_list_from(&settings);
+
+        assert_eq!(selected, vec![ProviderId::Claude]);
+    }
+
+    #[test]
+    fn empty_enabled_providers_resolves_to_empty_list() {
+        let settings = settings_with_enabled(&[]);
+        let selected = ProviderSelection::from_arg(None)
+            .unwrap()
+            .as_list_from(&settings);
+
+        assert!(selected.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- **SBS-855:** Bare `codexbar usage` documented as printing enabled providers but always queried Claude.
- `ProviderSelection::from_arg(None)` now resolves through `Settings::get_enabled_provider_ids()` (same set the desktop app uses).
- `-p all` still means every provider; `-p claude` stays single. `--all-accounts` (GH #274) is out of scope.

## Test plan
- [x] `cargo test --manifest-path rust/Cargo.toml --lib cli::usage` (11 passed)
- [ ] `codexbar usage` with no `-p` lists enabled providers from settings
- [ ] `codexbar usage -p all` still queries every provider
- [ ] `codexbar usage -p claude` stays single-provider

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Honor enabled providers from Settings for default `codex usage` provider selection
> - Previously, omitting `--provider` in the `codex usage` CLI command defaulted to Claude only. Now it resolves to the providers enabled in user `Settings`.
> - Adds a new `ProviderSelection::Enabled` variant in [usage.rs](https://github.com/tsouth89/ceiling/pull/309/files#diff-5e24f33c93735fe4eea871446bcc73d3e88ca1902309445a4f657f496823e3b7) and a `as_list_from(&Settings)` method to resolve it against the user's configured `enabled_providers`.
> - `UsageCommand::from_args` now loads `Settings` and passes it to provider resolution instead of returning a fixed default.
> - Behavioral Change: users with no `--provider` flag will now see usage for all their enabled providers instead of Claude alone; users with no enabled providers configured will see an empty result.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d71781.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->