### PR TITLE
Ignore unavailable Cursor Plan readings in reset detection

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/capacity_events.rs
+++ b/apps/desktop-tauri/src-tauri/src/capacity_events.rs
@@ -783,7 +783,19 @@ fn observed_windows(
             extra_window_ids.insert(id);
         }
     }
+    let unavailable = unavailable_window_ids(snapshot);
+    windows.retain(|id, _| !unavailable.contains(id));
+    extra_window_ids.retain(|id| windows.contains_key(id));
     (windows, extra_window_ids)
+}
+
+fn unavailable_window_ids(snapshot: &ProviderUsageSnapshot) -> HashSet<String> {
+    snapshot
+        .inactive_rate_windows
+        .iter()
+        .filter(|window| window.state == "unavailable")
+        .map(|window| semantic_inactive_window_id(&snapshot.provider_id, &window.id, &window.title))
+        .collect()
 }
 
 fn inactive_windows(snapshot: &ProviderUsageSnapshot) -> HashMap<String, String> {
@@ -1666,10 +1678,8 @@ mod tests {
         later.updated_at = (start + Duration::minutes(10)).to_rfc3339();
         let events = observer.observe(&later);
         assert!(
-            events
-                .iter()
-                .all(|event| event.kind != CapacityEventKind::WindowLifted),
-            "a missing Plan reading must not confirm as a lifted limit"
+            events.is_empty(),
+            "a missing Plan reading must not confirm a reset or lifted limit: {events:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Skip observed windows whose semantic id matches an `unavailable` inactive row, so a missing Cursor Plan reading is not treated as 0% used.
- Tighten the regression test to require no events at all, not just no `WindowLifted`.

Fixes SBS-963.

## Test plan
- [x] `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml cursor_plan_unavailable`


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude unavailable Cursor Plan windows from reset detection in `observed_windows`
> - `observed_windows` in [capacity_events.rs](https://github.com/tsouth89/ceiling/pull/337/files#diff-9e42248ff2536d3ab4b6e257fa7c6631912296ad45893a93472b2adc61573c8b) now filters out `inactive_rate_windows` whose `state == "unavailable"` before returning the windows map and `extra_window_ids` set.
> - A new `unavailable_window_ids` helper scans `snapshot.inactive_rate_windows`, selects unavailable entries, and returns their semantic IDs as a `HashSet<String>`.
> - Behavioral Change: a missing Plan reading no longer triggers any events; the test assertion updated from "no `WindowLifted` events" to "no events at all".
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8db0b75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->