### PR TITLE
Ask for a GitHub star, at most twice ever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Ceiling] Unreleased
 
+### Added
+- **Ceiling asks for a GitHub star, at most twice ever.** A card in the bottom-right of the dashboard, and the only thing Ceiling has ever asked of anyone using it. The first ask waits until a provider has actually reported a reading and that reading has been on screen for twenty seconds, so it lands after the app has done something useful rather than during setup, when it would be asking to be paid before the work. The second, if the first went unanswered, waits for a later version to have shipped and for a week to have passed since the first, because a version bump the day after is still two asks in one week. Clicking through to GitHub ends it permanently; so does reaching the second ask. Later and the close button mean the same thing and never count as interest. It is not a Windows notification, it takes no focus and traps none, Escape closes it, and the only network call involved is opening the repository in your browser when you ask for it.
+
 ## [Ceiling] 1.5.34 - 2026-08-18
 
 Charts opens in about two seconds instead of about thirty. Each local transcript is now parsed once into a small index beside your settings rather than re-read from the top by every card, every time, and the cards keep their last result so a restart is not a cold start. The numbers are unchanged: an indexed scan is checked against a full re-parse, and the index is discarded outright whenever model prices move.

--- a/apps/desktop-tauri/src/components/StarPrompt.test.tsx
+++ b/apps/desktop-tauri/src/components/StarPrompt.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const tauriMocks = vi.hoisted(() => ({
+  getLocaleStrings: vi.fn(),
+  setUiLanguage: vi.fn(),
+}));
+
+const eventMocks = vi.hoisted(() => ({ listen: vi.fn() }));
+
+vi.mock("../lib/tauri", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/tauri")>()),
+  ...tauriMocks,
+}));
+vi.mock("@tauri-apps/api/event", () => eventMocks);
+
+import { LocaleProvider } from "../i18n/LocaleProvider";
+import { buildBundle } from "../test/localeHarness";
+import StarPrompt from "./StarPrompt";
+import type { StarPromptReason } from "../lib/starPrompt";
+
+function renderPrompt(
+  reason: StarPromptReason,
+  handlers: { onStar?: () => void; onDismiss?: () => void } = {},
+) {
+  const onStar = handlers.onStar ?? vi.fn();
+  const onDismiss = handlers.onDismiss ?? vi.fn();
+  render(
+    <LocaleProvider>
+      <StarPrompt
+        reason={reason}
+        version="1.5.34"
+        onStar={onStar}
+        onDismiss={onDismiss}
+      />
+    </LocaleProvider>,
+  );
+  return { onStar, onDismiss };
+}
+
+describe("StarPrompt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eventMocks.listen.mockResolvedValue(() => {});
+    tauriMocks.getLocaleStrings.mockResolvedValue(
+      buildBundle({
+        StarPromptAriaLabel: "Star Ceiling on GitHub",
+        StarPromptTitleRunning: "Ceiling is up and running",
+        StarPromptTitleUpdated: "Updated to",
+        StarPromptBody:
+          "If Ceiling is useful to you, a GitHub star helps other developers find it.",
+        StarPromptStar: "Star on GitHub",
+        StarPromptLater: "Later",
+      }),
+    );
+  });
+
+  it("leads with the app working, not with the ask", async () => {
+    renderPrompt("firstValue");
+    expect(
+      await screen.findByText("Ceiling is up and running"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "If Ceiling is useful to you, a GitHub star helps other developers find it.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("names the version on the post-update ask", async () => {
+    renderPrompt("afterUpdate");
+    expect(await screen.findByText("Updated to 1.5.34")).toBeInTheDocument();
+  });
+
+  it("reports the star, not a dismissal, when the user goes to GitHub", async () => {
+    const { onStar, onDismiss } = renderPrompt("firstValue");
+    fireEvent.click(await screen.findByRole("button", { name: "Star on GitHub" }));
+    expect(onStar).toHaveBeenCalledOnce();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("treats the close button as Later, never as a star", async () => {
+    const { onStar, onDismiss } = renderPrompt("firstValue");
+    const buttons = await screen.findAllByRole("button", { name: "Later" });
+    // Both the ✕ and the Later button carry the same accessible name; either
+    // one must dismiss without being counted as interest.
+    for (const button of buttons) fireEvent.click(button);
+    expect(onDismiss).toHaveBeenCalledTimes(buttons.length);
+    expect(onStar).not.toHaveBeenCalled();
+  });
+
+  it("dismisses on Escape", async () => {
+    const { onStar, onDismiss } = renderPrompt("firstValue");
+    await screen.findByRole("dialog", { name: "Star Ceiling on GitHub" });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onDismiss).toHaveBeenCalledOnce();
+    expect(onStar).not.toHaveBeenCalled();
+  });
+
+  it("does not take focus from whatever the user was reading", async () => {
+    const before = document.activeElement;
+    renderPrompt("firstValue");
+    await screen.findByRole("dialog", { name: "Star Ceiling on GitHub" });
+    expect(document.activeElement).toBe(before);
+  });
+});

--- a/apps/desktop-tauri/src/components/StarPrompt.test.tsx
+++ b/apps/desktop-tauri/src/components/StarPrompt.test.tsx
@@ -97,6 +97,37 @@ describe("StarPrompt", () => {
     expect(onStar).not.toHaveBeenCalled();
   });
 
+  it("keeps Escape to itself so it cannot also close the dashboard", async () => {
+    // TrayPanel has its own window-level Escape handler that dismisses the
+    // whole tray panel. Answering the prompt must not shut the window the
+    // user was reading.
+    const trayEscape = vi.fn();
+    window.addEventListener("keydown", trayEscape);
+    try {
+      const { onDismiss } = renderPrompt("firstValue");
+      await screen.findByRole("dialog", { name: "Star Ceiling on GitHub" });
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(onDismiss).toHaveBeenCalledOnce();
+      expect(trayEscape).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("keydown", trayEscape);
+    }
+  });
+
+  it("leaves other keys alone", async () => {
+    const other = vi.fn();
+    window.addEventListener("keydown", other);
+    try {
+      const { onDismiss } = renderPrompt("firstValue");
+      await screen.findByRole("dialog", { name: "Star Ceiling on GitHub" });
+      fireEvent.keyDown(window, { key: "r", ctrlKey: true });
+      expect(other).toHaveBeenCalledOnce();
+      expect(onDismiss).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("keydown", other);
+    }
+  });
+
   it("does not take focus from whatever the user was reading", async () => {
     const before = document.activeElement;
     renderPrompt("firstValue");

--- a/apps/desktop-tauri/src/components/StarPrompt.tsx
+++ b/apps/desktop-tauri/src/components/StarPrompt.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from "react";
+import { useLocale } from "../hooks/useLocale";
+import type { StarPromptReason } from "../lib/starPrompt";
+
+interface Props {
+  reason: StarPromptReason;
+  /** App version, shown in the copy for the post-update ask. */
+  version: string;
+  onStar: () => void;
+  onDismiss: () => void;
+}
+
+/**
+ * The GitHub star ask (SOU-311). A card in the bottom-right of the dashboard,
+ * shown at most twice in the app's life; `starPrompt.ts` owns when.
+ *
+ * Deliberately not a modal: no backdrop, no focus trap, and focus is left
+ * where the user put it. It sits over the corner of a panel someone opened to
+ * read a number, and taking the keyboard away from them to ask a favour would
+ * be the rudest possible version of this feature. It stays until it is
+ * answered because a nudge that fades out unread would only have to be shown
+ * again, which is exactly the repetition the two-ask cap exists to avoid.
+ */
+export default function StarPrompt({
+  reason,
+  version,
+  onStar,
+  onDismiss,
+}: Props) {
+  const { t } = useLocale();
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+
+  // Escape is the expected way out of anything that floats above the page, and
+  // it counts as "Later" — the same as the close button, and never as a star.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      onDismissRef.current();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  const title =
+    reason === "afterUpdate"
+      ? `${t("StarPromptTitleUpdated")} ${version}`
+      : t("StarPromptTitleRunning");
+
+  return (
+    <aside
+      className="star-prompt"
+      role="dialog"
+      aria-label={t("StarPromptAriaLabel")}
+    >
+      <div className="star-prompt__header">
+        <span className="star-prompt__check" aria-hidden="true" />
+        <h3 className="star-prompt__title">{title}</h3>
+        <button
+          type="button"
+          className="star-prompt__close"
+          onClick={onDismiss}
+          aria-label={t("StarPromptLater")}
+          title={t("StarPromptLater")}
+        >
+          ✕
+        </button>
+      </div>
+      <p className="star-prompt__body">{t("StarPromptBody")}</p>
+      <div className="star-prompt__actions">
+        <button
+          type="button"
+          className="star-prompt__action star-prompt__action--primary"
+          onClick={onStar}
+        >
+          <span className="star-prompt__star" aria-hidden="true">
+            ☆
+          </span>
+          {t("StarPromptStar")}
+        </button>
+        <button
+          type="button"
+          className="star-prompt__action"
+          onClick={onDismiss}
+        >
+          {t("StarPromptLater")}
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/apps/desktop-tauri/src/components/StarPrompt.tsx
+++ b/apps/desktop-tauri/src/components/StarPrompt.tsx
@@ -33,14 +33,22 @@ export default function StarPrompt({
 
   // Escape is the expected way out of anything that floats above the page, and
   // it counts as "Later" — the same as the close button, and never as a star.
+  //
+  // Captured, and the event stopped dead. TrayPanel has its own window-level
+  // Escape handler that closes the whole dashboard, and `preventDefault` alone
+  // does not stop it: without this, answering the prompt would also shut the
+  // window the user was reading. Capture puts this listener ahead of that one
+  // regardless of which mounted first.
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       event.preventDefault();
+      event.stopImmediatePropagation();
       onDismissRef.current();
     };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", onKeyDown, { capture: true });
   }, []);
 
   const title =

--- a/apps/desktop-tauri/src/hooks/useStarPrompt.test.tsx
+++ b/apps/desktop-tauri/src/hooks/useStarPrompt.test.tsx
@@ -1,0 +1,183 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tauriMocks = vi.hoisted(() => ({
+  getAppInfo: vi.fn(),
+  openExternalUrl: vi.fn(),
+}));
+
+vi.mock("../lib/tauri", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/tauri")>()),
+  ...tauriMocks,
+}));
+
+import { SETTLE_MS, readStarPromptState } from "../lib/starPrompt";
+import { useStarPrompt } from "./useStarPrompt";
+import type { ProviderUsageSnapshot } from "../types/bridge";
+
+const VERSION = "1.5.34";
+
+function reading(): ProviderUsageSnapshot {
+  return {
+    providerId: "claude",
+    displayName: "Claude",
+    primary: {
+      usedPercent: 20,
+      remainingPercent: 80,
+      windowMinutes: null,
+      resetsAt: null,
+      resetDescription: null,
+      isExhausted: false,
+      reservePercent: null,
+      reserveDescription: null,
+    },
+    secondary: null,
+    modelSpecific: null,
+    tertiary: null,
+    extraRateWindows: [],
+    cost: null,
+    planName: null,
+    accountEmail: null,
+    sourceLabel: "test",
+    updatedAt: new Date().toISOString(),
+    error: null,
+    pace: null,
+    accountOrganization: null,
+    trayStatusLabel: null,
+  } as ProviderUsageSnapshot;
+}
+
+function Harness({ providers }: { providers: ProviderUsageSnapshot[] }) {
+  const { reason, onStar, onDismiss } = useStarPrompt(providers);
+  return (
+    <div>
+      <span data-testid="reason">{reason ?? "none"}</span>
+      <button type="button" onClick={onStar}>
+        star
+      </button>
+      <button type="button" onClick={onDismiss}>
+        dismiss
+      </button>
+    </div>
+  );
+}
+
+function currentReason(): string {
+  return screen.getByTestId("reason").textContent ?? "";
+}
+
+/** Let the version promise resolve, then run past the settle delay. */
+async function settle() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    vi.advanceTimersByTime(SETTLE_MS + 5_000);
+  });
+}
+
+describe("useStarPrompt", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    tauriMocks.getAppInfo.mockResolvedValue({
+      name: "Ceiling",
+      version: VERSION,
+      buildNumber: "1",
+      updateChannel: "stable",
+      tagline: "",
+    });
+    tauriMocks.openExternalUrl.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("stays quiet until the reading has been on screen a while", async () => {
+    render(<Harness providers={[reading()]} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(SETTLE_MS - 1_000);
+    });
+    expect(currentReason()).toBe("none");
+    expect(readStarPromptState().asked).toBe(0);
+  });
+
+  it("asks once the reading has settled", async () => {
+    render(<Harness providers={[reading()]} />);
+    await settle();
+    expect(currentReason()).toBe("firstValue");
+  });
+
+  it("counts the ask when it appears, not when it is answered", async () => {
+    // Otherwise closing the window without touching the card would leave the
+    // count at zero and the same prompt would return on the next launch.
+    const view = render(<Harness providers={[reading()]} />);
+    await settle();
+    expect(readStarPromptState().asked).toBe(1);
+    expect(readStarPromptState().lastAskedVersion).toBe(VERSION);
+    view.unmount();
+    expect(readStarPromptState().asked).toBe(1);
+  });
+
+  it("does not come back on the next launch of the same version", async () => {
+    const first = render(<Harness providers={[reading()]} />);
+    await settle();
+    expect(currentReason()).toBe("firstValue");
+    first.unmount();
+
+    render(<Harness providers={[reading()]} />);
+    await settle();
+    expect(currentReason()).toBe("none");
+    expect(readStarPromptState().asked).toBe(1);
+  });
+
+  it("opens the repo and stops asking for good when starred", async () => {
+    render(<Harness providers={[reading()]} />);
+    await settle();
+    await act(async () => {
+      screen.getByText("star").click();
+    });
+    expect(currentReason()).toBe("none");
+    expect(tauriMocks.openExternalUrl).toHaveBeenCalledWith(
+      "https://github.com/tsouth89/ceiling",
+    );
+    expect(readStarPromptState().starred).toBe(true);
+  });
+
+  it("does not treat Later as interest", async () => {
+    render(<Harness providers={[reading()]} />);
+    await settle();
+    await act(async () => {
+      screen.getByText("dismiss").click();
+    });
+    expect(currentReason()).toBe("none");
+    expect(tauriMocks.openExternalUrl).not.toHaveBeenCalled();
+    expect(readStarPromptState().starred).toBe(false);
+  });
+
+  it("stays put when the reading goes away underneath it", async () => {
+    // A refresh failing mid-click must not yank the card out from under the
+    // pointer; the ask is already counted, so hiding it would waste it too.
+    const view = render(<Harness providers={[reading()]} />);
+    await settle();
+    expect(currentReason()).toBe("firstValue");
+
+    view.rerender(<Harness providers={[]} />);
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(currentReason()).toBe("firstValue");
+  });
+
+  it("never asks with nothing on screen to have earned it", async () => {
+    render(<Harness providers={[]} />);
+    await settle();
+    expect(currentReason()).toBe("none");
+    expect(readStarPromptState().asked).toBe(0);
+  });
+});

--- a/apps/desktop-tauri/src/hooks/useStarPrompt.test.tsx
+++ b/apps/desktop-tauri/src/hooks/useStarPrompt.test.tsx
@@ -180,4 +180,50 @@ describe("useStarPrompt", () => {
     expect(currentReason()).toBe("none");
     expect(readStarPromptState().asked).toBe(0);
   });
+
+  it("restarts the wait when the reading disappears part-way through it", async () => {
+    // A failed refresh must not bank credit toward the settle period: the next
+    // reading starts its twenty seconds over.
+    const view = render(<Harness providers={[reading()]} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(SETTLE_MS - 2_000);
+    });
+
+    view.rerender(<Harness providers={[]} />);
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+    });
+    view.rerender(<Harness providers={[reading()]} />);
+
+    // The old partial wait plus this one would already be past SETTLE_MS.
+    await act(async () => {
+      vi.advanceTimersByTime(SETTLE_MS - 5_000);
+    });
+    expect(currentReason()).toBe("none");
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(currentReason()).toBe("firstValue");
+  });
+
+  it("does not show an ask it cannot record", async () => {
+    // Storage that will not hold the record means no cap, so no prompt at all
+    // rather than one on every launch.
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("storage disabled");
+      });
+    try {
+      render(<Harness providers={[reading()]} />);
+      await settle();
+      expect(currentReason()).toBe("none");
+    } finally {
+      setItem.mockRestore();
+    }
+  });
 });

--- a/apps/desktop-tauri/src/hooks/useStarPrompt.ts
+++ b/apps/desktop-tauri/src/hooks/useStarPrompt.ts
@@ -64,8 +64,14 @@ export function useStarPrompt(
   }, [enabled]);
 
   const hasReading = enabled && hasRealReading(providers);
-  if (hasReading && readingSinceRef.current == null) {
-    readingSinceRef.current = Date.now();
+  if (hasReading) {
+    readingSinceRef.current ??= Date.now();
+  } else if (reason === null) {
+    // The reading went away before it had settled — a failed refresh, a
+    // provider dropping out. The next one starts its twenty seconds over
+    // rather than inheriting credit from a reading that is no longer there.
+    // Once the card is up this stops applying; see the effect below.
+    readingSinceRef.current = null;
   }
 
   // Re-evaluate on a slow tick so the settle delay can elapse without needing a
@@ -78,6 +84,7 @@ export function useStarPrompt(
 
   useEffect(() => {
     if (!enabled || reason !== null || answeredRef.current) return;
+    if (!version) return;
     const next = starPromptReason({
       state: readStarPromptState(),
       version,
@@ -86,8 +93,11 @@ export function useStarPrompt(
       now: Date.now(),
     });
     if (!next) return;
-    // Count the ask at the moment it becomes visible.
-    recordStarPromptShown(version ?? "", Date.now());
+    // Count the ask before it becomes visible, and only show it if that count
+    // actually persisted. An ask that cannot be recorded is an ask with no cap
+    // on it, so a storage layer that will not hold the record means no prompt
+    // at all rather than one on every launch.
+    if (!recordStarPromptShown(version, Date.now())) return;
     setReason(next);
   }, [enabled, reason, version, hasReading, tick]);
 

--- a/apps/desktop-tauri/src/hooks/useStarPrompt.ts
+++ b/apps/desktop-tauri/src/hooks/useStarPrompt.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getAppInfo, openExternalUrl } from "../lib/tauri";
+import {
+  hasRealReading,
+  readStarPromptState,
+  recordStarPromptShown,
+  recordStarPromptStarred,
+  starPromptReason,
+  type StarPromptReason,
+} from "../lib/starPrompt";
+import type { ProviderUsageSnapshot } from "../types/bridge";
+
+const REPO_URL = "https://github.com/tsouth89/ceiling";
+
+/** How often the settle timer is re-checked. Coarse on purpose; nothing here is urgent. */
+const TICK_MS = 5_000;
+
+export interface StarPromptController {
+  /** Why the prompt is showing, or null when it is not. */
+  reason: StarPromptReason | null;
+  /** App version, for the post-update copy. Empty until `get_app_info` lands. */
+  version: string;
+  onStar: () => void;
+  onDismiss: () => void;
+}
+
+/**
+ * Drives the GitHub star prompt (SOU-311). Reads the eligibility rules in
+ * `starPrompt.ts`, and once the prompt goes up it stays up until the user
+ * answers it — a reading going stale or a provider erroring underneath does not
+ * pull the card out from under a click that is already on its way.
+ *
+ * The ask is counted when the card first appears, not when it is answered, so a
+ * user who closes the window without touching it has still had their first ask.
+ * Anything else would let the same prompt come back every launch, which is the
+ * behaviour this whole feature is trying not to have.
+ */
+export function useStarPrompt(
+  providers: ProviderUsageSnapshot[],
+  /** False in surfaces that must never ask (auxiliary windows, empty states). */
+  enabled = true,
+): StarPromptController {
+  const [version, setVersion] = useState<string | null>(null);
+  const [reason, setReason] = useState<StarPromptReason | null>(null);
+  const [tick, setTick] = useState(0);
+  // First moment this session that a real reading was on screen. The settle
+  // delay is measured from here rather than from mount, so the wait covers the
+  // user actually having numbers to look at and not a spinner.
+  const readingSinceRef = useRef<number | null>(null);
+  const answeredRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    void getAppInfo()
+      .then((info) => {
+        if (!cancelled) setVersion(info.version);
+      })
+      // No version means no prompt, which is the correct way to fail here.
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  const hasReading = enabled && hasRealReading(providers);
+  if (hasReading && readingSinceRef.current == null) {
+    readingSinceRef.current = Date.now();
+  }
+
+  // Re-evaluate on a slow tick so the settle delay can elapse without needing a
+  // provider refresh to happen to land at the right moment.
+  useEffect(() => {
+    if (!enabled || reason !== null || answeredRef.current) return;
+    const timer = window.setInterval(() => setTick((n) => n + 1), TICK_MS);
+    return () => window.clearInterval(timer);
+  }, [enabled, reason]);
+
+  useEffect(() => {
+    if (!enabled || reason !== null || answeredRef.current) return;
+    const next = starPromptReason({
+      state: readStarPromptState(),
+      version,
+      hasReading,
+      readingSince: readingSinceRef.current,
+      now: Date.now(),
+    });
+    if (!next) return;
+    // Count the ask at the moment it becomes visible.
+    recordStarPromptShown(version ?? "", Date.now());
+    setReason(next);
+  }, [enabled, reason, version, hasReading, tick]);
+
+  const onStar = useCallback(() => {
+    answeredRef.current = true;
+    recordStarPromptStarred();
+    setReason(null);
+    // A failed launch still ends the asking. The user answered; Ceiling not
+    // being able to open a browser is not their problem to be reminded about.
+    void openExternalUrl(REPO_URL).catch(() => {});
+  }, []);
+
+  const onDismiss = useCallback(() => {
+    answeredRef.current = true;
+    setReason(null);
+  }, []);
+
+  return { reason, version: version ?? "", onStar, onDismiss };
+}

--- a/apps/desktop-tauri/src/i18n/keys.ts
+++ b/apps/desktop-tauri/src/i18n/keys.ts
@@ -691,6 +691,14 @@ export const ALL_LOCALE_KEYS = [
   "FirstRunOpenDisplay",
   "FirstRunDismiss",
 
+  // GitHub star prompt (SOU-311)
+  "StarPromptAriaLabel",
+  "StarPromptTitleRunning",
+  "StarPromptTitleUpdated",
+  "StarPromptBody",
+  "StarPromptStar",
+  "StarPromptLater",
+
   "StatusConnected",
   "FreshnessStale",
   "FreshnessError",

--- a/apps/desktop-tauri/src/lib/starPrompt.test.ts
+++ b/apps/desktop-tauri/src/lib/starPrompt.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  MAX_ASKS,
+  MIN_GAP_MS,
+  SETTLE_MS,
+  hasRealReading,
+  readStarPromptState,
+  recordStarPromptShown,
+  recordStarPromptStarred,
+  starPromptReason,
+  type StarPromptInput,
+} from "./starPrompt";
+import type { ProviderUsageSnapshot } from "../types/bridge";
+
+const NOW = 1_700_000_000_000;
+
+function input(overrides: Partial<StarPromptInput> = {}): StarPromptInput {
+  return {
+    state: readStarPromptState(),
+    version: "1.5.34",
+    hasReading: true,
+    readingSince: NOW - SETTLE_MS,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+function window(usedPercent: number, remainingPercent: number) {
+  return {
+    usedPercent,
+    remainingPercent,
+    windowMinutes: null,
+    resetsAt: null,
+    resetDescription: null,
+    isExhausted: false,
+    reservePercent: null,
+    reserveDescription: null,
+  };
+}
+
+function snapshot(
+  overrides: Partial<ProviderUsageSnapshot> = {},
+): ProviderUsageSnapshot {
+  return {
+    providerId: "claude",
+    displayName: "Claude",
+    primary: window(0, 100),
+    secondary: null,
+    modelSpecific: null,
+    tertiary: null,
+    extraRateWindows: [],
+    cost: null,
+    planName: null,
+    accountEmail: null,
+    sourceLabel: "test",
+    updatedAt: new Date(NOW).toISOString(),
+    error: null,
+    pace: null,
+    accountOrganization: null,
+    trayStatusLabel: null,
+    ...overrides,
+  } as ProviderUsageSnapshot;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("hasRealReading", () => {
+  it("counts a fresh account sitting at 0% used", () => {
+    // The most common first reading a new user ever sees. Requiring usage
+    // before asking would mean the first ask never fires for a light user.
+    expect(hasRealReading([snapshot({ primary: window(0, 100) })])).toBe(true);
+  });
+
+  it("ignores a provider that errored", () => {
+    expect(
+      hasRealReading([
+        snapshot({ error: "network unreachable", primary: window(0, 100) }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("ignores an enabled provider reporting nothing", () => {
+    expect(hasRealReading([snapshot({ primary: window(0, 0) })])).toBe(false);
+  });
+
+  it("counts a money-only provider with no metered window", () => {
+    expect(
+      hasRealReading([
+        snapshot({
+          primary: window(0, 0),
+          cost: {
+            used: 4.2,
+            limit: null,
+            remaining: null,
+            currencyCode: "USD",
+            period: "month",
+            resetsAt: null,
+            formattedUsed: "$4.20",
+            formattedLimit: null,
+          },
+        }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("is false with no providers at all", () => {
+    expect(hasRealReading([])).toBe(false);
+  });
+});
+
+describe("starPromptReason", () => {
+  it("asks once a real reading has settled", () => {
+    expect(starPromptReason(input())).toBe("firstValue");
+  });
+
+  it("stays quiet while the reading is still new", () => {
+    // The numbers the user opened Ceiling for should be read first.
+    expect(
+      starPromptReason(input({ readingSince: NOW - SETTLE_MS + 1 })),
+    ).toBeNull();
+  });
+
+  it("stays quiet with no reading on screen", () => {
+    expect(
+      starPromptReason(input({ hasReading: false, readingSince: null })),
+    ).toBeNull();
+  });
+
+  it("stays quiet until the app version is known", () => {
+    // Without a version the second ask could not be version-gated, so the
+    // first one is held back rather than risk an ungated repeat.
+    expect(starPromptReason(input({ version: null }))).toBeNull();
+  });
+
+  it("never asks again once the user went to GitHub", () => {
+    recordStarPromptStarred();
+    expect(starPromptReason(input({ state: readStarPromptState() }))).toBeNull();
+  });
+
+  it("never asks a third time", () => {
+    recordStarPromptShown("1.5.30", NOW - 400 * MIN_GAP_MS);
+    recordStarPromptShown("1.5.32", NOW - 200 * MIN_GAP_MS);
+    expect(readStarPromptState().asked).toBe(MAX_ASKS);
+    expect(starPromptReason(input({ state: readStarPromptState() }))).toBeNull();
+  });
+
+  it("asks a second time on a later version after the gap", () => {
+    recordStarPromptShown("1.5.30", NOW - MIN_GAP_MS);
+    expect(starPromptReason(input({ state: readStarPromptState() }))).toBe(
+      "afterUpdate",
+    );
+  });
+
+  it("does not ask again on the same version", () => {
+    recordStarPromptShown("1.5.34", NOW - 10 * MIN_GAP_MS);
+    expect(starPromptReason(input({ state: readStarPromptState() }))).toBeNull();
+  });
+
+  it("does not ask again the day after the first ask, even on a new version", () => {
+    // A version bump alone is not consent to be asked twice in one week.
+    recordStarPromptShown("1.5.30", NOW - 24 * 60 * 60 * 1000);
+    expect(starPromptReason(input({ state: readStarPromptState() }))).toBeNull();
+  });
+
+  it("treats a corrupt record as a fresh install rather than repairing it", () => {
+    localStorage.setItem("ceiling.star-prompt.v1", "{not json");
+    expect(readStarPromptState()).toEqual({
+      asked: 0,
+      starred: false,
+      lastAskedVersion: null,
+      lastAskedAt: null,
+    });
+  });
+
+  it("holds back the second ask when the first has no timestamp", () => {
+    // An older record, or one written by a build that did not stamp the time:
+    // unknown gap is treated as too soon.
+    localStorage.setItem(
+      "ceiling.star-prompt.v1",
+      JSON.stringify({ asked: 1, starred: false, lastAskedVersion: "1.5.30" }),
+    );
+    expect(starPromptReason(input({ state: readStarPromptState() }))).toBeNull();
+  });
+});
+
+describe("recordStarPromptShown", () => {
+  it("carries the starred flag through a later ask being recorded", () => {
+    recordStarPromptStarred();
+    recordStarPromptShown("1.5.34", NOW);
+    expect(readStarPromptState().starred).toBe(true);
+  });
+});

--- a/apps/desktop-tauri/src/lib/starPrompt.test.ts
+++ b/apps/desktop-tauri/src/lib/starPrompt.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   MAX_ASKS,
   MIN_GAP_MS,
   SETTLE_MS,
   hasRealReading,
+  isLaterVersion,
   readStarPromptState,
   recordStarPromptShown,
   recordStarPromptStarred,
@@ -153,6 +154,26 @@ describe("starPromptReason", () => {
     );
   });
 
+  it("does not ask again after a downgrade", () => {
+    // Rolling back to an older build is not an update, and must not be spent
+    // as one.
+    recordStarPromptShown("1.5.40", NOW - 10 * MIN_GAP_MS);
+    expect(
+      starPromptReason(input({ state: readStarPromptState(), version: "1.5.39" })),
+    ).toBeNull();
+  });
+
+  it("does not ask again when either version is not a plain triplet", () => {
+    // A prerelease or locally built version cannot be ordered, so it is not
+    // treated as a later release.
+    recordStarPromptShown("1.5.30", NOW - 10 * MIN_GAP_MS);
+    expect(
+      starPromptReason(
+        input({ state: readStarPromptState(), version: "1.5.34-rc.1" }),
+      ),
+    ).toBeNull();
+  });
+
   it("does not ask again on the same version", () => {
     recordStarPromptShown("1.5.34", NOW - 10 * MIN_GAP_MS);
     expect(starPromptReason(input({ state: readStarPromptState() }))).toBeNull();
@@ -164,13 +185,46 @@ describe("starPromptReason", () => {
     expect(starPromptReason(input({ state: readStarPromptState() }))).toBeNull();
   });
 
-  it("treats a corrupt record as a fresh install rather than repairing it", () => {
+  it("never asks on a corrupt record", () => {
+    // A record we cannot read may already say "asked twice" or "starred".
+    // Zeroing it would turn the lifetime cap into an ask on every launch.
     localStorage.setItem("ceiling.star-prompt.v1", "{not json");
+    expect(readStarPromptState().unreadable).toBe(true);
+    expect(starPromptReason(input({ state: readStarPromptState() }))).toBeNull();
+  });
+
+  it("never asks on a record with a field of the wrong type", () => {
+    localStorage.setItem(
+      "ceiling.star-prompt.v1",
+      JSON.stringify({ asked: "1", starred: false }),
+    );
+    expect(readStarPromptState().unreadable).toBe(true);
+    expect(starPromptReason(input({ state: readStarPromptState() }))).toBeNull();
+  });
+
+  it("never asks when storage itself cannot be read", () => {
+    const getItem = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("storage disabled");
+      });
+    try {
+      expect(readStarPromptState().unreadable).toBe(true);
+      expect(
+        starPromptReason(input({ state: readStarPromptState() })),
+      ).toBeNull();
+    } finally {
+      getItem.mockRestore();
+    }
+  });
+
+  it("still treats a missing key as a fresh install", () => {
     expect(readStarPromptState()).toEqual({
       asked: 0,
       starred: false,
       lastAskedVersion: null,
       lastAskedAt: null,
+      unreadable: false,
     });
   });
 
@@ -185,10 +239,52 @@ describe("starPromptReason", () => {
   });
 });
 
+describe("isLaterVersion", () => {
+  it("orders plain triplets by release order, not string order", () => {
+    expect(isLaterVersion("1.5.34", "1.5.9")).toBe(true);
+    expect(isLaterVersion("1.10.0", "1.9.9")).toBe(true);
+    expect(isLaterVersion("1.5.29", "1.5.30")).toBe(false);
+    expect(isLaterVersion("1.5.34", "1.5.34")).toBe(false);
+  });
+
+  it("refuses to order anything that is not a plain triplet", () => {
+    expect(isLaterVersion("1.5.34-rc.1", "1.5.30")).toBeNull();
+    expect(isLaterVersion("1.5.34", "dev")).toBeNull();
+    expect(isLaterVersion("1.5", "1.4")).toBeNull();
+  });
+});
+
 describe("recordStarPromptShown", () => {
   it("carries the starred flag through a later ask being recorded", () => {
     recordStarPromptStarred();
     recordStarPromptShown("1.5.34", NOW);
     expect(readStarPromptState().starred).toBe(true);
+  });
+
+  it("reports failure when the record cannot be persisted", () => {
+    // The caller must not show an ask it cannot count.
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("quota exceeded");
+      });
+    try {
+      expect(recordStarPromptShown("1.5.34", NOW)).toBe(false);
+    } finally {
+      setItem.mockRestore();
+    }
+  });
+
+  it("reports failure when a write is silently dropped", () => {
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {});
+    try {
+      // Nothing was stored, so the read back finds no record and the write
+      // cannot be confirmed.
+      expect(recordStarPromptShown("1.5.34", NOW)).toBe(false);
+    } finally {
+      setItem.mockRestore();
+    }
   });
 });

--- a/apps/desktop-tauri/src/lib/starPrompt.ts
+++ b/apps/desktop-tauri/src/lib/starPrompt.ts
@@ -52,6 +52,14 @@ export interface StarPromptState {
   lastAskedVersion: string | null;
   /** Epoch ms of the last ask, for MIN_GAP_MS. */
   lastAskedAt: number | null;
+  /**
+   * The record exists but could not be read or trusted. Terminal, and the
+   * reason a failed read cannot just return a zeroed state: a record we cannot
+   * read may already say "asked twice" or "starred", and a storage layer that
+   * keeps throwing would hand back that zeroed state on every launch, turning
+   * a two-ask lifetime cap into an ask every time the app starts.
+   */
+  unreadable: boolean;
 }
 
 const EMPTY: StarPromptState = {
@@ -59,53 +67,95 @@ const EMPTY: StarPromptState = {
   starred: false,
   lastAskedVersion: null,
   lastAskedAt: null,
+  unreadable: false,
 };
 
+const UNREADABLE: StarPromptState = { ...EMPTY, unreadable: true };
+
+/** A field is acceptable when it is absent entirely, or is the type it should be. */
+function optional(value: unknown, check: (v: unknown) => boolean): boolean {
+  return value === undefined || value === null || check(value);
+}
+
 /**
- * Read the stored state. Anything malformed is treated as a fresh install
- * rather than repaired: the only cost is one extra ask over the app's life,
- * and guessing at a half-written record risks the opposite.
+ * Read the stored state. A missing key is the only fresh-install case;
+ * anything present but unreadable fails closed rather than being repaired or
+ * zeroed, because a half-written record cannot tell us whether the user has
+ * already been asked or has already starred.
  */
 export function readStarPromptState(): StarPromptState {
+  let raw: string | null;
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return { ...EMPTY };
-    const parsed = JSON.parse(raw) as Partial<StarPromptState>;
-    return {
-      asked:
-        typeof parsed.asked === "number" && Number.isFinite(parsed.asked)
-          ? Math.max(0, Math.trunc(parsed.asked))
-          : 0,
-      starred: parsed.starred === true,
-      lastAskedVersion:
-        typeof parsed.lastAskedVersion === "string"
-          ? parsed.lastAskedVersion
-          : null,
-      lastAskedAt:
-        typeof parsed.lastAskedAt === "number" &&
-        Number.isFinite(parsed.lastAskedAt)
-          ? parsed.lastAskedAt
-          : null,
-    };
+    raw = localStorage.getItem(STORAGE_KEY);
   } catch {
-    return { ...EMPTY };
+    // Storage is unavailable (private mode, disabled storage). Nothing can be
+    // recorded either, so asking would repeat on every launch.
+    return { ...UNREADABLE };
   }
+  if (raw === null) return { ...EMPTY };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ...UNREADABLE };
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { ...UNREADABLE };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const { asked, starred, lastAskedVersion, lastAskedAt } = record;
+  const wellFormed =
+    optional(
+      asked,
+      (v) => typeof v === "number" && Number.isFinite(v) && v >= 0,
+    ) &&
+    optional(starred, (v) => typeof v === "boolean") &&
+    optional(lastAskedVersion, (v) => typeof v === "string") &&
+    optional(lastAskedAt, (v) => typeof v === "number" && Number.isFinite(v));
+  if (!wellFormed) return { ...UNREADABLE };
+
+  return {
+    asked: typeof asked === "number" ? Math.trunc(asked) : 0,
+    starred: starred === true,
+    lastAskedVersion:
+      typeof lastAskedVersion === "string" ? lastAskedVersion : null,
+    lastAskedAt: typeof lastAskedAt === "number" ? lastAskedAt : null,
+    unreadable: false,
+  };
 }
 
-function writeStarPromptState(state: StarPromptState): void {
+/** Write the record and confirm it survived. False means it did not persist. */
+function writeStarPromptState(state: StarPromptState): boolean {
+  const { unreadable: _unreadable, ...persisted } = state;
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted));
   } catch {
-    // Storage can be unavailable (private mode, disabled storage). Losing the
-    // record means at most one extra ask later, which is the safe direction to
-    // fail in; it is not worth surfacing to the user.
+    return false;
   }
+  // Read the record back and compare rather than trust the write. A storage
+  // layer that accepts a `setItem` and drops it would otherwise leave an ask
+  // shown but uncounted, which is an ask that comes back on every launch.
+  const back = readStarPromptState();
+  return (
+    !back.unreadable &&
+    back.asked === persisted.asked &&
+    back.starred === persisted.starred &&
+    back.lastAskedVersion === persisted.lastAskedVersion &&
+    back.lastAskedAt === persisted.lastAskedAt
+  );
 }
 
-/** Record that an ask was shown. Called once, when the toast first appears. */
-export function recordStarPromptShown(version: string, now: number): void {
+/**
+ * Record that an ask is about to be shown. Returns false when the record did
+ * not persist, in which case the caller must not show the prompt: an ask that
+ * cannot be counted is an ask with no cap on it.
+ */
+export function recordStarPromptShown(version: string, now: number): boolean {
   const state = readStarPromptState();
-  writeStarPromptState({
+  if (state.unreadable) return false;
+  return writeStarPromptState({
     ...state,
     asked: state.asked + 1,
     lastAskedVersion: version,
@@ -115,7 +165,35 @@ export function recordStarPromptShown(version: string, now: number): void {
 
 /** Record that the user clicked through to GitHub. Ends all future asks. */
 export function recordStarPromptStarred(): void {
-  writeStarPromptState({ ...readStarPromptState(), starred: true });
+  const state = readStarPromptState();
+  // An unreadable record already blocks every future ask, so there is nothing
+  // to preserve and overwriting it would be guessing at the counts.
+  if (state.unreadable) return;
+  writeStarPromptState({ ...state, starred: true });
+}
+
+/**
+ * Compare two `X.Y.Z` versions. Null when either side is not a plain triplet,
+ * which is what a prerelease or a locally built version string looks like, and
+ * which the caller treats as "do not ask".
+ */
+export function isLaterVersion(
+  version: string,
+  previous: string,
+): boolean | null {
+  const next = parseTriplet(version);
+  const prior = parseTriplet(previous);
+  if (!next || !prior) return null;
+  for (let i = 0; i < 3; i += 1) {
+    if (next[i] !== prior[i]) return next[i] > prior[i];
+  }
+  return false;
+}
+
+function parseTriplet(version: string): [number, number, number] | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version.trim());
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
 /**
@@ -160,6 +238,7 @@ export function starPromptReason({
   readingSince,
   now,
 }: StarPromptInput): StarPromptReason | null {
+  if (state.unreadable) return null;
   if (state.starred) return null;
   if (state.asked >= MAX_ASKS) return null;
   // Without a version there is no way to honour the version-bump gate on the
@@ -172,7 +251,10 @@ export function starPromptReason({
 
   // Second ask: a genuinely later version, and not hard on the heels of the
   // first. A missing timestamp on a prior ask is treated as "too soon".
-  if (state.lastAskedVersion === version) return null;
+  if (state.lastAskedVersion == null) return null;
+  // Later by release order, not merely different: rolling back to an older
+  // build is not an update, and must not spend the second ask.
+  if (isLaterVersion(version, state.lastAskedVersion) !== true) return null;
   if (state.lastAskedAt == null) return null;
   if (now - state.lastAskedAt < MIN_GAP_MS) return null;
   return "afterUpdate";

--- a/apps/desktop-tauri/src/lib/starPrompt.ts
+++ b/apps/desktop-tauri/src/lib/starPrompt.ts
@@ -1,0 +1,179 @@
+import type { ProviderUsageSnapshot } from "../types/bridge";
+
+/**
+ * One-off GitHub star prompt (SOU-311).
+ *
+ * The whole point of this file is restraint. An ask that shows up twice and
+ * then never again is a nudge; the same ask on a timer is spam, and spam from
+ * a tray app that people keep open all day is worse than not asking at all.
+ * The rules below are therefore all upper bounds, and every one of them fails
+ * closed: an unreadable store, a missing version, a reading we are not sure
+ * about — each returns "do not ask" rather than "ask anyway".
+ *
+ * Two asks, ever:
+ *   1. The first time Ceiling shows a real reading, which is the first moment
+ *      it has actually done anything for the user. Asking during onboarding
+ *      would be asking before the app has earned it.
+ *   2. Once after a later version has been running, and only if the first ask
+ *      went unanswered. A version bump alone is not enough — see MIN_GAP_MS.
+ *
+ * Clicking through to GitHub ends it for good, whether or not the star
+ * actually happened. Ceiling cannot see the user's GitHub identity and is not
+ * going to ask for it, so intent is the only signal available and the honest
+ * thing to do is treat it as final.
+ */
+
+const STORAGE_KEY = "ceiling.star-prompt.v1";
+
+/** Hard ceiling on lifetime asks. Not a tunable. */
+export const MAX_ASKS = 2;
+
+/**
+ * Floor between the two asks. Without it, a user who updates the day after
+ * their first ask gets the second one immediately, which reads as nagging even
+ * though the lifetime count is still honoured.
+ */
+export const MIN_GAP_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * How long a real reading must have been on screen before the first ask. Long
+ * enough that the numbers, not the prompt, are the first thing the user reads.
+ */
+export const SETTLE_MS = 20_000;
+
+export type StarPromptReason = "firstValue" | "afterUpdate";
+
+export interface StarPromptState {
+  /** Lifetime count of asks actually shown. */
+  asked: number;
+  /** The user clicked through to GitHub. Terminal. */
+  starred: boolean;
+  /** App version the last ask was shown under, for the version-bump gate. */
+  lastAskedVersion: string | null;
+  /** Epoch ms of the last ask, for MIN_GAP_MS. */
+  lastAskedAt: number | null;
+}
+
+const EMPTY: StarPromptState = {
+  asked: 0,
+  starred: false,
+  lastAskedVersion: null,
+  lastAskedAt: null,
+};
+
+/**
+ * Read the stored state. Anything malformed is treated as a fresh install
+ * rather than repaired: the only cost is one extra ask over the app's life,
+ * and guessing at a half-written record risks the opposite.
+ */
+export function readStarPromptState(): StarPromptState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...EMPTY };
+    const parsed = JSON.parse(raw) as Partial<StarPromptState>;
+    return {
+      asked:
+        typeof parsed.asked === "number" && Number.isFinite(parsed.asked)
+          ? Math.max(0, Math.trunc(parsed.asked))
+          : 0,
+      starred: parsed.starred === true,
+      lastAskedVersion:
+        typeof parsed.lastAskedVersion === "string"
+          ? parsed.lastAskedVersion
+          : null,
+      lastAskedAt:
+        typeof parsed.lastAskedAt === "number" &&
+        Number.isFinite(parsed.lastAskedAt)
+          ? parsed.lastAskedAt
+          : null,
+    };
+  } catch {
+    return { ...EMPTY };
+  }
+}
+
+function writeStarPromptState(state: StarPromptState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Storage can be unavailable (private mode, disabled storage). Losing the
+    // record means at most one extra ask later, which is the safe direction to
+    // fail in; it is not worth surfacing to the user.
+  }
+}
+
+/** Record that an ask was shown. Called once, when the toast first appears. */
+export function recordStarPromptShown(version: string, now: number): void {
+  const state = readStarPromptState();
+  writeStarPromptState({
+    ...state,
+    asked: state.asked + 1,
+    lastAskedVersion: version,
+    lastAskedAt: now,
+  });
+}
+
+/** Record that the user clicked through to GitHub. Ends all future asks. */
+export function recordStarPromptStarred(): void {
+  writeStarPromptState({ ...readStarPromptState(), starred: true });
+}
+
+/**
+ * True when a snapshot represents a reading the user can act on, as opposed to
+ * a provider that is enabled but errored, signed out, or reporting nothing.
+ *
+ * A fresh account sitting at 0% used still counts: 100% remaining is a real
+ * answer to "how much is left", and it is the answer most new users see first.
+ * What does not count is the both-zero shape, which is what an unavailable
+ * window looks like once it reaches this layer.
+ */
+export function hasRealReading(providers: ProviderUsageSnapshot[]): boolean {
+  return providers.some((provider) => {
+    if (provider.error) return false;
+    const { usedPercent, remainingPercent } = provider.primary;
+    if (usedPercent > 0 || remainingPercent > 0) return true;
+    // A provider that reports only money (no metered window) is still a real
+    // reading; Cursor on-demand and the local cost scanners land here.
+    return provider.cost != null;
+  });
+}
+
+export interface StarPromptInput {
+  state: StarPromptState;
+  /** Current app version, or null while `get_app_info` is still in flight. */
+  version: string | null;
+  /** Whether a real reading is on screen right now. */
+  hasReading: boolean;
+  /** Epoch ms at which a real reading was first seen this session. */
+  readingSince: number | null;
+  now: number;
+}
+
+/**
+ * Decide whether to show the prompt, and why. `null` means stay quiet, which
+ * is the answer for every case this function is not certain about.
+ */
+export function starPromptReason({
+  state,
+  version,
+  hasReading,
+  readingSince,
+  now,
+}: StarPromptInput): StarPromptReason | null {
+  if (state.starred) return null;
+  if (state.asked >= MAX_ASKS) return null;
+  // Without a version there is no way to honour the version-bump gate on the
+  // second ask, so nothing is shown rather than risk a repeat.
+  if (!version) return null;
+  if (!hasReading || readingSince == null) return null;
+  if (now - readingSince < SETTLE_MS) return null;
+
+  if (state.asked === 0) return "firstValue";
+
+  // Second ask: a genuinely later version, and not hard on the heels of the
+  // first. A missing timestamp on a prior ask is treated as "too soon".
+  if (state.lastAskedVersion === version) return null;
+  if (state.lastAskedAt == null) return null;
+  if (now - state.lastAskedAt < MIN_GAP_MS) return null;
+  return "afterUpdate";
+}

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -9863,6 +9863,128 @@ body:has(.dashboard-shell) #root {
   opacity: 0.9;
 }
 
+/* ── GitHub star prompt (SOU-311) ──────────────────────────────────── */
+
+/* Anchored to the window rather than to the panel so the tray surface's `zoom`
+   does not scale it: this is chrome over the dashboard, not part of it. It sits
+   below .confirm-dialog-backdrop (z-index 80) because a confirmation the user
+   asked for always outranks a favour Ceiling is asking of them. */
+.star-prompt {
+  position: fixed;
+  right: 14px;
+  bottom: 14px;
+  z-index: 60;
+  width: min(320px, calc(100vw - 28px));
+  padding: 14px 16px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--provider-icon-ring, rgba(255, 255, 255, 0.08));
+  background: var(--ceiling-panel-bg);
+  color: var(--text-primary);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.star-prompt__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+/* Ring plus tick, drawn rather than shipped as an asset so it follows the
+   theme's success color the way every other confirmation mark does. */
+.star-prompt__check {
+  position: relative;
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1.5px solid var(--status-success-text, #5eead4);
+}
+.star-prompt__check::after {
+  content: "";
+  position: absolute;
+  left: 5px;
+  top: 2px;
+  width: 4px;
+  height: 8px;
+  border: solid var(--status-success-text, #5eead4);
+  border-width: 0 1.5px 1.5px 0;
+  transform: rotate(45deg);
+}
+
+.star-prompt__title {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  font-size: 0.92rem;
+  font-weight: 650;
+  color: var(--text-primary);
+}
+
+.star-prompt__close {
+  appearance: none;
+  flex: 0 0 auto;
+  background: none;
+  border: none;
+  padding: 2px 4px;
+  font: inherit;
+  font-size: 0.8rem;
+  line-height: 1;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.star-prompt__close:hover {
+  color: var(--text-primary);
+}
+
+.star-prompt__body {
+  margin: 0 0 12px;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.star-prompt__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.star-prompt__action {
+  appearance: none;
+  flex: 1 1 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--provider-icon-ring, rgba(255, 255, 255, 0.1));
+  background: var(--provider-row-bg, rgba(255, 255, 255, 0.04));
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+.star-prompt__action:hover {
+  opacity: 0.9;
+}
+
+/* The star is the action being asked for, so it carries the accent. Kept as a
+   tinted fill and ring rather than a solid accent button: this is an optional
+   favour sitting on top of someone's data, and it should not shout louder than
+   the numbers underneath it. */
+.star-prompt__action--primary {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: var(--accent);
+}
+
+.star-prompt__star {
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
 /* ── Config-directory accounts (SOU-285) ───────────────────────────── */
 
 /* Which account a card is reporting, tinted when the account has a color set.

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
@@ -30,6 +30,9 @@ const tauriMocks = vi.hoisted(() => ({
   getCurrentSurfaceState: vi.fn(),
   getLocaleStrings: vi.fn(),
   setUiLanguage: vi.fn(),
+  // Used by the star prompt (SOU-311); resolved in beforeEach.
+  getAppInfo: vi.fn(),
+  openExternalUrl: vi.fn(),
 }));
 
 const eventMocks = vi.hoisted(() => ({
@@ -197,6 +200,18 @@ describe("TrayPanel provider grid", () => {
     vi.clearAllMocks();
     eventMocks.listeners.clear();
     tauriMocks.flyoutStoredSize.mockResolvedValue(null);
+    // The star prompt (SOU-311) reads the version on mount. Its settle
+    // delay and the cleared localStorage keep it off screen here, but the
+    // call still has to resolve or the effect rejects mid-render.
+    tauriMocks.getAppInfo.mockResolvedValue({
+      name: "Ceiling",
+      version: "1.5.34",
+      buildNumber: "1",
+      updateChannel: "stable",
+      tagline: "",
+    });
+    tauriMocks.openExternalUrl.mockResolvedValue(undefined);
+    localStorage.clear();
     tauriMocks.refreshProviders.mockResolvedValue(undefined);
     tauriMocks.refreshProvidersIfStale.mockResolvedValue(undefined);
     tauriMocks.dismissTrayPanel.mockResolvedValue(undefined);

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
@@ -41,6 +41,8 @@ import {
   orderedEnabledProviderSlots,
 } from "../lib/trayProviders";
 import AgentSessions from "../components/AgentSessions";
+import StarPrompt from "../components/StarPrompt";
+import { useStarPrompt } from "../hooks/useStarPrompt";
 
 /** Provider IDs that have a dashboard URL in the backend */
 const HAS_DASHBOARD = new Set([
@@ -434,6 +436,18 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
   const handleGestureEnd = useCallback(() => {
     void endFlyoutGesture().catch(() => {});
   }, []);
+  // Asks for a GitHub star, at most twice ever (SOU-311). Gated on a real
+  // reading, so the empty state below never sees it.
+  const starPrompt = useStarPrompt(sorted);
+  const starPromptCard =
+    starPrompt.reason !== null ? (
+      <StarPrompt
+        reason={starPrompt.reason}
+        version={starPrompt.version}
+        onStar={starPrompt.onStar}
+        onDismiss={starPrompt.onDismiss}
+      />
+    ) : null;
   const banner = (
     <UpdateBanner
       updateState={updateState}
@@ -587,6 +601,7 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
           </div>
         )}
       </MenuSurface>
+      {starPromptCard}
       <TrayResizeHandles />
     </div>
   );

--- a/rust/src/locale.rs
+++ b/rust/src/locale.rs
@@ -941,6 +941,14 @@ locale_keys! {
     FirstRunOpenDisplay,
     FirstRunDismiss,
 
+    // GitHub star prompt (SOU-311)
+    StarPromptAriaLabel,
+    StarPromptTitleRunning,
+    StarPromptTitleUpdated,
+    StarPromptBody,
+    StarPromptStar,
+    StarPromptLater,
+
     // Leftover English (SBS-156)
     StatusConnected,
     FreshnessStale,

--- a/rust/src/locale/en-US.ftl
+++ b/rust/src/locale/en-US.ftl
@@ -659,6 +659,14 @@ FirstRunOpenProviders = Open provider settings
 FirstRunOpenDisplay = Open display settings
 FirstRunDismiss = Dismiss
 
+# GitHub star prompt (SOU-311)
+StarPromptAriaLabel = Star Ceiling on GitHub
+StarPromptTitleRunning = Ceiling is up and running
+StarPromptTitleUpdated = Updated to
+StarPromptBody = If Ceiling is useful to you, a GitHub star helps other developers find it.
+StarPromptStar = Star on GitHub
+StarPromptLater = Later
+
 # Config-directory accounts (SOU-285)
 SectionAccounts = Accounts
 AccountsIntro = Every account listed here is tracked, and each one gets its own bars. Add a config directory to track another.

--- a/rust/src/locale/zh-CN.ftl
+++ b/rust/src/locale/zh-CN.ftl
@@ -659,6 +659,14 @@ FirstRunOpenProviders = 打开服务商设置
 FirstRunOpenDisplay = 打开显示设置
 FirstRunDismiss = 忽略
 
+# GitHub star prompt (SOU-311)
+StarPromptAriaLabel = 在 GitHub 上给 Ceiling 加星
+StarPromptTitleRunning = Ceiling 已开始运行
+StarPromptTitleUpdated = 已更新到
+StarPromptBody = 如果 Ceiling 对你有用，在 GitHub 上加星可以帮助更多开发者发现它。
+StarPromptStar = 在 GitHub 上加星
+StarPromptLater = 以后再说
+
 # Config-directory accounts (SOU-285)
 SectionAccounts = 账户
 AccountsIntro = 此处列出的每个账户都会被跟踪，并各自拥有独立的用量条。添加一个配置目录以跟踪另一个账户。


### PR DESCRIPTION
## Summary

Adds a one-off GitHub star ask to the dashboard, in the bottom-right, styled after the Orca prompt. The whole design goal was that it must not be annoying, so every rule is an upper bound and every uncertain case resolves to "stay quiet".

**Two asks, ever.**

1. **First ask** fires once a provider has reported a real reading and that reading has been on screen for 20 seconds. Not during onboarding: asking a new user before Ceiling has shown them anything is asking to be paid before the work.
2. **Second ask** only if the first went unanswered, and only when a *later version* has shipped *and* a week has passed since the first. A version bump the day after the first ask is still two asks in one week.

Anything else stays quiet. Clicking through to GitHub ends the asking permanently, whether or not a star actually happened (Ceiling cannot see the user's GitHub identity and is not going to ask for it, so intent is the only honest signal). `Later`, the `✕`, and `Escape` are the same action and never count as interest.

**Not a Windows notification and not a modal.** No backdrop, no focus trap, and focus is left where the user put it. It sits over the corner of a panel someone opened to read a number; taking the keyboard away from them to ask a favour would be the rudest version of this feature. It stays until answered because a nudge that fades out unread would only have to be shown again, which is the repetition the two-ask cap exists to prevent.

The only network call is `open_external_url` on the repo, and only when the user clicks Star.

## What is where

- `src/lib/starPrompt.ts` — eligibility rules and the localStorage record. Pure, and fails closed: an unreadable record, a missing app version, or an uncertain reading all return "do not ask". A corrupt record is treated as a fresh install rather than repaired, since the worst case is one extra ask over the app's life and guessing at a half-written record risks the opposite.
- `src/hooks/useStarPrompt.ts` — drives it. The ask is counted when the card *appears*, not when it is answered, so closing the window without touching it still spends the ask. Anything else would bring the same prompt back every launch.
- `src/components/StarPrompt.tsx` — the card.
- Wired into `TrayPanel` only, and only in the populated branch, so the empty state never sees it.

## Screenshot

Both themes, card over the dashboard:

_Shared with the author alongside this PR._

## Commands run

- `npx vitest run` — 88 files, 682 tests, all pass (31 of them new)
- `npx tsc --noEmit` — clean
- `node scripts/check-locale-drift.mjs` — OK, 791 keys match across Rust/TS/FTL
- `node scripts/check-no-glow.mjs` — OK, 68 box-shadow rules
- `node scripts/check-native-controls.mjs` — OK
- `cargo test` (rust) — 1077 + 22 pass
- `cargo fmt --all -- --check` — clean

Locale keys added to `keys.ts`, `locale.rs`, `en-US.ftl` and `zh-CN.ftl`.

https://claude.ai/code/session_01HzmjVHiMVV2woGm3RqU5eK


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a GitHub star prompt to the tray panel that appears at most twice ever
> - Adds a non-modal bottom-right card ([StarPrompt.tsx](https://github.com/tsouth89/ceiling/pull/332/files#diff-367cc999dae9e375fbf068bfb13d702ac98a043d941a12266bab3c53fca28e40)) rendered in [TrayPanel.tsx](https://github.com/tsouth89/ceiling/pull/332/files#diff-0d21cd90a13849d1a226cc774d9a59741c90ee183075939c22d2b4b85171684d) with "Star on GitHub" and "Later" actions.
> - The [useStarPrompt](https://github.com/tsouth89/ceiling/pull/332/files#diff-3d3cd1aa3a0c0cf86435b5af407c9e5515ff4d40067f28f9e6db3054619b1f76) hook gates display on a real reading being present for 20 seconds, caps lifetime asks at 2, enforces a 7-day minimum gap between asks, and version-gates the second ask.
> - Persistence logic in [lib/starPrompt.ts](https://github.com/tsouth89/ceiling/pull/332/files#diff-cbdbb64f9c063c323cd59bc8417b03f0c82730bf0198d3a67f6a6666a2324814) is failure-closed: any unreadable or unwritable storage state permanently suppresses the prompt.
> - Escape is captured in the capture phase to dismiss the prompt without propagating to other window-level handlers; focus is not moved or trapped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8b6316.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a localized GitHub star prompt for eligible users after a settled provider reading or app update.
  * Users can open the project page to star it or dismiss the prompt, including via the close button or Escape key.
  * Prompt behavior respects response history, version changes, timing limits, and accessibility requirements.
  * Added English and Chinese translations.

* **Documentation**
  * Documented the GitHub star prompt behavior in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->