### PR TITLE
Honor the 15-minute incident-check promise on failures

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/provider_incidents.rs
+++ b/apps/desktop-tauri/src-tauri/src/provider_incidents.rs
@@ -41,7 +41,6 @@ struct CachedIncident {
     loaded_at: Instant,
     /// `None` once a provider reads operational, which is still a fresh answer.
     incident: Option<ProviderIncident>,
-    ok: bool,
 }
 
 impl CachedIncident {
@@ -152,9 +151,8 @@ pub async fn current_incidents(settings: &Settings) -> HashMap<String, ProviderI
         if let Ok(mut guard) = cache().lock() {
             for (provider_id, status) in fetched {
                 // `Unknown` means the page did not parse, which is a failed
-                // read rather than an operational provider. Treating it as
-                // success would still hold a stale answer for the same 15
-                // minutes; we keep `ok: false` so a later poll can replace it.
+                // read rather than an operational provider. Keep the last
+                // good badge and still hold this miss for the full TTL.
                 let readable = status
                     .as_ref()
                     .is_some_and(|status| status.level != StatusLevel::Unknown);
@@ -184,7 +182,6 @@ pub async fn current_incidents(settings: &Settings) -> HashMap<String, ProviderI
                     CachedIncident {
                         loaded_at: Instant::now(),
                         incident,
-                        ok: readable,
                     },
                 );
             }
@@ -294,7 +291,6 @@ mod tests {
                 CachedIncident {
                     loaded_at: Instant::now(),
                     incident: Some(live.clone()),
-                    ok: true,
                 },
             );
         }
@@ -308,14 +304,16 @@ mod tests {
                 CachedIncident {
                     loaded_at: Instant::now(),
                     incident: carried,
-                    ok: false,
                 },
             );
         }
 
         let guard = cache().lock().expect("cache");
         assert_eq!(guard["codex"].incident.as_ref(), Some(&live));
-        assert!(!guard["codex"].ok, "and it is marked for the next refresh");
+        assert!(
+            guard["codex"].is_fresh(),
+            "a failed poll still holds the last good badge for the full TTL"
+        );
     }
 
     #[test]
@@ -323,12 +321,10 @@ mod tests {
         let ok = CachedIncident {
             loaded_at: Instant::now() - Duration::from_secs(6 * 60),
             incident: None,
-            ok: true,
         };
         let failed = CachedIncident {
             loaded_at: Instant::now() - Duration::from_secs(6 * 60),
             incident: None,
-            ok: false,
         };
 
         assert!(ok.is_fresh(), "a good reading is still valid at 6 minutes");
@@ -339,7 +335,6 @@ mod tests {
         let aged = CachedIncident {
             loaded_at: Instant::now() - Duration::from_secs(16 * 60),
             incident: None,
-            ok: false,
         };
         assert!(!aged.is_fresh());
     }

--- a/apps/desktop-tauri/src-tauri/src/provider_incidents.rs
+++ b/apps/desktop-tauri/src-tauri/src/provider_incidents.rs
@@ -19,12 +19,9 @@ use serde::{Deserialize, Serialize};
 
 /// How long a reading stays good. Status pages move on the order of minutes,
 /// and a badge that is a quarter-hour stale is still far better than none.
+/// Failures use the same window: the settings copy promises at most one check
+/// every 15 minutes, and a 5-minute error backoff tripled the requests.
 const INCIDENT_TTL: Duration = Duration::from_secs(15 * 60);
-
-/// Backoff after a failed poll, so an unreachable page is not retried on every
-/// surface open. Shorter than the success TTL because a failure carries no
-/// information.
-const INCIDENT_ERROR_TTL: Duration = Duration::from_secs(5 * 60);
 
 /// A provider's current public status, as shown on its badge.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -49,12 +46,7 @@ struct CachedIncident {
 
 impl CachedIncident {
     fn is_fresh(&self) -> bool {
-        let ttl = if self.ok {
-            INCIDENT_TTL
-        } else {
-            INCIDENT_ERROR_TTL
-        };
-        self.loaded_at.elapsed() < ttl
+        self.loaded_at.elapsed() < INCIDENT_TTL
     }
 }
 
@@ -161,8 +153,8 @@ pub async fn current_incidents(settings: &Settings) -> HashMap<String, ProviderI
             for (provider_id, status) in fetched {
                 // `Unknown` means the page did not parse, which is a failed
                 // read rather than an operational provider. Treating it as
-                // success would hold a stale answer for the full 15 minutes
-                // instead of retrying on the short backoff.
+                // success would still hold a stale answer for the same 15
+                // minutes; we keep `ok: false` so a later poll can replace it.
                 let readable = status
                     .as_ref()
                     .is_some_and(|status| status.level != StatusLevel::Unknown);
@@ -323,11 +315,11 @@ mod tests {
 
         let guard = cache().lock().expect("cache");
         assert_eq!(guard["codex"].incident.as_ref(), Some(&live));
-        assert!(!guard["codex"].ok, "and it is retried on the short backoff");
+        assert!(!guard["codex"].ok, "and it is marked for the next refresh");
     }
 
     #[test]
-    fn a_failed_poll_backs_off_for_less_time_than_a_good_one() {
+    fn a_failed_poll_uses_the_same_ttl_as_a_good_one() {
         let ok = CachedIncident {
             loaded_at: Instant::now() - Duration::from_secs(6 * 60),
             incident: None,
@@ -340,6 +332,15 @@ mod tests {
         };
 
         assert!(ok.is_fresh(), "a good reading is still valid at 6 minutes");
-        assert!(!failed.is_fresh(), "a failure is retried sooner");
+        assert!(
+            failed.is_fresh(),
+            "a failure must not retry sooner than the promised 15 minutes"
+        );
+        let aged = CachedIncident {
+            loaded_at: Instant::now() - Duration::from_secs(16 * 60),
+            incident: None,
+            ok: false,
+        };
+        assert!(!aged.is_fresh());
     }
 }

--- a/apps/desktop-tauri/src/hooks/useProviderIncidents.test.tsx
+++ b/apps/desktop-tauri/src/hooks/useProviderIncidents.test.tsx
@@ -82,12 +82,10 @@ describe("useProviderIncidents", () => {
     expect(getProviderIncidents).toHaveBeenCalledTimes(2);
   });
 
-  /// An empty map usually means "nothing is wrong", but it is also what comes
-  /// back on a cold start where every status page failed its first read and
-  /// there was no earlier answer to carry forward. Holding that for the full
-  /// quarter hour sits on the miss long past the backend's own five-minute
-  /// backoff.
-  it("re-asks after five minutes when the answer was empty", async () => {
+  /// An empty map usually means "nothing is wrong". Hold it for the same
+  /// 15-minute window as a live badge so a failed status page is not retried
+  /// three times more often than the settings copy promises.
+  it("holds an empty answer for the full refresh window", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date("2026-08-15T12:00:00Z"));
     getProviderIncidents.mockResolvedValueOnce({});
@@ -98,10 +96,9 @@ describe("useProviderIncidents", () => {
 
     vi.setSystemTime(new Date("2026-08-15T12:06:00Z"));
     getProviderIncidents.mockResolvedValueOnce({ codex: incident() });
-    const second = renderHook(() => useProviderIncidents(true));
+    renderHook(() => useProviderIncidents(true));
 
-    await waitFor(() => expect(second.result.current.codex).toBeDefined());
-    expect(getProviderIncidents).toHaveBeenCalledTimes(2);
+    expect(getProviderIncidents).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
   });
 

--- a/apps/desktop-tauri/src/hooks/useProviderIncidents.ts
+++ b/apps/desktop-tauri/src/hooks/useProviderIncidents.ts
@@ -19,24 +19,8 @@ export type IncidentMap = Record<string, ProviderIncident>;
 /** Matches the backend's own reading TTL, so the UI never re-asks sooner. */
 const REFRESH_MS = 15 * 60 * 1000;
 
-/**
- * Matches the backend's error backoff.
- *
- * An empty map is ambiguous: it means "nothing is wrong" most of the time, but
- * it is also what comes back when every status page failed its first read and
- * there was no earlier answer to carry forward. Holding that for the full
- * quarter hour would sit on a first-open timeout long past the point the
- * backend itself is willing to retry, so an empty answer ages out on the short
- * window instead.
- */
-const EMPTY_REFRESH_MS = 5 * 60 * 1000;
-
-function refreshWindowMs(): number {
-  return Object.keys(cached).length === 0 ? EMPTY_REFRESH_MS : REFRESH_MS;
-}
-
 function isStale(): boolean {
-  return Date.now() - loadedAt >= refreshWindowMs();
+  return Date.now() - loadedAt >= REFRESH_MS;
 }
 
 let cached: IncidentMap = {};
@@ -58,8 +42,7 @@ function load(): Promise<IncidentMap> {
       // make a badge flicker away while the incident is still live.
       //
       // loadedAt is deliberately not advanced: a first-open timeout would
-      // otherwise serve an empty map for the full refresh window, well past
-      // the backend's own five-minute error backoff.
+      // otherwise serve an empty map for the full refresh window.
       return cached;
     })
     .finally(() => {
@@ -93,11 +76,10 @@ export function useProviderIncidents(enabled: boolean): IncidentMap {
     } else {
       setIncidents(cached);
     }
-    // Ticks on the short window and lets `isStale` decide, so a held incident
-    // still waits the full TTL while an empty answer re-asks sooner.
+    // Ticks on the same 15-minute window as the backend cache.
     const timer = window.setInterval(() => {
       if (isStale()) void load();
-    }, EMPTY_REFRESH_MS);
+    }, REFRESH_MS);
     return () => {
       live = false;
       listeners.delete(listener);


### PR DESCRIPTION
## Summary
- Failed provider status-page polls now use the same 15-minute TTL as successful ones, matching the settings copy.
- The UI poll interval matches that window instead of re-asking empty answers every 5 minutes.

Fixes SBS-966.

## Test plan
- [x] `pnpm --dir apps/desktop-tauri exec vitest run src/hooks/useProviderIncidents.test.tsx`
- [x] `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml a_failed_poll_uses_the_same_ttl`


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify incident cache TTL to 15 minutes for both successful and failed polls
> - Removes the separate 5-minute error backoff (`INCIDENT_ERROR_TTL` in [provider_incidents.rs](https://github.com/tsouth89/ceiling/pull/340/files#diff-0f499175df035e7769d86d1a9ccdd36a865c6874eef28051326ca8728c5cd8f5) and `EMPTY_REFRESH_MS` in [useProviderIncidents.ts](https://github.com/tsouth89/ceiling/pull/340/files#diff-2a3916b13b6f6fc388f05cca48c40a76b3e815b975c69a791c1849186d041cee)) so failed or empty polls are now held for the full 15-minute TTL, matching the documented check cadence.
> - On a failed or unreadable provider status poll, the cache now retains the last known good incident rather than serving an empty result.
> - The `CachedIncident` struct drops its `ok` flag; freshness is always evaluated against the single `INCIDENT_TTL` constant.
> - Behavioral Change: empty incident responses and failed polls are no longer retried after 5 minutes — the next check happens at the 15-minute mark.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d00be0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->