### PR TITLE
Reject Charts custom ranges that start more than a year back

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -1188,6 +1188,12 @@ fn parse_api_value_custom_range(
             "Custom range can span at most {API_VALUE_CUSTOM_MAX_DAYS} days."
         ));
     }
+    let start_age_days = (today - start).num_days() + 1;
+    if start_age_days > API_VALUE_CUSTOM_MAX_DAYS {
+        return Err(format!(
+            "Custom range must start within the last {API_VALUE_CUSTOM_MAX_DAYS} days."
+        ));
+    }
     // Inclusive end day → [start midnight, day-after-end midnight).
     Ok((
         local_midnight_utc(start),
@@ -1212,7 +1218,6 @@ fn load_local_api_value_totals(
             let start_date = start.with_timezone(&Local).date_naive();
             let days = (today - start_date).num_days().max(0) as u32 + 1;
             days.max(API_VALUE_DEFAULT_SCAN_DAYS)
-                .min(API_VALUE_CUSTOM_MAX_DAYS as u32)
         })
         .unwrap_or(API_VALUE_DEFAULT_SCAN_DAYS);
     scan_providers_parallel(&API_VALUE_PROVIDERS, |provider_id| {
@@ -3780,6 +3785,11 @@ mod tests {
         assert!(parse_api_value_custom_range("2026-07-10", "2026-07-01", today).is_err());
         assert!(parse_api_value_custom_range("2026-07-01", "2026-08-01", today).is_err());
         assert!(parse_api_value_custom_range("not-a-date", "2026-07-01", today).is_err());
+        // Span is legal (214 days) but the start is more than 366 days ago, so
+        // the old scan clamp would have silently truncated June/July 2025.
+        let later = NaiveDate::from_ymd_opt(2026, 8, 18).unwrap();
+        assert!(parse_api_value_custom_range("2025-06-01", "2025-12-31", later).is_err());
+        assert!(parse_api_value_custom_range("2025-08-20", "2025-12-31", later).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Reject a custom Estimated API value range whose start is more than 366 days before today, instead of scanning a shorter window and displaying that truncated sum as complete.
- Drop the silent scan-day clamp so an accepted range cannot be shortened behind the card's back.

Fixes SBS-942.

## Test plan
- [x] `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml parse_api_value_custom_range`
- [ ] Charts custom range 2025-08-20–2025-12-31 still works; 2025-06-01–2025-12-31 errors


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject Charts custom date ranges starting more than a year in the past
> - `parse_api_value_custom_range` in [chart.rs](https://github.com/tsouth89/ceiling/pull/334/files#diff-dd7afa22800a23cd5d615302c3cea0603e1c29fe1e777943eb5f4e6acd7e2afe) now returns an error if the start date is more than `API_VALUE_CUSTOM_MAX_DAYS` days before today, even when the span length is within limits.
> - `load_local_api_value_totals` removes the explicit `scan_days` cap at `API_VALUE_CUSTOM_MAX_DAYS` for custom ranges, since the new start-age validation makes it redundant.
> - Behavioral Change: previously, a custom range with a valid span but an old start date was accepted; it is now rejected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f91f1c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->