### PR TITLE
Use as_chunks for the constant-size chunk walks

### DIFF
--- a/rust/src/providers/windsurf/mod.rs
+++ b/rust/src/providers/windsurf/mod.rs
@@ -249,8 +249,10 @@ fn decode_json_blob(value: &[u8]) -> Option<String> {
 
     if value.len().is_multiple_of(2) {
         let utf16: Vec<u16> = value
-            .chunks_exact(2)
-            .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|chunk| u16::from_le_bytes(*chunk))
             .collect();
         if let Ok(text) = String::from_utf16(&utf16)
             && let Some(json) = valid_json_text(&text)

--- a/rust/src/tray/render.rs
+++ b/rust/src/tray/render.rs
@@ -260,11 +260,13 @@ mod tests {
         assert_eq!(rgba.len() as u32, w * h * 4);
         assert_eq!(rgba[3], 0, "top-left corner should remain transparent");
         assert!(
-            rgba.chunks_exact(4)
+            rgba.as_chunks::<4>()
+                .0
+                .iter()
                 .any(|pixel| { pixel[3] == 255 && (pixel[0], pixel[1], pixel[2]) == CEILING })
         );
         assert!(
-            rgba.chunks_exact(4).any(|pixel| {
+            rgba.as_chunks::<4>().0.iter().any(|pixel| {
                 pixel[3] == 255 && (pixel[0], pixel[1], pixel[2]) == (225, 232, 238)
             })
         );
@@ -285,7 +287,9 @@ mod tests {
         assert_ne!(normal, error);
         assert!(
             error
-                .chunks_exact(4)
+                .as_chunks::<4>()
+                .0
+                .iter()
                 .any(|pixel| { pixel[3] == 255 && pixel[0] == pixel[1] && pixel[1] == pixel[2] })
         );
     }
@@ -339,7 +343,9 @@ mod tests {
         let (rgba, _, _) = render_percent_icon_rgba(72.0, false);
         // A visible glyph pixel: opaque, and neither the tile nor the ceiling line.
         assert!(
-            rgba.chunks_exact(4)
+            rgba.as_chunks::<4>()
+                .0
+                .iter()
                 .any(|px| px[3] == 255 && px[0] != TILE.0 && px[0] != CEILING.0)
         );
     }


### PR DESCRIPTION
## Why

Rust stable picked up `clippy::chunks_exact_to_as_chunks` since 19 Aug. CI runs clippy with `-D warnings`, so the lint is a hard error and **`main` itself is red**, along with every open PR:

- `rust/src/providers/windsurf/mod.rs:252`
- `rust/src/tray/render.rs:263, 267, 288, 342`

Nothing in the tree changed — the toolchain moved.

## What

Five `chunks_exact(N)` walks become `as_chunks::<N>()`. All five already walk fixed-size groups, so this is the closer fit: `as_chunks` yields `&[u8; N]` instead of an unsized `&[u8]`, which lets the windsurf decoder pass the array straight to `u16::from_le_bytes` rather than re-indexing it.

Behaviour is unchanged. The windsurf caller already guards on an even length, so the remainder slice is always empty.

## Verified

- `cargo clippy --all-targets -- -D warnings`: the five errors are gone; what remains are two pre-existing items that are Windows-gated (`keep_replacement_temp`'s `error`, `verify_installer_signature_or_delete`) and so only appear on a Linux run. CI is Windows and was green on these on 19 Aug.
- `cargo test`: 1068 pass. The 6 failures are pre-existing on `main` on Linux and are Windows-path tests.
- `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical clippy-driven rewrite of existing byte walks; no logic or API changes.
> 
> **Overview**
> Replaces five `chunks_exact(N)` walks with `as_chunks::<N>()` so clippy’s new `chunks_exact_to_as_chunks` lint no longer fails CI.
> 
> The Windsurf UTF-16 decoder now maps `&[u8; 2]` straight into `u16::from_le_bytes`. Tray icon tests iterate RGBA pixels the same way. Behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb50e4196a0893ce79772e1892e8f6c880c0567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `chunks_exact` with `as_chunks` for constant-size byte walks
> - Swaps `chunks_exact(2)`/`chunks_exact(4)` for `as_chunks::<N>().0.iter()` in [windsurf/mod.rs](https://github.com/tsouth89/ceiling/pull/365/files#diff-869fe974d59cc7088efebe38b7c7f2be6f88dae828c714b39c75e12ad6033e32) and [tray/render.rs](https://github.com/tsouth89/ceiling/pull/365/files#diff-fe14c8a20a830a3a84f3d54ab208c91e18be7622693edfbe096f8bbe7f5b1ed8), mapping fixed-size arrays directly via `from_le_bytes` instead of manual indexing.
> - Affects the `decode_json_blob` UTF-16 conversion path and several tray icon pixel-iteration test assertions.
> - Risk: none — iteration logic and existing `is_multiple_of(2)` guard are unchanged; only the chunking mechanism differs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bb50e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of encoded data and rendered pixel information.
  * Updated processing logic without changing decoding, rendering, or public application behavior.
* **Tests**
  * Refined rendering validation to use more precise pixel-group checks.
  * No user-visible changes or new configuration options were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->