### PR TITLE
Honor refresh_interval_secs in desktop auto-refresh

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/auto_refresh.rs
+++ b/apps/desktop-tauri/src-tauri/src/auto_refresh.rs
@@ -46,13 +46,13 @@ pub fn install(app: tauri::AppHandle) {
                 if let Err(error) = refreshed {
                     tracing::warn!(%error, "Automatic provider refresh failed");
                 }
-                if scheduled_due {
-                    if let (Some(interval), Some(scheduled_at)) = (interval, scheduled_at) {
-                        schedule = Some((
-                            interval,
-                            next_fixed_tick(scheduled_at, Instant::now(), interval),
-                        ));
-                    }
+                if let (true, Some(interval), Some(scheduled_at)) =
+                    (scheduled_due, interval, scheduled_at)
+                {
+                    schedule = Some((
+                        interval,
+                        next_fixed_tick(scheduled_at, Instant::now(), interval),
+                    ));
                 }
             }
 

--- a/apps/desktop-tauri/src-tauri/src/auto_refresh.rs
+++ b/apps/desktop-tauri/src-tauri/src/auto_refresh.rs
@@ -9,24 +9,30 @@ use crate::commands::ProviderUsageSnapshot;
 use crate::state::AppState;
 
 const AUTO_REFRESH_POLL_INTERVAL: Duration = Duration::from_secs(15);
-const PROVIDER_REFRESH_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// `refresh_interval_secs = 0` is manual-only: no periodic background refresh.
+fn scheduled_refresh_interval(refresh_interval_secs: u64) -> Option<Duration> {
+    (refresh_interval_secs > 0).then(|| Duration::from_secs(refresh_interval_secs))
+}
 
 pub fn install(app: tauri::AppHandle) {
     tauri::async_runtime::spawn(async move {
         let mut schedule: Option<(Duration, Instant)> = None;
         let mut next_reset: Option<DateTime<Utc>> = None;
         loop {
-            let interval = PROVIDER_REFRESH_INTERVAL;
+            let interval = scheduled_refresh_interval(Settings::load().refresh_interval_secs);
             let now = Instant::now();
-            let scheduled_at = schedule
-                .filter(|(scheduled_interval, _)| *scheduled_interval == interval)
-                .map(|(_, scheduled_at)| scheduled_at)
-                .unwrap_or(now);
+            let scheduled_at = interval.map(|interval| {
+                schedule
+                    .filter(|(scheduled_interval, _)| *scheduled_interval == interval)
+                    .map(|(_, scheduled_at)| scheduled_at)
+                    .unwrap_or(now)
+            });
             // A window that just reset is the one moment a stale reading is most
             // visible, and reset notifications are only produced inside a refresh.
             // Waiting for the next fixed tick delayed them by minutes, so cross a
             // known boundary and refresh on this wake instead.
-            let scheduled_due = now >= scheduled_at;
+            let scheduled_due = scheduled_at.is_some_and(|scheduled_at| now >= scheduled_at);
             let reset_due = next_reset.is_some_and(|reset| Utc::now() >= reset);
 
             if scheduled_due || reset_due {
@@ -41,11 +47,17 @@ pub fn install(app: tauri::AppHandle) {
                     tracing::warn!(%error, "Automatic provider refresh failed");
                 }
                 if scheduled_due {
-                    schedule = Some((
-                        interval,
-                        next_fixed_tick(scheduled_at, Instant::now(), interval),
-                    ));
+                    if let (Some(interval), Some(scheduled_at)) = (interval, scheduled_at) {
+                        schedule = Some((
+                            interval,
+                            next_fixed_tick(scheduled_at, Instant::now(), interval),
+                        ));
+                    }
                 }
+            }
+
+            if interval.is_none() {
+                schedule = None;
             }
 
             // Only ever track a boundary that is still ahead of us. A provider
@@ -282,6 +294,27 @@ async fn check_spend_anomaly_alert(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn zero_refresh_interval_is_manual_only() {
+        assert_eq!(scheduled_refresh_interval(0), None);
+    }
+
+    #[test]
+    fn configured_refresh_interval_is_used() {
+        assert_eq!(
+            scheduled_refresh_interval(300),
+            Some(Duration::from_secs(300))
+        );
+        assert_eq!(
+            scheduled_refresh_interval(42),
+            Some(Duration::from_secs(42))
+        );
+        assert_eq!(
+            scheduled_refresh_interval(900),
+            Some(Duration::from_secs(900))
+        );
+    }
 
     #[test]
     fn fixed_cadence_advances_from_the_scheduled_tick() {

--- a/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
@@ -836,9 +836,8 @@ describe("FloatBar", () => {
     try {
       tauriMocks.getCachedProviders.mockResolvedValue([]);
       tauriMocks.getSettingsSnapshot.mockResolvedValue(settings());
-      // 60s minimum is enforced in FloatBar.tsx; use the floor here.
       await act(async () => {
-        renderFloatBar(bootstrap({ refreshIntervalSecs: 60 }));
+        renderFloatBar(bootstrap({ refreshIntervalSecs: 120 }));
       });
 
       // Initial tick fires synchronously on mount; useProviders is passive here
@@ -848,12 +847,30 @@ describe("FloatBar", () => {
       });
       const initialCalls = tauriMocks.refreshProvidersIfStale.mock.calls.length;
 
-      // Advance the timer past the 60-second interval — the floatbar tick
-      // should fire again.
-      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(119_000);
+      expect(tauriMocks.refreshProvidersIfStale.mock.calls.length).toBe(initialCalls);
+
+      await vi.advanceTimersByTimeAsync(1_000);
       expect(tauriMocks.refreshProvidersIfStale.mock.calls.length).toBeGreaterThan(
         initialCalls,
       );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not poll when refresh_interval_secs is 0 (manual only)", async () => {
+    vi.useFakeTimers();
+    try {
+      tauriMocks.getCachedProviders.mockResolvedValue([]);
+      tauriMocks.getSettingsSnapshot.mockResolvedValue(settings());
+      await act(async () => {
+        renderFloatBar(bootstrap({ refreshIntervalSecs: 0 }));
+      });
+
+      expect(tauriMocks.refreshProvidersIfStale).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(300_000);
+      expect(tauriMocks.refreshProvidersIfStale).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop-tauri/src/floatbar/FloatBar.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.tsx
@@ -510,9 +510,13 @@ export default function FloatBar({ state }: { state: BootstrapState }) {
 
   // The detached floatbar should keep usage fresh, but it must not open or
   // focus any other surface. Refresh data only; provider-updated events feed
-  // this window when the backend completes.
+  // this window when the backend completes. 0 = manual refresh only.
   useEffect(() => {
-    const intervalMs = Math.max(60_000, settings.refreshIntervalSecs * 1000);
+    const intervalSecs = settings.refreshIntervalSecs;
+    if (intervalSecs === 0) {
+      return;
+    }
+    const intervalMs = intervalSecs * 1000;
     const tick = () => {
       void refreshProvidersIfStale().catch(() => {});
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`SETTINGS_JSON.md` documents `refresh_interval_secs` as the desktop refresh cadence, with `0` meaning manual refresh only. The setting was stored and exposed on the bridge, but the live refresh paths ignored it:

- `auto_refresh.rs` always ticked every 5 minutes.
- FloatBar floored the interval at 60 seconds, so `0` still polled.

Both paths now read the setting. `0` skips periodic auto-refresh (manual only). Quota-reset fetches still run so reset alerts can fire. Manual refresh, tray/menu open, and `refresh_all_providers_on_menu_open` are unchanged.

Closes SBS-1027.

## Related issue

Fixes SBS-1027

## Affected areas

- [x] Tray panel
- [ ] Settings UI
- [x] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [x] Startup / background behavior
- [ ] Documentation
- [x] Other: FloatBar polling

## Validation

Hosted CI on `c27af820` is green (Frontend, Rust / shared, Rust / desktop, Rust).

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` (Windows script; not run in this Linux environment)
- [x] Other:
  - `pnpm --dir apps/desktop-tauri test` — 713 passed
  - `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --bin codexbar-desktop-tauri auto_refresh` — 7 passed
  - `cargo fmt --all` on both manifests
  - First desktop CI run failed clippy `collapsible_if`; flattened in `c27af820`. Re-run passed.

## UI / tray proof

- [x] Visual proof was not practical; manual validation and explanation attached

Interval behavior is timer-driven. Coverage is the unit tests: configured seconds are used, and `0` does not schedule a periodic tick.

## Notes for reviewers

- `SETTINGS_JSON.md` already described the intended behavior; no doc change.
- Reset-boundary refreshes stay automatic even when the interval is `0`, because reset notifications are produced only inside a refresh.
- One ticket only. Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-431cfea6-343d-4dac-8b72-95b927ea20a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-431cfea6-343d-4dac-8b72-95b927ea20a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `refresh_interval_secs` setting for desktop auto-refresh instead of fixed interval
> - Replaces the fixed `PROVIDER_REFRESH_INTERVAL` in the background task with a dynamic interval from `Settings::load().refresh_interval_secs` via the new `scheduled_refresh_interval` helper in [auto_refresh.rs](https://github.com/tsouth89/ceiling/pull/372/files#diff-3b4312d4d32d3f79f47b127a5abe61652a518216479b613e14f74bd28554d9eb)
> - A value of 0 disables periodic refresh entirely (manual-only mode); positive values are used exactly instead of enforcing a 60s minimum
> - Updates `FloatBar` polling in [FloatBar.tsx](https://github.com/tsouth89/ceiling/pull/372/files#diff-f22f77d98254e33904b23109b0f92837e226d8dc3ff6b8db7eb13081ee4a6901) to skip interval setup when `refreshIntervalSecs` is 0, while keeping the initial refresh on mount
> - Risk: scheduling state now carries `Option<(Duration, Instant)>`; rescheduling only occurs when a schedule exists and the schedule is cleared when the interval becomes `None` — reviewers should verify the `due` checks and `next_fixed_tick` calls handle the `None` case correctly
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c27af82.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->