### PR TITLE
Rotate a leaked serve token instead of chmodding it

### DIFF
--- a/rust/src/cli/serve.rs
+++ b/rust/src/cli/serve.rs
@@ -447,6 +447,18 @@ fn load_or_create_serve_token_at(path: PathBuf) -> io::Result<ServeToken> {
 }
 
 fn read_existing_serve_token(path: PathBuf) -> io::Result<ServeToken> {
+    // Stat before chmod. A token that was world-readable is already leaked;
+    // tightening the mode cannot un-expose it, so treat it as invalid and let
+    // the caller mint a replacement.
+    #[cfg(unix)]
+    {
+        if serve_token_mode_is_too_open(&path)? {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "serve token file is readable by other users",
+            ));
+        }
+    }
     let token = std::fs::read_to_string(&path)?;
     let token = token.trim();
     if token.is_empty() {
@@ -492,9 +504,7 @@ fn create_new_serve_token(path: &Path) -> io::Result<String> {
 fn validate_existing_token_file(path: &Path) -> io::Result<()> {
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let mode = std::fs::metadata(path)?.permissions().mode() & 0o777;
-        if mode & 0o077 != 0 {
+        if serve_token_mode_is_too_open(path)? {
             return Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
                 "serve token file is readable by other users",
@@ -503,6 +513,13 @@ fn validate_existing_token_file(path: &Path) -> io::Result<()> {
     }
     let _ = path;
     Ok(())
+}
+
+#[cfg(unix)]
+fn serve_token_mode_is_too_open(path: &Path) -> io::Result<bool> {
+    use std::os::unix::fs::PermissionsExt;
+    let mode = std::fs::metadata(path)?.permissions().mode() & 0o777;
+    Ok(mode & 0o077 != 0)
 }
 
 fn protect_token_file(path: &std::path::Path) -> io::Result<()> {
@@ -642,6 +659,28 @@ mod tests {
         assert!(loaded.created);
         assert!(!loaded.token.is_empty());
         assert_eq!(std::fs::read_to_string(&path).unwrap().trim(), loaded.token);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rotates_a_world_readable_serve_token_instead_of_reusing_it() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!(
+            "ceiling-serve-token-open-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("serve.token");
+        std::fs::write(&path, "leaked-token\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let loaded = load_or_create_serve_token_at(path.clone()).unwrap();
+        assert!(loaded.created);
+        assert_ne!(loaded.token, "leaked-token");
+        assert_eq!(std::fs::read_to_string(&path).unwrap().trim(), loaded.token);
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
         let _ = std::fs::remove_dir_all(dir);
     }
 


### PR DESCRIPTION
## Summary
- Check `serve.token` permissions before chmod. A 0644 (or otherwise group/other-readable) token is already leaked, so tightening the mode cannot un-expose it.
- Treat that as invalid and mint a new token, matching the empty-file rotation path.

Fixes SBS-953.

## Test plan
- [x] `cargo test --manifest-path rust/Cargo.toml --lib serve_token`
- [ ] On Unix, a restored 0644 `serve.token` is replaced on the next `codexbar serve`


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rotate a leaked serve token when its file permissions are too open
> - Adds a `serve_token_mode_is_too_open` helper (Unix-only) that returns true if any group/other permission bits are set (`mode & 0o077 != 0`).
> - `read_existing_serve_token` now checks permissions before reading the file; if the token file is world/group readable, it returns an `InvalidData` error instead of attempting to reuse the token.
> - `load_or_create_serve_token_at` responds to this error by generating a new token and writing it back to disk with `0o600` permissions, effectively rotating the leaked credential.
> - Behavioral Change: previously, a too-open token file would be chmod'd and reused; now it is always replaced with a fresh token.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3525587.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->