### PR TITLE
Keep a corrupt settings.json as a backup instead of overwriting it

### DIFF
--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -802,6 +802,10 @@ impl Settings {
         dirs::config_dir().map(|p| p.join("Ceiling").join("settings.json"))
     }
 
+    pub(crate) fn backup_path(path: &std::path::Path) -> PathBuf {
+        path.with_extension("json.bak")
+    }
+
     /// Load settings from disk
     pub fn load() -> Self {
         let settings = Self::load_from_disk();
@@ -844,23 +848,7 @@ impl Settings {
         #[allow(unused_mut)]
         let mut settings = match Self::settings_path() {
             Some(path) if path.exists() => match crate::secure_file::read_string(&path) {
-                Ok(content) => {
-                    match serde_json::from_str(content.trim_start_matches('\u{feff}')) {
-                        Ok(settings) => settings,
-                        Err(error) => {
-                            // Falling back to defaults means the next save
-                            // rewrites the user's file as defaults, so a parse
-                            // failure must at least be diagnosable rather than
-                            // silent. Unknown provider ids no longer land here
-                            // (see `RawSettings::provider_configs`).
-                            tracing::warn!(
-                                %error,
-                                "settings.json could not be parsed; falling back to defaults"
-                            );
-                            Self::default()
-                        }
-                    }
-                }
+                Ok(content) => Self::parse_or_quarantine(&path, &content),
                 Err(error) => {
                     tracing::warn!(%error, "settings.json could not be read; using defaults");
                     Self::default()
@@ -876,6 +864,30 @@ impl Settings {
         }
 
         settings
+    }
+
+    /// Parse `settings.json`, or move a corrupt file aside so the next save
+    /// cannot overwrite the user's last known contents.
+    pub(crate) fn parse_or_quarantine(path: &std::path::Path, content: &str) -> Self {
+        match serde_json::from_str(content.trim_start_matches('\u{feff}')) {
+            Ok(settings) => settings,
+            Err(error) => {
+                let backup = Self::backup_path(path);
+                match std::fs::rename(path, &backup) {
+                    Ok(()) => tracing::warn!(
+                        %error,
+                        backup = %backup.display(),
+                        "settings.json could not be parsed; original moved aside and defaults loaded"
+                    ),
+                    Err(rename_error) => tracing::warn!(
+                        %error,
+                        %rename_error,
+                        "settings.json could not be parsed; falling back to defaults without a backup"
+                    ),
+                }
+                Self::default()
+            }
+        }
     }
 
     /// Save settings to disk

--- a/rust/src/settings/tests.rs
+++ b/rust/src/settings/tests.rs
@@ -1634,5 +1634,8 @@ fn unparseable_settings_are_moved_aside_instead_of_overwritten() {
         "the live path must be vacated so a later save cannot clobber the original"
     );
     let backup = Settings::backup_path(&path);
-    assert_eq!(std::fs::read_to_string(&backup).expect("read backup"), original);
+    assert_eq!(
+        std::fs::read_to_string(&backup).expect("read backup"),
+        original
+    );
 }

--- a/rust/src/settings/tests.rs
+++ b/rust/src/settings/tests.rs
@@ -1616,3 +1616,23 @@ fn a_successful_revoke_clears_preferences_after_the_hook() {
     let after = ApiKeys::try_load_from(&keys_path).expect("reload api keys");
     assert!(!after.has_key(ProviderId::StepFun.cli_name()));
 }
+
+#[test]
+fn unparseable_settings_are_moved_aside_instead_of_overwritten() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("settings.json");
+    let original = "{\"refresh_interval_secs\":\"60\"";
+    std::fs::write(&path, original).expect("write corrupt settings");
+
+    let loaded = Settings::parse_or_quarantine(&path, original);
+    assert_eq!(
+        loaded.refresh_interval_secs,
+        Settings::default().refresh_interval_secs
+    );
+    assert!(
+        !path.exists(),
+        "the live path must be vacated so a later save cannot clobber the original"
+    );
+    let backup = Settings::backup_path(&path);
+    assert_eq!(std::fs::read_to_string(&backup).expect("read backup"), original);
+}


### PR DESCRIPTION
## Summary
- Unparseable `settings.json` is renamed to `settings.json.bak` before defaults are loaded.
- The next save writes a new file at the live path and leaves the original contents in the backup.

Fixes SBS-954.

## Test plan
- [x] `cargo test --manifest-path rust/Cargo.toml --lib unparseable_settings`


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep corrupt `settings.json` as a backup instead of overwriting it
> When `settings.json` fails to parse, the file is now renamed to `settings.json.bak` before falling back to defaults, preserving the corrupt file for inspection. Previously, the corrupt file was left in place with only a warning logged. The new `parse_or_quarantine` method in [settings.rs](https://github.com/tsouth89/ceiling/pull/344/files#diff-e942ff1cc196680bb9d65bc031007c839badedb1435f2c5ac11ccea8b882055d) handles BOM trimming, rename, and logging in one place.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b91cdc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->