### PR TITLE
Fail when no providers are enabled instead of returning []

### DIFF
--- a/rust/src/cli/cost.rs
+++ b/rust/src/cli/cost.rs
@@ -52,18 +52,20 @@ pub async fn run(args: CostArgs) -> anyhow::Result<()> {
     };
 
     let providers = ProviderSelection::from_arg(args.provider.as_deref())?;
+    let settings = crate::settings::Settings::load();
+    let provider_ids = providers.resolved_ids(&settings)?;
     let use_color = !args.no_color && is_terminal();
     let scanner = CostScanner::with_codex_speed(args.days, Some(args.codex_speed.as_str()));
 
     tracing::debug!(
         "Running cost command: providers={:?}, format={:?}, days={}, codex_speed={:?}",
-        providers.as_list(),
+        provider_ids,
         format,
         args.days,
         scanner.codex_speed()
     );
 
-    let results = collect_results(&scanner, &providers.as_list());
+    let results = collect_results(&scanner, &provider_ids);
 
     match format {
         OutputFormat::Text => {

--- a/rust/src/cli/serve.rs
+++ b/rust/src/cli/serve.rs
@@ -690,7 +690,9 @@ mod tests {
 
     #[test]
     fn empty_enabled_providers_are_a_conflict_not_an_empty_array() {
-        let body = no_enabled_providers_response(super::super::usage::NO_ENABLED_PROVIDERS_ERROR.to_string());
+        let body = no_enabled_providers_response(
+            super::super::usage::NO_ENABLED_PROVIDERS_ERROR.to_string(),
+        );
         assert!(
             body.starts_with("HTTP/1.1 409 Conflict"),
             "status must be distinguishable from 200 []: {body}"

--- a/rust/src/cli/serve.rs
+++ b/rust/src/cli/serve.rs
@@ -13,6 +13,7 @@ use crate::core::{
     ConfiguredAccounts, FetchContext, ProviderId, SourceMode, UsageSnapshot, instantiate_provider,
 };
 use crate::cost_scanner::CostScanner;
+use crate::settings::Settings;
 
 const UNAUTHENTICATED_ERROR: &str = "unauthorized";
 const PROVIDER_FAILURE: &str = "provider request failed";
@@ -121,6 +122,11 @@ async fn usage_response(provider: Option<&str>, include_identity: bool) -> Strin
             return json_response(400, serde_json::json!({ "error": error.to_string() }));
         }
     };
+    let settings = Settings::load();
+    let providers = match selection.resolved_ids(&settings) {
+        Ok(providers) => providers,
+        Err(error) => return no_enabled_providers_response(error.to_string()),
+    };
     let ctx = FetchContext {
         source_mode: SourceMode::Auto,
         include_credits: true,
@@ -136,7 +142,7 @@ async fn usage_response(provider: Option<&str>, include_identity: bool) -> Strin
     let accounts = ConfiguredAccounts::load();
 
     let mut results = Vec::new();
-    for provider_id in selection.as_list() {
+    for provider_id in providers {
         let provider = instantiate_provider(provider_id);
         match provider
             .fetch_usage(&ctx.clone().for_account(provider_id, &accounts))
@@ -164,10 +170,25 @@ async fn cost_response(provider: Option<&str>) -> String {
             return json_response(400, serde_json::json!({ "error": error.to_string() }));
         }
     };
+    let settings = Settings::load();
+    let providers = match selection.resolved_ids(&settings) {
+        Ok(providers) => providers,
+        Err(error) => return no_enabled_providers_response(error.to_string()),
+    };
     let scanner = CostScanner::new(30);
     json_response(
         200,
-        serde_json::Value::Array(cost_payloads(&scanner, &selection.as_list())),
+        serde_json::Value::Array(cost_payloads(&scanner, &providers)),
+    )
+}
+
+fn no_enabled_providers_response(error: String) -> String {
+    json_response(
+        409,
+        serde_json::json!({
+            "error": error,
+            "code": "no_enabled_providers",
+        }),
     )
 }
 
@@ -531,6 +552,7 @@ fn json_response(status: u16, payload: serde_json::Value) -> String {
         403 => "Forbidden",
         404 => "Not Found",
         405 => "Method Not Allowed",
+        409 => "Conflict",
         _ => "Internal Server Error",
     };
     format!(
@@ -664,6 +686,21 @@ mod tests {
         assert!(payloads[0].get("error").is_none());
         assert_eq!(payloads[1]["provider"], "cursor");
         assert_eq!(payloads[1]["supported"], false);
+    }
+
+    #[test]
+    fn empty_enabled_providers_are_a_conflict_not_an_empty_array() {
+        let body = no_enabled_providers_response(super::super::usage::NO_ENABLED_PROVIDERS_ERROR.to_string());
+        assert!(
+            body.starts_with("HTTP/1.1 409 Conflict"),
+            "status must be distinguishable from 200 []: {body}"
+        );
+        assert!(body.contains("\"code\":\"no_enabled_providers\""));
+        let payload_start = body.find("\r\n\r\n").map(|i| i + 4).unwrap_or(0);
+        assert!(
+            !body[payload_start..].starts_with('['),
+            "must not look like a successful empty list: {body}"
+        );
     }
 
     #[tokio::test]

--- a/rust/src/cli/usage.rs
+++ b/rust/src/cli/usage.rs
@@ -129,7 +129,20 @@ impl ProviderSelection {
             ProviderSelection::Enabled => settings.get_enabled_provider_ids(),
         }
     }
+
+    /// Like [`Self::as_list_from`], but the default (enabled) selection fails
+    /// instead of resolving to an empty list that looks like success.
+    pub fn resolved_ids(&self, settings: &Settings) -> anyhow::Result<Vec<ProviderId>> {
+        let ids = self.as_list_from(settings);
+        if matches!(self, Self::Enabled) && ids.is_empty() {
+            anyhow::bail!(NO_ENABLED_PROVIDERS_ERROR);
+        }
+        Ok(ids)
+    }
 }
+
+pub const NO_ENABLED_PROVIDERS_ERROR: &str =
+    "No providers are enabled. Enable a provider in Preferences, or pass --provider.";
 
 /// JSON output payload
 #[derive(Debug, Serialize)]
@@ -174,7 +187,7 @@ impl UsageCommand {
         let source_mode = SourceMode::parse(&args.source).unwrap_or(SourceMode::Auto);
         let settings = Settings::load();
         let providers =
-            ProviderSelection::from_arg(args.provider.as_deref())?.as_list_from(&settings);
+            ProviderSelection::from_arg(args.provider.as_deref())?.resolved_ids(&settings)?;
 
         Ok(Self {
             format,
@@ -721,5 +734,21 @@ mod tests {
             .as_list_from(&settings);
 
         assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn empty_enabled_providers_is_an_error_for_the_default_selection() {
+        let settings = settings_with_enabled(&[]);
+        let err = ProviderSelection::from_arg(None)
+            .unwrap()
+            .resolved_ids(&settings)
+            .expect_err("empty enabled set must not look like success");
+        assert!(err.to_string().contains("No providers are enabled"));
+
+        let still_ok = ProviderSelection::from_arg(Some("claude"))
+            .unwrap()
+            .resolved_ids(&settings)
+            .unwrap();
+        assert_eq!(still_ok, vec![ProviderId::Claude]);
     }
 }


### PR DESCRIPTION
## Summary
- `codexbar usage` / `cost` exit non-zero with a clear message when the default enabled-provider set is empty.
- `GET /usage` and `GET /cost` return HTTP 409 with `code: no_enabled_providers` instead of `200 []`.
- `--provider` / `?provider=` still work. `as_list_from` still resolves empty for callers that need the raw list.

Fixes SBS-960.

## Test plan
- [x] `cargo test --manifest-path rust/Cargo.toml --lib -- empty_enabled`


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail with HTTP 409 when no providers are enabled instead of returning empty results
> - Adds `ProviderSelection.resolved_ids` in [usage.rs](https://github.com/tsouth89/ceiling/pull/343/files#diff-5e24f33c93735fe4eea871446bcc73d3e88ca1902309445a4f657f496823e3b7) that returns an error when the default selection resolves to an empty provider list, replacing silent empty-list returns.
> - Updates the `cost` and `usage` CLI commands to use `resolved_ids`, so both now exit with an error if no providers are enabled.
> - Updates the `usage_response` and `cost_response` handlers in [serve.rs](https://github.com/tsouth89/ceiling/pull/343/files#diff-5a2f76017642adc46069e376ff9ac895ac849645e7c4d082adca4a4cf52cc818) to return HTTP 409 Conflict with a structured JSON error (`code: "no_enabled_providers"`) instead of HTTP 200 with an empty array.
> - Behavioral Change: Any client that relied on an empty `[]` response when no providers are enabled will now receive a 409 error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d38c48.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->