### PR TITLE
Stop two CI flakes blocking the merge queue

### DIFF
--- a/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
@@ -44,7 +44,10 @@ const eventMocks = vi.hoisted(() => ({
   // (reading 'then')" and failed whichever test was on screen. Restoring to a
   // resolved promise keeps that harmless; beforeEach still installs the
   // listener-capturing version the tests drive.
-  listen: vi.fn(() => Promise.resolve(() => {})),
+  listen: vi.fn(
+    (_event: string, _handler: (event: { payload: unknown }) => void) =>
+      Promise.resolve(() => {}),
+  ),
   listeners: new Map<string, Array<(event: { payload: unknown }) => void>>(),
 }));
 

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
@@ -36,7 +36,15 @@ const tauriMocks = vi.hoisted(() => ({
 }));
 
 const eventMocks = vi.hoisted(() => ({
-  listen: vi.fn(),
+  // Declared with a working default, not a bare vi.fn(). `afterEach` calls
+  // vi.restoreAllMocks(), which resets each mock to the implementation it was
+  // created with — for a bare vi.fn() that is "return undefined". LocaleProvider
+  // does `listen(...).then(...)`, so any call that lands outside the
+  // beforeEach-to-test window threw "Cannot read properties of undefined
+  // (reading 'then')" and failed whichever test was on screen. Restoring to a
+  // resolved promise keeps that harmless; beforeEach still installs the
+  // listener-capturing version the tests drive.
+  listen: vi.fn(() => Promise.resolve(() => {})),
   listeners: new Map<string, Array<(event: { payload: unknown }) => void>>(),
 }));
 

--- a/rust/src/secure_file.rs
+++ b/rust/src/secure_file.rs
@@ -36,7 +36,7 @@ const STATE_LOCK_STALE: std::time::Duration = std::time::Duration::from_secs(120
 ///
 /// Unix unlinks by name and never reports this state, so the retry is compiled
 /// in everywhere but only enabled where it can happen.
-const DELETE_PENDING_GRACE: std::time::Duration = std::time::Duration::from_secs(1);
+const DELETE_PENDING_GRACE: std::time::Duration = std::time::Duration::from_millis(250);
 const RETRIES_DELETE_PENDING: bool = cfg!(windows);
 
 /// Serialize read-modify-write transactions across Ceiling processes.
@@ -257,8 +257,12 @@ impl StateWriteLock {
             if !RETRIES_DELETE_PENDING {
                 return attempt;
             }
+            // A directory sitting on the sibling path is also access-denied on
+            // Windows, and unlike a closing handle it never clears. Retrying
+            // that only delays a failure the caller needs now.
             let denied = matches!(&attempt, LockAttempt::Failed(error)
-                if error.kind() == io::ErrorKind::PermissionDenied);
+                if error.kind() == io::ErrorKind::PermissionDenied)
+                && !exclusive.is_dir();
             if !denied || std::time::Instant::now() >= deadline {
                 return attempt;
             }
@@ -2000,7 +2004,13 @@ mod tests {
             attempts, 1,
             "a failed fallback must not be retried as success"
         );
-        assert!(started.elapsed() < std::time::Duration::from_secs(1));
+        // A directory on the sibling path is access-denied on Windows too, but
+        // it never clears. The delete-pending retry must not sit on it: this
+        // used to spend the whole grace period before failing.
+        assert!(
+            started.elapsed() < DELETE_PENDING_GRACE,
+            "an unfixable fallback must fail without waiting out the retry grace"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two unrelated flakes have each failed PRs today that did not touch them.

## 1. `TrayPanel > keeps a counted star ask visible when the tray is empty`

Failed on #367 and #355 with:

```
TypeError: Cannot read properties of undefined (reading 'then')
  The above error occurred in the <TrayPanel> component
```

`afterEach` calls `vi.restoreAllMocks()`, which resets every mock to the implementation it was **created** with — and for a bare `vi.fn()` that is "return undefined". `LocaleProvider` does `listen(...).then(...)`, so any call landing outside the `beforeEach`→test window throws.

It is always this test because it is the only one that sets `starPromptMocks.reason`, so it is the only one that renders the prompt and takes the slower path.

`eventMocks.listen` is now declared as `vi.fn(() => Promise.resolve(() => {}))`, so a restore leaves it harmless. `beforeEach` still installs the listener-capturing version the tests drive.

**Proof** — same file, forcing `eventMocks.listen.mockReset()` before the render:

| `listen` declared as | Result |
|---|---|
| `vi.fn()` (before) | `1 failed \| 24 passed` — the exact CI error |
| `vi.fn(() => Promise.resolve(…))` (after) | `25 passed` |

## 2. `an_unenforceable_lock_fails_closed_instead_of_writing_unserialized`

Failed on #355. **This one is my regression from #368.** That PR added a retry for Windows' delete-pending state, which reports access-denied. A *directory* planted at the sibling path — which is exactly what this test does — is also access-denied on Windows, but it never clears. The retry sat on it for the full second and broke the test's sub-second bound.

The retry now skips a directory, the grace drops from 1s to 250ms (still orders of magnitude longer than delete-pending needs), and the test asserts against `DELETE_PENDING_GRACE` rather than a bare literal so the two cannot drift.

## Verified

Frontend: **88 files, 707 tests passing.** Rust: 26 `secure_file` tests, clippy `-D warnings` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock change plus a narrower Windows lock retry that fails faster on an unfixable directory sibling. Does not change the successful lock or write path.
> 
> **Overview**
> Stops two unrelated CI flakes: a Vitest mock restore that made `listen()` return `undefined`, and a Windows exclusive-create retry that sat on a directory for the full grace period.
> 
> `eventMocks.listen` is now created as a function that resolves to an unsubscribe, so `vi.restoreAllMocks()` in `afterEach` no longer breaks `LocaleProvider`'s `listen(...).then(...)` outside the `beforeEach` window.
> 
> On the lock path, `try_exclusive_create` no longer retries `PermissionDenied` when the sibling is a directory (that never clears on Windows). `DELETE_PENDING_GRACE` drops from 1s to 250ms, and the fail-closed test asserts against that constant so it cannot drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 383d3b15c6e0ee1d03a049b4adb0df28ff61b9a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI flakes in `TrayPanel` test mock and `secure_file` lock retry logic
> - Changes the `eventMocks.listen` mock in [TrayPanel.test.tsx](https://github.com/tsouth89/ceiling/pull/369/files#diff-d28e96cb56241c4ab16b385da508fb6832756fb3f5b99c0ef7c2098ee0386269) to return a resolved Promise to prevent errors when mocks are restored.
> - Reduces `DELETE_PENDING_GRACE` from 1 second to 250 milliseconds in [secure_file.rs](https://github.com/tsouth89/ceiling/pull/369/files#diff-ad931c0d6c98745631dc7a8420f5f246909a8c5b9f80d9987e7f76df43b3e157).
> - Updates `StateWriteLock.try_exclusive_create` to fail fast when the lock path is a directory instead of retrying until the deadline.
> - Behavioral Change: `DELETE_PENDING_GRACE` reduction lowers the maximum wait time for exclusive-create retries on Windows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 383d3b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->