### PR TITLE
Trim pace and primary labels before hiding placeholder pace

### DIFF
--- a/apps/desktop-tauri/src/surfaces/ProviderDetailView.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/ProviderDetailView.test.tsx
@@ -175,7 +175,7 @@ describe("ProviderDetailView", () => {
       // inside a Cursor view, which is exactly what provider siloing forbids.
       planName: "Ultra",
       primary: rate(0),
-      primaryLabel: "Plan",
+      primaryLabel: "Plan ",
       extraRateWindows: [],
       inactiveRateWindows: [
         {

--- a/apps/desktop-tauri/src/surfaces/ProviderDetailView.tsx
+++ b/apps/desktop-tauri/src/surfaces/ProviderDetailView.tsx
@@ -316,12 +316,17 @@ export default function ProviderDetailView({
   // primary (`preferred_pace` in bridge.rs picks across all of them). Drop it
   // only when it is the placeholder's own verdict, which would read a fake 0%;
   // an Auto pace beside an unavailable Plan is still a real reading (SBS-876).
+  const rawPrimaryLabel = provider.primaryLabel?.trim() ?? "";
+  const primaryLabel = rawPrimaryLabel || "Primary";
+  const paceWindow = provider.pace?.windowLabel?.trim() ?? "";
   const pace =
-    namedPrimary && provider.pace?.windowLabel === provider.primaryLabel
+    namedPrimary &&
+    !!rawPrimaryLabel &&
+    !!paceWindow &&
+    paceWindow === rawPrimaryLabel
       ? null
       : provider.pace;
   const primaryPercent = Math.round(percentFor(provider.primary, showAsUsed));
-  const primaryLabel = provider.primaryLabel?.trim() || "Primary";
   const planName = displayPlanName(provider.planName);
   // A drill-in opens a specific account, so name it whenever there is an email.
   // Without this, two accounts on one provider open two identical detail views.


### PR DESCRIPTION
## Summary
- Compare trimmed, non-empty pace and primary labels so an unavailable Cursor Plan still suppresses its placeholder 0% pace when one side has surrounding whitespace.

Fixes SBS-976.

## Test plan
- [x] `pnpm --dir apps/desktop-tauri exec vitest run src/surfaces/ProviderDetailView.test.tsx`


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pace suppression in `ProviderDetailView` to trim labels before comparing
> The `PaceSection` was incorrectly suppressed when labels were empty or differed only by surrounding whitespace. Now both `primaryLabel` and `paceWindow` are trimmed before comparison, and suppression requires both to be non-empty and equal after trimming.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d37d4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->