### PR TITLE
Keep at least one provider on a custom taskbar strip

### DIFF
--- a/apps/desktop-tauri/src/floatbar/SettingsSection.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/SettingsSection.test.tsx
@@ -158,6 +158,29 @@ describe("FloatBar settings", () => {
     expect(set).toHaveBeenCalledWith({ floatBarProviderIds: [] });
   });
 
+  it("does not uncheck the last remaining strip provider", () => {
+    const set = vi.fn();
+    render(
+      <FloatBarSettingsSection
+        settings={{
+          ...settings,
+          floatBarProviderIds: ["grok"],
+        }}
+        saving={false}
+        set={set}
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: "Show Grok on taskbar strip",
+    });
+    expect(checkbox).toBeChecked();
+    expect(checkbox).toBeDisabled();
+    fireEvent.click(checkbox);
+    expect(set).not.toHaveBeenCalled();
+    expect(screen.getByText("StripKeepAtLeastOne")).toBeInTheDocument();
+  });
+
   it("persists floating-bar provider selection mode", () => {
     const set = vi.fn();
     render(

--- a/apps/desktop-tauri/src/floatbar/SettingsSection.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/SettingsSection.test.tsx
@@ -178,7 +178,39 @@ describe("FloatBar settings", () => {
     expect(checkbox).toBeDisabled();
     fireEvent.click(checkbox);
     expect(set).not.toHaveBeenCalled();
-    expect(screen.getByText("StripKeepAtLeastOne")).toBeInTheDocument();
+    const hint = screen.getByText("StripKeepAtLeastOne");
+    expect(hint).toBeInTheDocument();
+    // The lock has to explain itself to a screen reader too, not only on screen.
+    expect(checkbox).toHaveAttribute("aria-describedby", hint.id);
+  });
+
+  /// Automatic order with one enabled provider also lands on a single strip
+  /// entry, but there are no choices to restore and the button that would
+  /// restore them is hidden, so the custom-mode copy would be a dead end.
+  it("explains the locked checkbox without offering automatic order twice", () => {
+    render(
+      <FloatBarSettingsSection
+        settings={{
+          ...settings,
+          floatBarProviderIds: [],
+          enabledProviders: ["grok"],
+          providerOrder: ["grok"],
+        }}
+        saving={false}
+        set={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "StripUseAutomaticOrder" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("StripKeepAtLeastOne")).not.toBeInTheDocument();
+    const hint = screen.getByText("StripAlwaysOneProvider");
+    const checkbox = screen.getByRole("checkbox", {
+      name: "Show Grok on taskbar strip",
+    });
+    expect(checkbox).toBeDisabled();
+    expect(checkbox).toHaveAttribute("aria-describedby", hint.id);
   });
 
   it("persists floating-bar provider selection mode", () => {

--- a/apps/desktop-tauri/src/floatbar/SettingsSection.tsx
+++ b/apps/desktop-tauri/src/floatbar/SettingsSection.tsx
@@ -118,6 +118,8 @@ function useDraftNumber(value: number) {
 /**
  * Settings UI for the two independent at-a-glance surfaces.
  */
+const KEEP_ONE_HINT_ID = "strip-keep-one-hint";
+
 export default function FloatBarSettingsSection({ settings, saving, set }: Props) {
   const { t } = useLocale();
   const opacity = useDraftNumber(settings.floatBarOpacity);
@@ -363,6 +365,9 @@ export default function FloatBarSettingsSection({ settings, saving, set }: Props
                               lastChecked ||
                               (atCap && !checked)
                             }
+                            aria-describedby={
+                              lastChecked ? KEEP_ONE_HINT_ID : undefined
+                            }
                             aria-label={formatLocale(t("StripShowProvider"), providerLabel(id))}
                             onChange={(e) =>
                               toggleStripProvider(id, e.target.checked)
@@ -436,7 +441,13 @@ export default function FloatBarSettingsSection({ settings, saving, set }: Props
                 })}
               </ul>
               {selectedStripIds.length === 1 && (
-                <p className="settings-section__hint">{t("StripKeepAtLeastOne")}</p>
+                <p id={KEEP_ONE_HINT_ID} className="settings-section__hint">
+                  {/* Automatic order has no choices to restore, and the button
+                      that would do it is hidden, so name the real way out. */}
+                  {customStrip
+                    ? t("StripKeepAtLeastOne")
+                    : t("StripAlwaysOneProvider")}
+                </p>
               )}
             </>
           )}

--- a/apps/desktop-tauri/src/floatbar/SettingsSection.tsx
+++ b/apps/desktop-tauri/src/floatbar/SettingsSection.tsx
@@ -341,103 +341,103 @@ export default function FloatBarSettingsSection({ settings, saving, set }: Props
             <p className="settings-section__hint">{t("StripEnableProvidersFirst")}</p>
           ) : (
             <>
-            <ul className="taskbar-provider-picker__list">
-              {enabledOrdered.map((id) => {
-                const checked = selectedStripIds.includes(id);
-                const rank = selectedStripIds.indexOf(id);
-                const lastChecked = checked && selectedStripIds.length === 1;
-                const atCap =
-                  !checked && selectedStripIds.length >= MAX_STRIP_PROVIDERS;
-                const multi = multiAccountByProvider.get(id);
-                return (
-                  <li key={id} className="taskbar-provider-picker__row">
-                    <div className="taskbar-provider-picker__main">
-                      <label className="taskbar-provider-picker__label">
-                        <input
-                          type="checkbox"
-                          className="toggle"
-                          checked={checked}
-                          disabled={
-                            saving ||
-                            !settings.taskbarWidgetEnabled ||
-                            lastChecked ||
-                            (atCap && !checked)
-                          }
-                          aria-label={formatLocale(t("StripShowProvider"), providerLabel(id))}
-                          onChange={(e) =>
-                            toggleStripProvider(id, e.target.checked)
-                          }
-                        />
-                        <ProviderIcon
-                          providerId={id}
-                          size={16}
-                          title={providerLabel(id)}
-                        />
-                        <span>{providerLabel(id)}</span>
-                        {checked && rank >= 0 && (
-                          <span className="taskbar-provider-picker__rank">
-                            {rank + 1}
-                          </span>
-                        )}
-                      </label>
-                      <span className="providers-sidebar__reorder-controls">
-                        <button
-                          type="button"
-                          className="providers-sidebar__reorder-button"
-                          aria-label={formatLocale(t("StripMoveUp"), providerLabel(id))}
-                          disabled={saving || !checked || rank <= 0}
-                          onClick={() => moveStripProvider(id, -1)}
-                        >
-                          ↑
-                        </button>
-                        <button
-                          type="button"
-                          className="providers-sidebar__reorder-button"
-                          aria-label={formatLocale(t("StripMoveDown"), providerLabel(id))}
-                          disabled={
-                            saving ||
-                            !checked ||
-                            rank < 0 ||
-                            rank >= selectedStripIds.length - 1
-                          }
-                          onClick={() => moveStripProvider(id, 1)}
-                        >
-                          ↓
-                        </button>
-                      </span>
-                    </div>
-                    {multi && checked && (
-                      <label className="taskbar-provider-picker__account">
-                        <span className="taskbar-provider-picker__account-label">
-                          {t("StripTaskbarShows")}
+              <ul className="taskbar-provider-picker__list">
+                {enabledOrdered.map((id) => {
+                  const checked = selectedStripIds.includes(id);
+                  const rank = selectedStripIds.indexOf(id);
+                  const lastChecked = checked && selectedStripIds.length === 1;
+                  const atCap =
+                    !checked && selectedStripIds.length >= MAX_STRIP_PROVIDERS;
+                  const multi = multiAccountByProvider.get(id);
+                  return (
+                    <li key={id} className="taskbar-provider-picker__row">
+                      <div className="taskbar-provider-picker__main">
+                        <label className="taskbar-provider-picker__label">
+                          <input
+                            type="checkbox"
+                            className="toggle"
+                            checked={checked}
+                            disabled={
+                              saving ||
+                              !settings.taskbarWidgetEnabled ||
+                              lastChecked ||
+                              (atCap && !checked)
+                            }
+                            aria-label={formatLocale(t("StripShowProvider"), providerLabel(id))}
+                            onChange={(e) =>
+                              toggleStripProvider(id, e.target.checked)
+                            }
+                          />
+                          <ProviderIcon
+                            providerId={id}
+                            size={16}
+                            title={providerLabel(id)}
+                          />
+                          <span>{providerLabel(id)}</span>
+                          {checked && rank >= 0 && (
+                            <span className="taskbar-provider-picker__rank">
+                              {rank + 1}
+                            </span>
+                          )}
+                        </label>
+                        <span className="providers-sidebar__reorder-controls">
+                          <button
+                            type="button"
+                            className="providers-sidebar__reorder-button"
+                            aria-label={formatLocale(t("StripMoveUp"), providerLabel(id))}
+                            disabled={saving || !checked || rank <= 0}
+                            onClick={() => moveStripProvider(id, -1)}
+                          >
+                            ↑
+                          </button>
+                          <button
+                            type="button"
+                            className="providers-sidebar__reorder-button"
+                            aria-label={formatLocale(t("StripMoveDown"), providerLabel(id))}
+                            disabled={
+                              saving ||
+                              !checked ||
+                              rank < 0 ||
+                              rank >= selectedStripIds.length - 1
+                            }
+                            onClick={() => moveStripProvider(id, 1)}
+                          >
+                            ↓
+                          </button>
                         </span>
-                        <select
-                          className="select"
-                          aria-label={formatLocale(t("StripTaskbarAccount"), providerLabel(id))}
-                          disabled={saving || !settings.taskbarWidgetEnabled}
-                          value={pinnedAccounts[id] ?? ""}
-                          onChange={(e) =>
-                            setPinnedAccount(id, e.target.value)
-                          }
-                        >
-                          <option value="">
-                            {t("StripAutoClosest")}
-                          </option>
-                          {multi.accounts.map((account) => (
-                            <option key={account.id} value={account.id}>
-                              {accountOptionLabel(account)}
+                      </div>
+                      {multi && checked && (
+                        <label className="taskbar-provider-picker__account">
+                          <span className="taskbar-provider-picker__account-label">
+                            {t("StripTaskbarShows")}
+                          </span>
+                          <select
+                            className="select"
+                            aria-label={formatLocale(t("StripTaskbarAccount"), providerLabel(id))}
+                            disabled={saving || !settings.taskbarWidgetEnabled}
+                            value={pinnedAccounts[id] ?? ""}
+                            onChange={(e) =>
+                              setPinnedAccount(id, e.target.value)
+                            }
+                          >
+                            <option value="">
+                              {t("StripAutoClosest")}
                             </option>
-                          ))}
-                        </select>
-                      </label>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-            {selectedStripIds.length === 1 && (
-              <p className="settings-section__hint">{t("StripKeepAtLeastOne")}</p>
-            )}
+                            {multi.accounts.map((account) => (
+                              <option key={account.id} value={account.id}>
+                                {accountOptionLabel(account)}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+              {selectedStripIds.length === 1 && (
+                <p className="settings-section__hint">{t("StripKeepAtLeastOne")}</p>
+              )}
             </>
           )}
           {multiAccountByProvider.size > 0 && (

--- a/apps/desktop-tauri/src/floatbar/SettingsSection.tsx
+++ b/apps/desktop-tauri/src/floatbar/SettingsSection.tsx
@@ -227,6 +227,7 @@ export default function FloatBarSettingsSection({ settings, saving, set }: Props
       commitStripIds([...base, id]);
       return;
     }
+    if (base.length <= 1) return;
     commitStripIds(base.filter((pid) => pid !== id));
   };
 
@@ -339,10 +340,12 @@ export default function FloatBarSettingsSection({ settings, saving, set }: Props
           {enabledOrdered.length === 0 ? (
             <p className="settings-section__hint">{t("StripEnableProvidersFirst")}</p>
           ) : (
+            <>
             <ul className="taskbar-provider-picker__list">
               {enabledOrdered.map((id) => {
                 const checked = selectedStripIds.includes(id);
                 const rank = selectedStripIds.indexOf(id);
+                const lastChecked = checked && selectedStripIds.length === 1;
                 const atCap =
                   !checked && selectedStripIds.length >= MAX_STRIP_PROVIDERS;
                 const multi = multiAccountByProvider.get(id);
@@ -357,6 +360,7 @@ export default function FloatBarSettingsSection({ settings, saving, set }: Props
                           disabled={
                             saving ||
                             !settings.taskbarWidgetEnabled ||
+                            lastChecked ||
                             (atCap && !checked)
                           }
                           aria-label={formatLocale(t("StripShowProvider"), providerLabel(id))}
@@ -431,6 +435,10 @@ export default function FloatBarSettingsSection({ settings, saving, set }: Props
                 );
               })}
             </ul>
+            {selectedStripIds.length === 1 && (
+              <p className="settings-section__hint">{t("StripKeepAtLeastOne")}</p>
+            )}
+            </>
           )}
           {multiAccountByProvider.size > 0 && (
             <p className="settings-section__hint">

--- a/apps/desktop-tauri/src/i18n/keys.ts
+++ b/apps/desktop-tauri/src/i18n/keys.ts
@@ -723,6 +723,7 @@ export const ALL_LOCALE_KEYS = [
   "StripProvidersTitle",
   "StripProvidersHelp",
   "StripUseAutomaticOrder",
+  "StripKeepAtLeastOne",
   "StripEnableProvidersFirst",
   "StripShowProvider",
   "StripMoveUp",

--- a/apps/desktop-tauri/src/i18n/keys.ts
+++ b/apps/desktop-tauri/src/i18n/keys.ts
@@ -724,6 +724,7 @@ export const ALL_LOCALE_KEYS = [
   "StripProvidersHelp",
   "StripUseAutomaticOrder",
   "StripKeepAtLeastOne",
+  "StripAlwaysOneProvider",
   "StripEnableProvidersFirst",
   "StripShowProvider",
   "StripMoveUp",

--- a/rust/src/locale.rs
+++ b/rust/src/locale.rs
@@ -977,6 +977,7 @@ locale_keys! {
     StripProvidersTitle,
     StripProvidersHelp,
     StripUseAutomaticOrder,
+    StripKeepAtLeastOne,
     StripEnableProvidersFirst,
     StripShowProvider,
     StripMoveUp,

--- a/rust/src/locale.rs
+++ b/rust/src/locale.rs
@@ -978,6 +978,7 @@ locale_keys! {
     StripProvidersHelp,
     StripUseAutomaticOrder,
     StripKeepAtLeastOne,
+    StripAlwaysOneProvider,
     StripEnableProvidersFirst,
     StripShowProvider,
     StripMoveUp,

--- a/rust/src/locale/en-US.ftl
+++ b/rust/src/locale/en-US.ftl
@@ -720,6 +720,7 @@ StripProvidersTitle = Providers on the strip
 StripProvidersHelp = Choose up to { "{}" } enabled providers and their order for the taskbar strip and floating bar. Automatic uses your Providers tab order (Codex, Claude, Cursor, Grok, …).
 StripUseAutomaticOrder = Use automatic order
 StripKeepAtLeastOne = Keep at least one provider on the strip, or restore automatic order.
+StripAlwaysOneProvider = The strip always shows at least one provider. Enable another on the Providers tab.
 StripEnableProvidersFirst = Enable providers on the Providers tab first.
 StripShowProvider = Show { "{}" } on taskbar strip
 StripMoveUp = Move { "{}" } up

--- a/rust/src/locale/en-US.ftl
+++ b/rust/src/locale/en-US.ftl
@@ -719,6 +719,7 @@ TaskbarWidgetNoProviders = No enabled providers to show.
 StripProvidersTitle = Providers on the strip
 StripProvidersHelp = Choose up to { "{}" } enabled providers and their order for the taskbar strip and floating bar. Automatic uses your Providers tab order (Codex, Claude, Cursor, Grok, …).
 StripUseAutomaticOrder = Use automatic order
+StripKeepAtLeastOne = Keep at least one provider on the strip, or restore automatic order.
 StripEnableProvidersFirst = Enable providers on the Providers tab first.
 StripShowProvider = Show { "{}" } on taskbar strip
 StripMoveUp = Move { "{}" } up

--- a/rust/src/locale/zh-CN.ftl
+++ b/rust/src/locale/zh-CN.ftl
@@ -719,6 +719,7 @@ TaskbarWidgetNoProviders = 没有可显示的已启用服务商。
 StripProvidersTitle = 条上的服务商
 StripProvidersHelp = 最多选择 { "{}" } 个已启用服务商及其顺序，用于任务栏条和悬浮栏。自动使用“服务商”选项卡中的顺序（Codex、Claude、Cursor、Grok …）。
 StripUseAutomaticOrder = 使用自动顺序
+StripKeepAtLeastOne = 条上至少保留一个服务商，或恢复自动顺序。
 StripEnableProvidersFirst = 请先在“服务商”选项卡中启用服务商。
 StripShowProvider = 在任务栏条上显示 { "{}" }
 StripMoveUp = 上移 { "{}" }

--- a/rust/src/locale/zh-CN.ftl
+++ b/rust/src/locale/zh-CN.ftl
@@ -720,6 +720,7 @@ StripProvidersTitle = 条上的服务商
 StripProvidersHelp = 最多选择 { "{}" } 个已启用服务商及其顺序，用于任务栏条和悬浮栏。自动使用“服务商”选项卡中的顺序（Codex、Claude、Cursor、Grok …）。
 StripUseAutomaticOrder = 使用自动顺序
 StripKeepAtLeastOne = 条上至少保留一个服务商，或恢复自动顺序。
+StripAlwaysOneProvider = 条上始终至少显示一个服务商。请在“服务商”选项卡中启用另一个。
 StripEnableProvidersFirst = 请先在“服务商”选项卡中启用服务商。
 StripShowProvider = 在任务栏条上显示 { "{}" }
 StripMoveUp = 上移 { "{}" }


### PR DESCRIPTION
## Summary
- Unchecking the last remaining taskbar-strip provider no longer writes an empty list, which was the same value as \"use automatic order\" and re-checked every enabled provider.
- The last checkbox is disabled, with copy pointing at the automatic-order control.

Fixes SBS-973.

## Test plan
- [x] `pnpm --dir apps/desktop-tauri exec vitest run src/floatbar/SettingsSection.test.tsx`
- [x] `cargo test --manifest-path rust/Cargo.toml --lib test_all_locale_keys_present`


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent removing the last provider from a custom taskbar strip
> - Disables the checkbox of the sole remaining selected strip provider and early-returns from `toggleStripProvider` without calling the settings updater when only one provider is selected.
> - Shows an explanatory hint linked via `aria-describedby`: `StripKeepAtLeastOne` for custom ordering and `StripAlwaysOneProvider` when automatic order already results in a single provider.
> - Adds translations for both hint keys in [en-US.ftl](https://github.com/tsouth89/ceiling/pull/345/files#diff-4ab607f3b8e6d48e5117906733f053858a83c6f0c831e2f7edc074d7f2e5e863) and [zh-CN.ftl](https://github.com/tsouth89/ceiling/pull/345/files#diff-b1ab77f744869d5072e176f0ffae8c3d31312059da9dede9aacde509c07752d0).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e56427.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Taskbar provider settings now always keep at least one provider selected.
  * Added clear guidance when only one provider remains selected.
  * Automatic ordering hides the restore-order option when it is not applicable.
  * Added accessibility hints for provider selection behavior.

* **Localization**
  * Added English and Simplified Chinese translations for the new provider-selection guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->