### PR TITLE
Keep a counted GitHub star ask on the empty tray

### DIFF
--- a/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
@@ -52,9 +52,21 @@ const windowMocks = vi.hoisted(() => ({
   PhysicalSize: vi.fn((width: number, height: number) => ({ width, height })),
 }));
 
+const starPromptMocks = vi.hoisted(() => ({
+  reason: null as "firstValue" | "afterUpdate" | null,
+}));
+
 vi.mock("../lib/tauri", () => tauriMocks);
 vi.mock("@tauri-apps/api/event", () => eventMocks);
 vi.mock("@tauri-apps/api/window", () => windowMocks);
+vi.mock("../hooks/useStarPrompt", () => ({
+  useStarPrompt: () => ({
+    reason: starPromptMocks.reason,
+    version: "1.5.34",
+    onStar: () => {},
+    onDismiss: () => {},
+  }),
+}));
 
 import TrayPanel from "./TrayPanel";
 import { LocaleProvider } from "../i18n/LocaleProvider";
@@ -199,6 +211,7 @@ describe("TrayPanel provider grid", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     eventMocks.listeners.clear();
+    starPromptMocks.reason = null;
     tauriMocks.flyoutStoredSize.mockResolvedValue(null);
     // The star prompt (SOU-311) reads the version on mount. Its settle
     // delay and the cleared localStorage keep it off screen here, but the
@@ -258,6 +271,11 @@ describe("TrayPanel provider grid", () => {
         PanelShowFewerProviders: "Show fewer providers",
         PanelUsedSuffix: "used",
         PanelZoom: "Zoom",
+        StarPromptAriaLabel: "Star Ceiling on GitHub",
+        StarPromptTitleRunning: "Ceiling is up and running",
+        StarPromptBody: "If Ceiling is saving you time, a GitHub star helps others find it.",
+        StarPromptStar: "Star on GitHub",
+        StarPromptLater: "Later",
       }),
     );
     eventMocks.listen.mockImplementation(
@@ -271,6 +289,15 @@ describe("TrayPanel provider grid", () => {
   });
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("keeps a counted star ask visible when the tray is empty", async () => {
+    starPromptMocks.reason = "firstValue";
+    renderTrayPanel([]);
+
+    expect(
+      await screen.findByRole("dialog", { name: "Star Ceiling on GitHub" }),
+    ).toBeInTheDocument();
   });
 
   it("reveals regardless of the shared surface-mode snapshot (TrayPanel now runs in its own dedicated window)", async () => {

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
@@ -436,8 +436,8 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
   const handleGestureEnd = useCallback(() => {
     void endFlyoutGesture().catch(() => {});
   }, []);
-  // Asks for a GitHub star, at most twice ever (SOU-311). Gated on a real
-  // reading, so the empty state below never sees it.
+  // Asks for a GitHub star, at most twice ever (SOU-311). Once counted it
+  // must stay visible even if every provider is then disabled.
   const starPrompt = useStarPrompt(sorted);
   const starPromptCard =
     starPrompt.reason !== null ? (
@@ -517,6 +517,7 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
             onSettings={openSettings}
           />
         </MenuSurface>
+        {starPromptCard}
         <TrayResizeHandles />
       </div>
     );


### PR DESCRIPTION
## Summary
- The tray empty state now renders the same star-prompt card as the populated dashboard, so a counted ask stays on screen until the user answers it.

Fixes SBS-975.

## Test plan
- [x] `pnpm --dir apps/desktop-tauri exec vitest run src/surfaces/TrayPanel.test.tsx`


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show the GitHub star prompt on the empty tray when a count reason is set
> The star prompt card now renders in the empty-tray branch of [TrayPanel.tsx](https://github.com/tsouth89/ceiling/pull/347/files#diff-0d21cd90a13849d1a226cc774d9a59741c90ee183075939c22d2b4b85171684d) when `starPrompt.reason` is non-null, alongside the existing `MenuEmpty` component. A new test in [TrayPanel.test.tsx](https://github.com/tsouth89/ceiling/pull/347/files#diff-d28e96cb56241c4ab16b385da508fb6832756fb3f5b99c0ef7c2098ee0386269) verifies this by mocking `useStarPrompt` with a `firstValue` reason and asserting the dialog is present on an empty provider list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c8cf55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub star prompts now remain visible when no providers are enabled.
  * Prompts continue displaying after being counted, up to the lifetime display limit.
* **Tests**
  * Added coverage for star-prompt visibility in the empty-provider state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->