### PR TITLE
Share one transcript walk between Charts API-value and heatmap (SBS-909)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Ceiling] Unreleased
 
+### Fixed
+- **Charts no longer walks the same transcript trees twice on a cold open.** Opening the tab fired Estimated API value and the activity heatmap as two independent scans of `~/.codex/sessions`, `~/.claude/projects`, and `~/.grok/sessions`, in series, so a large corpus sat blank for 30+ seconds. Both cards now share one pass per provider that fills reset windows and hourly buckets together. A second reader inside five minutes reuses that walk. Hours older than the heatmap's 30-day axis stay in the report for the API-value card and are dropped from the grid.
+
 ## [Ceiling] 1.5.33 - 2026-08-16
 
 Adds an activity heatmap to Charts and an opt-in spend warning that needs no budget set, and lets the floating bar follow whichever app you are working in. Mostly, though, this release stops surfaces reporting a state they could not actually read: a provider outage is now told apart from an empty quota, a missing Cursor plan reads as unavailable rather than 0% used, SuperGrok's weekly figure is decoded rather than guessed at, the taskbar strip stops cutting the last character off a reset, and prices, chart caches, and CLI logs stop losing or hoarding data on disk. Release builds also drop the loopback exception their content policy was carrying from the dev server.

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -8,8 +8,9 @@
 use chrono::{DateTime, Datelike, Local, LocalResult, NaiveDate, TimeZone, Timelike, Utc};
 use codexbar::core::OpenAIDashboardCacheStore;
 use codexbar::cost_scanner::{
-    CostScanner, CostSummary, CostUsageReport, CurrentUsageWindow, get_cost_usage_report,
-    get_cost_usage_report_hourly, get_cost_usage_report_scoped, get_cost_usage_report_with_windows,
+    CostScanner, CostSummary, CostUsageReport, CurrentUsageWindow, LOCAL_LOG_PROVIDERS,
+    charts_tab_corpus_reports, get_cost_usage_report, get_cost_usage_report_scoped,
+    get_cost_usage_report_with_windows,
 };
 use codexbar::locale::{self, LocaleKey};
 use serde::{Deserialize, Serialize};
@@ -822,7 +823,7 @@ fn write_chart_cache(path: &Path, cache: &PersistedChartCache) {
 /// Providers that expose token-derived local usage for the aggregate card.
 /// Inclusion is by capability, not by merely having some other dollar balance.
 // Grok dollars come from session costUsdTicks (API-equivalent), same as provider Charts.
-const API_VALUE_PROVIDERS: [&str; 3] = ["codex", "claude", "grok"];
+const API_VALUE_PROVIDERS: [&str; 3] = LOCAL_LOG_PROVIDERS;
 
 /// Priced vs total model-token counts for pricing-coverage disclosure.
 ///
@@ -1097,10 +1098,27 @@ fn parse_api_value_custom_range(
     ))
 }
 
-fn load_local_api_value_totals(
+/// Scan horizon for the default Charts-tab cards. Custom ranges may extend it.
+fn api_value_scan_days(
     now: DateTime<Local>,
     custom_range: Option<(DateTime<Utc>, DateTime<Utc>)>,
-) -> Vec<LocalApiValueProvider> {
+) -> u32 {
+    let today = now.date_naive();
+    custom_range
+        .map(|(start, _)| {
+            let start_date = start.with_timezone(&Local).date_naive();
+            let days = (today - start_date).num_days().max(0) as u32 + 1;
+            days.max(API_VALUE_DEFAULT_SCAN_DAYS)
+                .min(API_VALUE_CUSTOM_MAX_DAYS as u32)
+        })
+        .unwrap_or(API_VALUE_DEFAULT_SCAN_DAYS)
+}
+
+/// Named [start, end) windows the API-value card reads from one scan.
+fn api_value_windows(
+    now: DateTime<Local>,
+    custom_range: Option<(DateTime<Utc>, DateTime<Utc>)>,
+) -> Vec<CurrentUsageWindow> {
     let today = now.date_naive();
     let (yesterday_start, yesterday_end) = local_yesterday_window_utc(now);
     // Exact [start, end) windows so thirty-day and prior-thirty stay adjacent
@@ -1109,51 +1127,63 @@ fn load_local_api_value_totals(
     let thirty_start = local_midnight_utc(today - chrono::Duration::days(29));
     let thirty_end = local_midnight_utc(today + chrono::Duration::days(1));
     let prior_start = local_midnight_utc(today - chrono::Duration::days(59));
-    let scan_days = custom_range
-        .map(|(start, _)| {
-            let start_date = start.with_timezone(&Local).date_naive();
-            let days = (today - start_date).num_days().max(0) as u32 + 1;
-            days.max(API_VALUE_DEFAULT_SCAN_DAYS)
-                .min(API_VALUE_CUSTOM_MAX_DAYS as u32)
-        })
-        .unwrap_or(API_VALUE_DEFAULT_SCAN_DAYS);
+    let mut windows = vec![
+        CurrentUsageWindow {
+            id: "yesterday".to_string(),
+            starts_at: yesterday_start,
+            ends_at: yesterday_end,
+        },
+        CurrentUsageWindow {
+            id: "thirty".to_string(),
+            starts_at: thirty_start,
+            ends_at: thirty_end,
+        },
+        CurrentUsageWindow {
+            id: "prior_thirty".to_string(),
+            starts_at: prior_start,
+            ends_at: thirty_start,
+        },
+    ];
+    if let Some((starts_at, ends_at)) = custom_range {
+        windows.push(CurrentUsageWindow {
+            id: "custom".to_string(),
+            starts_at,
+            ends_at,
+        });
+    }
+    // One window per local calendar day for the seven-day trend.
+    for offset in 0..7i64 {
+        let date = today - chrono::Duration::days(offset);
+        windows.push(CurrentUsageWindow {
+            id: format!("day-{offset}"),
+            starts_at: local_midnight_utc(date),
+            ends_at: local_midnight_utc(date + chrono::Duration::days(1)),
+        });
+    }
+    windows
+}
+
+/// One machine-wide walk shared by the API-value card and the heatmap (SBS-909).
+fn charts_tab_reports(
+    now: DateTime<Local>,
+    custom_range: Option<(DateTime<Utc>, DateTime<Utc>)>,
+) -> HashMap<String, CostUsageReport> {
+    charts_tab_corpus_reports(
+        api_value_scan_days(now, custom_range),
+        &api_value_windows(now, custom_range),
+    )
+}
+
+fn load_local_api_value_totals(
+    now: DateTime<Local>,
+    custom_range: Option<(DateTime<Utc>, DateTime<Utc>)>,
+) -> Vec<LocalApiValueProvider> {
+    let today = now.date_naive();
+    let reports = charts_tab_reports(now, custom_range);
     API_VALUE_PROVIDERS
         .iter()
         .filter_map(|provider_id| {
-            let mut windows = vec![
-                CurrentUsageWindow {
-                    id: "yesterday".to_string(),
-                    starts_at: yesterday_start,
-                    ends_at: yesterday_end,
-                },
-                CurrentUsageWindow {
-                    id: "thirty".to_string(),
-                    starts_at: thirty_start,
-                    ends_at: thirty_end,
-                },
-                CurrentUsageWindow {
-                    id: "prior_thirty".to_string(),
-                    starts_at: prior_start,
-                    ends_at: thirty_start,
-                },
-            ];
-            if let Some((starts_at, ends_at)) = custom_range {
-                windows.push(CurrentUsageWindow {
-                    id: "custom".to_string(),
-                    starts_at,
-                    ends_at,
-                });
-            }
-            // One window per local calendar day for the seven-day trend.
-            for offset in 0..7i64 {
-                let date = today - chrono::Duration::days(offset);
-                windows.push(CurrentUsageWindow {
-                    id: format!("day-{offset}"),
-                    starts_at: local_midnight_utc(date),
-                    ends_at: local_midnight_utc(date + chrono::Duration::days(1)),
-                });
-            }
-            let report = get_cost_usage_report_with_windows(provider_id, scan_days, &windows)?;
+            let report = reports.get(*provider_id)?;
             let yesterday = report
                 .current_windows
                 .get("yesterday")
@@ -1348,10 +1378,9 @@ fn activity_heatmap_cache() -> &'static Mutex<Option<CachedActivityHeatmap>> {
 
 /// Local activity by day and hour across every provider with local logs.
 ///
-/// This is a second pass over the same transcripts the API-value card reads, so
-/// results are cached for the same five minutes the chart caches use. Callers
-/// that need fresh numbers after a scan should let the TTL lapse rather than
-/// forcing a rescan on every tab switch.
+/// Derived from the same corpus scan the API-value card pays for (SBS-909).
+/// The assembled heatmap is still cached for five minutes so a tab switch
+/// does not rebuild the grid; the underlying walk is shared, not repeated.
 #[tauri::command]
 pub async fn get_local_activity_heatmap() -> Result<ActivityHeatmap, String> {
     if let Ok(guard) = activity_heatmap_cache().lock()
@@ -1390,6 +1419,23 @@ fn activity_heatmap_days(today: NaiveDate) -> Vec<String> {
                 .format("%Y-%m-%d")
                 .to_string()
         })
+        .collect()
+}
+
+/// Keep only hours that fall on the heatmap day axis.
+///
+/// The shared Charts-tab scan covers 90 days so the API-value card can
+/// fill its series. The heatmap is a 30-day grid; hours outside that
+/// axis would otherwise leak into the weekday view.
+fn heatmap_hours_for_days(
+    provider_id: &str,
+    report: &CostUsageReport,
+    days: &[String],
+) -> Vec<ActivityHourPoint> {
+    let day_set: HashSet<&str> = days.iter().map(String::as_str).collect();
+    activity_hours_for_provider(provider_id, report)
+        .into_iter()
+        .filter(|point| day_set.contains(point.date.as_str()))
         .collect()
 }
 
@@ -1464,18 +1510,18 @@ fn load_activity_heatmap<Tz: TimeZone>(now: DateTime<Tz>) -> ActivityHeatmap
 where
     Tz::Offset: std::fmt::Display,
 {
+    let local_now = now.with_timezone(&Local);
+    let reports = charts_tab_reports(local_now, None);
+    let days = activity_heatmap_days(now.date_naive());
     let per_provider = API_VALUE_PROVIDERS
         .iter()
         .filter_map(|provider_id| {
-            let report = get_cost_usage_report_hourly(provider_id, ACTIVITY_HEATMAP_DAYS)?;
-            Some(activity_hours_for_provider(provider_id, &report))
+            let report = reports.get(*provider_id)?;
+            let hours = heatmap_hours_for_days(provider_id, report, &days);
+            Some(hours)
         })
         .collect();
-    assemble_activity_heatmap(
-        activity_heatmap_days(now.date_naive()),
-        per_provider,
-        format!("UTC{}", now.offset()),
-    )
+    assemble_activity_heatmap(days, per_provider, format!("UTC{}", now.offset()))
 }
 
 /// One model's local Cursor activity. This is code-contribution activity from
@@ -2353,12 +2399,12 @@ mod tests {
         ProviderLocalUsageSummary, activity_heatmap_days, activity_hours_for_provider,
         api_value_period, assemble_activity_heatmap, chart_cache_key, comparison_period_specs,
         cost_fetch_failure_allows_early_retry, current_unix_ms, daily_series_from_report,
-        effort_breakdown, format_cost_csv, load_chart_cache_from, local_midnight_in_tz,
-        local_usage_summary_from_report, local_yesterday_window_utc, localized_estimate_note,
-        model_breakdown, parse_api_value_custom_range, period_from_daily_series,
-        pricing_coverage_tokens, project_breakdown, prune_chart_cache, prune_loaded_chart_cache,
-        resolve_chart_account_scope, spend_anomaly_reading, spend_budget_period_details,
-        token_breakdown, token_cost_cache_is_fresh,
+        effort_breakdown, format_cost_csv, heatmap_hours_for_days, load_chart_cache_from,
+        local_midnight_in_tz, local_usage_summary_from_report, local_yesterday_window_utc,
+        localized_estimate_note, model_breakdown, parse_api_value_custom_range,
+        period_from_daily_series, pricing_coverage_tokens, project_breakdown, prune_chart_cache,
+        prune_loaded_chart_cache, resolve_chart_account_scope, spend_anomaly_reading,
+        spend_budget_period_details, token_breakdown, token_cost_cache_is_fresh,
     };
     use crate::commands::is_provider_cache_fresh;
     use chrono::{Local, LocalResult, NaiveDate, NaiveTime, TimeZone, Timelike, Utc};
@@ -3885,5 +3931,48 @@ mod tests {
                 ("2026-08-15", 9, "codex"),
             ],
         );
+    }
+
+    /// SBS-909: the shared 90-day scan can emit hours the 30-day heatmap
+    /// must not display. Those hours stay in the report for the API-value
+    /// card; the grid only keeps days on its own axis.
+    #[test]
+    fn heatmap_hours_drop_days_outside_the_axis() {
+        let mut busy = CostSummary {
+            total_cost_usd: 1.0,
+            input_tokens: 100,
+            output_tokens: 10,
+            ..Default::default()
+        };
+        busy.by_model_tokens.insert(
+            "gpt-5.1-codex".to_string(),
+            ModelTokenCounts {
+                input_tokens: 100,
+                output_tokens: 10,
+                calls: 1,
+                ..Default::default()
+            },
+        );
+        let report = CostUsageReport {
+            hourly_activity: vec![
+                HourlyActivityPoint {
+                    date: NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+                    hour: 9,
+                    summary: busy.clone(),
+                },
+                HourlyActivityPoint {
+                    date: NaiveDate::from_ymd_opt(2026, 8, 15).unwrap(),
+                    hour: 10,
+                    summary: busy,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let hours = heatmap_hours_for_days("codex", &report, &["2026-08-15".to_string()]);
+
+        assert_eq!(hours.len(), 1);
+        assert_eq!(hours[0].date, "2026-08-15");
+        assert_eq!(hours[0].hour, 10);
     }
 }

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -12,6 +12,8 @@ use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
 
 use crate::codex_cost_speed::{self, CodexCostSpeed};
 #[cfg(test)]
@@ -1358,19 +1360,13 @@ pub fn get_cost_usage_report(provider: &str, days: u32) -> Option<CostUsageRepor
 
 /// As [`get_cost_usage_report`], but also fills [`CostUsageReport::hourly_activity`].
 ///
-/// Separate entry point because bucketing every record by clock-hour runs its
-/// accounting a second time. Only the activity heatmap needs it; the charts,
-/// reset windows, and API-value card all scan the same trees on every refresh
-/// and would pay for buckets they never read.
+/// Hourly bucketing runs a second accounting pass per record. Callers that
+/// never read those buckets should keep using [`get_cost_usage_report`] or
+/// [`get_cost_usage_report_with_windows`]. The Charts tab's two cards share
+/// [`charts_tab_corpus_reports`] instead, which pays for hourly once and
+/// derives both surfaces from it (SBS-909).
 pub fn get_cost_usage_report_hourly(provider: &str, days: u32) -> Option<CostUsageReport> {
-    let days = days.max(1);
-    let scanner = CostScanner::new(days).with_hourly_activity();
-    match provider {
-        "codex" => Some(scan_codex_report(&scanner, days, &[])),
-        "claude" => Some(scan_claude_report(&scanner, days, &[])),
-        "grok" => Some(scan_grok_report(&scanner, days, &[])),
-        _ => None,
-    }
+    get_cost_usage_report_scoped_opts(provider, days, &[], None, true)
 }
 
 pub fn get_cost_usage_report_with_windows(
@@ -1378,7 +1374,19 @@ pub fn get_cost_usage_report_with_windows(
     days: u32,
     current_windows: &[CurrentUsageWindow],
 ) -> Option<CostUsageReport> {
-    get_cost_usage_report_scoped(provider, days, current_windows, None)
+    get_cost_usage_report_scoped_opts(provider, days, current_windows, None, false)
+}
+
+/// One transcript walk that fills both reset windows and hourly buckets.
+///
+/// The Charts tab opens the API-value card and the heatmap together. Each used
+/// to walk the same trees; this is the pass they now share.
+pub fn get_cost_usage_report_with_windows_hourly(
+    provider: &str,
+    days: u32,
+    current_windows: &[CurrentUsageWindow],
+) -> Option<CostUsageReport> {
+    get_cost_usage_report_scoped_opts(provider, days, current_windows, None, true)
 }
 
 /// As [`get_cost_usage_report_with_windows`], but scoped to one account's config
@@ -1390,17 +1398,171 @@ pub fn get_cost_usage_report_scoped(
     current_windows: &[CurrentUsageWindow],
     scoped_home: Option<PathBuf>,
 ) -> Option<CostUsageReport> {
+    get_cost_usage_report_scoped_opts(provider, days, current_windows, scoped_home, false)
+}
+
+/// Providers whose local JSONL trees feed Estimated API value and the heatmap.
+pub const LOCAL_LOG_PROVIDERS: [&str; 3] = ["codex", "claude", "grok"];
+
+/// How long a Charts-tab corpus scan can be reused by a second card.
+const CHARTS_TAB_CORPUS_TTL: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChartsTabCorpusKey {
+    days: u32,
+    windows: Vec<(String, DateTime<Utc>, DateTime<Utc>)>,
+}
+
+impl ChartsTabCorpusKey {
+    fn new(days: u32, windows: &[CurrentUsageWindow]) -> Self {
+        Self {
+            days,
+            windows: windows
+                .iter()
+                .map(|window| (window.id.clone(), window.starts_at, window.ends_at))
+                .collect(),
+        }
+    }
+}
+
+struct CachedChartsTabCorpus {
+    loaded_at: Instant,
+    key: ChartsTabCorpusKey,
+    reports: HashMap<String, CostUsageReport>,
+}
+
+/// In-process reuse of one machine-wide local-log scan.
+///
+/// The Charts tab fires two commands on a cold open. They must wait on the
+/// same walk rather than each starting their own.
+pub struct ChartsTabCorpusCache {
+    inner: Mutex<Option<CachedChartsTabCorpus>>,
+}
+
+impl Default for ChartsTabCorpusCache {
+    fn default() -> Self {
+        Self {
+            inner: Mutex::new(None),
+        }
+    }
+}
+
+impl ChartsTabCorpusCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Scan each local-log provider once, with windows and hourly buckets.
+    ///
+    /// A second reader with the same key inside [`CHARTS_TAB_CORPUS_TTL`]
+    /// reuses the reports. The lock is held for the walk so two concurrent
+    /// Charts commands cannot start two walks of the same trees.
+    pub fn reports(
+        &self,
+        days: u32,
+        windows: &[CurrentUsageWindow],
+    ) -> HashMap<String, CostUsageReport> {
+        let key = ChartsTabCorpusKey::new(days, windows);
+        let mut guard = self.inner.lock().unwrap_or_else(|err| err.into_inner());
+        if let Some(cached) = guard.as_ref()
+            && cached.key == key
+            && cached.loaded_at.elapsed() < CHARTS_TAB_CORPUS_TTL
+        {
+            return cached.reports.clone();
+        }
+        let reports = scan_local_log_providers_with_windows_hourly(days, windows);
+        *guard = Some(CachedChartsTabCorpus {
+            loaded_at: Instant::now(),
+            key,
+            reports: reports.clone(),
+        });
+        reports
+    }
+
+    #[cfg(test)]
+    fn reset(&self) {
+        let mut guard = self.inner.lock().unwrap_or_else(|err| err.into_inner());
+        *guard = None;
+    }
+}
+
+fn charts_tab_corpus_cache() -> &'static ChartsTabCorpusCache {
+    static CACHE: OnceLock<ChartsTabCorpusCache> = OnceLock::new();
+    CACHE.get_or_init(ChartsTabCorpusCache::new)
+}
+
+/// Machine-wide Codex/Claude/Grok reports for the Charts tab cards (SBS-909).
+///
+/// One walk per provider, with hourly buckets always on, reused for five
+/// minutes so the API-value card and the heatmap do not each rescan.
+pub fn charts_tab_corpus_reports(
+    days: u32,
+    windows: &[CurrentUsageWindow],
+) -> HashMap<String, CostUsageReport> {
+    charts_tab_corpus_cache().reports(days, windows)
+}
+
+fn scan_local_log_providers_with_windows_hourly(
+    days: u32,
+    windows: &[CurrentUsageWindow],
+) -> HashMap<String, CostUsageReport> {
+    LOCAL_LOG_PROVIDERS
+        .iter()
+        .filter_map(|provider_id| {
+            get_cost_usage_report_with_windows_hourly(provider_id, days, windows)
+                .map(|report| ((*provider_id).to_string(), report))
+        })
+        .collect()
+}
+
+fn get_cost_usage_report_scoped_opts(
+    provider: &str,
+    days: u32,
+    current_windows: &[CurrentUsageWindow],
+    scoped_home: Option<PathBuf>,
+    hourly: bool,
+) -> Option<CostUsageReport> {
+    #[cfg(test)]
+    note_cost_scan();
     let days = days.max(1);
-    let scanner = match scoped_home {
+    let mut scanner = match scoped_home {
         Some(home) => CostScanner::scoped_to(days, home),
         None => CostScanner::new(days),
     };
+    if hourly {
+        scanner = scanner.with_hourly_activity();
+    }
     match provider {
         "codex" => Some(scan_codex_report(&scanner, days, current_windows)),
         "claude" => Some(scan_claude_report(&scanner, days, current_windows)),
         "grok" => Some(scan_grok_report(&scanner, days, current_windows)),
         _ => None,
     }
+}
+
+#[cfg(test)]
+thread_local! {
+    static COST_SCAN_INVOCATIONS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn note_cost_scan() {
+    COST_SCAN_INVOCATIONS.with(|count| count.set(count.get().saturating_add(1)));
+}
+
+#[cfg(test)]
+pub fn reset_cost_scan_invocations() {
+    COST_SCAN_INVOCATIONS.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub fn cost_scan_invocations() -> usize {
+    COST_SCAN_INVOCATIONS.with(|count| count.get())
+}
+
+#[cfg(test)]
+pub fn reset_charts_tab_corpus_cache() {
+    charts_tab_corpus_cache().reset();
 }
 
 fn empty_current_window_summaries(windows: &[CurrentUsageWindow]) -> HashMap<String, CostSummary> {
@@ -3246,6 +3408,146 @@ mod tests {
         assert!(
             (hourly_cost - daily_cost).abs() < 1e-9,
             "hourly {hourly_cost} vs daily {daily_cost}"
+        );
+    }
+
+    /// SBS-909: the Charts tab needs windows and hourly buckets from one walk.
+    /// A second entry point that only filled one of those is what made the
+    /// cold open scan the same trees twice.
+    #[test]
+    fn windows_and_hourly_are_filled_in_one_scoped_pass() {
+        let recent = Utc::now() - Duration::hours(1);
+        let home = tempfile::tempdir().unwrap();
+        let today = Local::now().date_naive();
+        let day_dir = home
+            .path()
+            .join("sessions")
+            .join(today.format("%Y").to_string())
+            .join(today.format("%m").to_string())
+            .join(today.format("%d").to_string());
+        std::fs::create_dir_all(&day_dir).unwrap();
+        std::fs::write(
+            day_dir.join(format!(
+                "rollout-{}-44444444-4444-4444-4444-444444444444.jsonl",
+                today.format("%Y-%m-%d")
+            )),
+            format!(
+                r#"{{"timestamp":"{}","type":"event_msg","payload":{{"type":"token_count","info":{{"last_token_usage":{{"input_tokens":400,"cached_input_tokens":0,"output_tokens":0}}}}}}}}"#,
+                recent.to_rfc3339()
+            ),
+        )
+        .unwrap();
+
+        let window = CurrentUsageWindow {
+            id: "today".to_string(),
+            starts_at: recent - Duration::hours(2),
+            ends_at: recent + Duration::hours(2),
+        };
+        let report = scan_codex_report(
+            &CostScanner::scoped_to(2, home.path().to_path_buf()).with_hourly_activity(),
+            2,
+            std::slice::from_ref(&window),
+        );
+
+        assert!(
+            !report.hourly_activity.is_empty(),
+            "hourly buckets must be present for the heatmap"
+        );
+        let today_window = report
+            .current_windows
+            .get("today")
+            .expect("named window must be present for the API-value card");
+        assert_eq!(today_window.input_tokens, 400);
+        assert_eq!(
+            report
+                .hourly_activity
+                .iter()
+                .map(|p| p.summary.input_tokens)
+                .sum::<u64>(),
+            400
+        );
+    }
+
+    /// SBS-909: two Charts-tab readers of the same key must not walk the
+    /// corpus twice. This is the failure mode of the 1.5.33 cold open.
+    #[test]
+    fn charts_tab_corpus_cache_scans_each_provider_once_for_a_second_reader() {
+        reset_cost_scan_invocations();
+        let cache = ChartsTabCorpusCache::new();
+        let now = Utc::now();
+        let windows = [CurrentUsageWindow {
+            id: "today".to_string(),
+            starts_at: now - Duration::hours(24),
+            ends_at: now + Duration::hours(1),
+        }];
+
+        let first = cache.reports(2, &windows);
+        let first_scans = cost_scan_invocations();
+        let second = cache.reports(2, &windows);
+
+        assert_eq!(
+            first_scans,
+            LOCAL_LOG_PROVIDERS.len(),
+            "first reader walks each local-log provider once"
+        );
+        assert_eq!(
+            cost_scan_invocations(),
+            first_scans,
+            "second reader must reuse the first walk, not start another"
+        );
+        assert_eq!(first.keys().len(), second.keys().len());
+        assert_eq!(first.keys().len(), LOCAL_LOG_PROVIDERS.len());
+    }
+
+    /// A different window set is a different question and must not reuse
+    /// reports that never computed that window.
+    #[test]
+    fn charts_tab_corpus_cache_rescans_when_the_windows_change() {
+        reset_cost_scan_invocations();
+        let cache = ChartsTabCorpusCache::new();
+        let now = Utc::now();
+        let today = [CurrentUsageWindow {
+            id: "today".to_string(),
+            starts_at: now - Duration::hours(24),
+            ends_at: now,
+        }];
+        let custom = [CurrentUsageWindow {
+            id: "custom".to_string(),
+            starts_at: now - Duration::days(10),
+            ends_at: now,
+        }];
+
+        let _ = cache.reports(2, &today);
+        let after_first = cost_scan_invocations();
+        let _ = cache.reports(2, &custom);
+
+        assert_eq!(after_first, LOCAL_LOG_PROVIDERS.len());
+        assert_eq!(
+            cost_scan_invocations(),
+            LOCAL_LOG_PROVIDERS.len() * 2,
+            "a new window set is a new walk"
+        );
+    }
+
+    /// The function the Charts tab actually calls must be the cached one.
+    #[test]
+    fn charts_tab_corpus_reports_reuses_the_process_cache() {
+        reset_charts_tab_corpus_cache();
+        reset_cost_scan_invocations();
+        let now = Utc::now();
+        let windows = [CurrentUsageWindow {
+            id: "today".to_string(),
+            starts_at: now - Duration::hours(24),
+            ends_at: now,
+        }];
+
+        let _ = charts_tab_corpus_reports(2, &windows);
+        let _ = charts_tab_corpus_reports(2, &windows);
+
+        assert_eq!(
+            cost_scan_invocations(),
+            LOCAL_LOG_PROVIDERS.len(),
+            "the process cache is what both Charts cards share"
         );
     }
 }


### PR DESCRIPTION
## Summary

Opening Charts fired Estimated API value and When you work as two independent walks of the same local-log trees, in series. Both cards now share one pass per provider that fills reset windows and hourly buckets. A second reader inside five minutes reuses that walk. Hours older than the heatmap 30-day axis stay in the report for the API-value card and are dropped from the grid.

A user who opens Charts on a large corpus now pays for one machine-wide scan, not two.

Linear: https://linear.app/southboundsoftware/issue/SBS-909

## Test plan

- Open Charts on a large Codex/Claude/Grok corpus. Both cards should appear after one walk.
- Switch away and back within five minutes: neither card should rescan.
- Custom API-value range is a different window set and may walk again.
- Confirm a 30-day heatmap cell is not darkened by older activity.

## Quality gate

- cargo fmt --all --check: pass
- cargo test --manifest-path rust/Cargo.toml: 1004 passed, 6 failed. The 6 are unchanged Windows-path assertions on this Linux box (codex_sessions path separators, grok_costs project basenames). New SBS-909 tests passed. Windows CI is the required runner.
- cargo clippy --all-targets -- -D warnings: fails here on two pre-existing unused Windows-only items (secure_file.rs:489, updater.rs:442). No findings in cost_scanner.rs or chart.rs.
- Desktop crate: could not compile (glib-2.0 missing). Not a Linux harness as Windows CI.
- Frontend CI not rerun; no frontend files changed.
- Store-submission PowerShell script not run (Linux box).

## Fail without the fix

Reverted only the cache hit in ChartsTabCorpusCache::reports. charts_tab_corpus tests failed with left: 6, right: 3 (one walk per provider per card instead of one walk per provider). Restored; tests pass.

## Sweep leftovers

- Spend budget and spend-anomaly still scan on their own (different windows). Spend-anomaly is still Codex+Claude only.
- Provider Charts/Compare still do a 30-day scoped scan.
- No provider parallelism, no per-file incremental cache, no first-card streaming.
- Custom range evicts the single-slot default cache.

## Gaps

- Desktop test heatmap_hours_drop_days_outside_the_axis not executed here (no glib).
- No large-corpus profile.
- Frontend CI not rerun.