### PR TITLE
Make bare `codexbar` run usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Ceiling] Unreleased
 
+### Fixed
+- **`codexbar` with no subcommand now runs `usage`.** CLI.md and `--help` already called usage the default command, but a bare `codexbar` printed an error asking for an explicit subcommand. It now does what those docs said. Closes SBS-1026.
+
 ## [Ceiling] 1.5.35 - 2026-08-22
 
 Charts stops showing numbers it cannot stand behind. A month whose models have no published prices painted as an empty one, the busiest day on the activity heatmap could share a shade with the quietest, and a Codex session carried whatever calendar day it was first parsed on, so a DST change or a trip moved usage onto the wrong day. Two cards scanning at once could overwrite each other's index, and a price refresh landing mid-scan stamped old dollars as current for every card already in the file.

--- a/rust/src/cli/mod.rs
+++ b/rust/src/cli/mod.rs
@@ -1,7 +1,7 @@
 //! CLI module - command-line interface
 //!
 //! Matches the original CodexBar CLI structure:
-//! - `codexbar` - launches the menu bar GUI app (default)
+//! - `codexbar` - print usage from enabled providers (default)
 //! - `codexbar usage` - print usage from providers
 //! - `codexbar cost` - print local token cost usage
 //! - `codexbar autostart` - manage Windows auto-start
@@ -172,7 +172,64 @@ impl Cli {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::CommandFactory;
+    use clap::{CommandFactory, Parser};
+
+    #[test]
+    fn bare_invocation_parses_as_default_usage() {
+        let cli = Cli::try_parse_from(["codexbar"]).expect("bare invocation should parse");
+        assert!(cli.command.is_none());
+
+        let args = cli.to_usage_args();
+        assert!(args.provider.is_none());
+        assert_eq!(args.format, usage::OutputFormat::Text);
+        assert!(!args.brief);
+        assert!(!args.json);
+    }
+
+    #[test]
+    fn top_level_usage_flags_map_onto_the_default_command() {
+        let cli = Cli::try_parse_from(["codexbar", "--provider", "all", "--brief", "--json"])
+            .expect("top-level usage flags should parse without a subcommand");
+        assert!(cli.command.is_none());
+
+        let args = cli.to_usage_args();
+        assert_eq!(args.provider.as_deref(), Some("all"));
+        assert!(args.brief);
+        assert_eq!(args.format, usage::OutputFormat::Json);
+        assert!(args.json);
+    }
+
+    #[test]
+    fn explicit_usage_subcommand_still_parses() {
+        let cli = Cli::try_parse_from(["codexbar", "usage", "--provider", "claude"])
+            .expect("explicit usage should parse");
+        match cli.command {
+            Some(Commands::Usage(args)) => {
+                assert_eq!(args.provider.as_deref(), Some("claude"));
+            }
+            other => panic!("expected usage subcommand, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn top_level_help_names_usage_as_the_default_command() {
+        let mut command = Cli::command();
+        let mut output = Vec::new();
+        command
+            .write_long_help(&mut output)
+            .expect("top-level help should render");
+
+        let help = String::from_utf8(output).expect("help should be valid utf-8");
+        assert!(
+            help.contains("default command"),
+            "help should name usage as the default: {help}"
+        );
+        assert!(
+            !help.contains("requires an explicit subcommand")
+                && !help.contains("codexbar is now CLI-only"),
+            "help should not claim a subcommand is required: {help}"
+        );
+    }
 
     #[test]
     fn top_level_help_mentions_nanogpt_provider() {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -442,9 +442,7 @@ fn launch_arg_summary() -> String {
 /// Whether an exit code is worth keeping a launch log for.
 ///
 /// Only a genuine failure is. A usage error is the user's typo, already
-/// explained on stderr, and `missing_subcommand` reaches here through the `Ok`
-/// path rather than clap's own exit, so bare `codexbar` would otherwise leave a
-/// file behind on every run.
+/// explained on stderr.
 fn keeps_launch_log(exit_code: i32) -> bool {
     exit_code != exit_codes::SUCCESS && exit_code != exit_codes::USAGE_ERROR
 }
@@ -521,7 +519,7 @@ fn run(log_path: Option<&Path>) -> i32 {
         }
     };
 
-    dispatch_command(&rt, cli.command)
+    dispatch_command(&rt, cli)
 }
 
 fn startup_log() -> String {
@@ -549,8 +547,9 @@ fn wsl_log() -> Option<String> {
     Some(log)
 }
 
-fn dispatch_command(rt: &Runtime, command: Option<Commands>) -> i32 {
-    match command {
+fn dispatch_command(rt: &Runtime, cli: Cli) -> i32 {
+    let default_usage = cli.to_usage_args();
+    match cli.command {
         Some(Commands::Usage(args)) => run_categorized(rt, cli::usage::run(args)),
         Some(Commands::Cost(args)) => run_categorized(rt, cli::cost::run(args)),
         Some(Commands::Diagnose(args)) => run_categorized(rt, cli::diagnose::run(args)),
@@ -561,7 +560,7 @@ fn dispatch_command(rt: &Runtime, command: Option<Commands>) -> i32 {
         Some(Commands::Autostart(args)) => run_unexpected(rt, cli::autostart::run(args)),
         Some(Commands::Account(args)) => run_unexpected(rt, cli::account::run(args)),
         Some(Commands::Config(args)) => run_unexpected(rt, cli::config::run(args)),
-        None => missing_subcommand(),
+        None => run_categorized(rt, cli::usage::run(default_usage)),
     }
 }
 
@@ -590,17 +589,6 @@ where
             error_code(&e)
         }
     }
-}
-
-fn missing_subcommand() -> i32 {
-    // The egui menubar shell has been retired; the desktop UI lives in
-    // apps/desktop-tauri. The CLI binary now requires an explicit subcommand.
-    eprintln!(
-        "codexbar is now CLI-only. Run a subcommand (e.g. `codexbar usage -p claude`) \
-         or launch the Tauri desktop shell via `apps/desktop-tauri`.\n\
-         Use `codexbar --help` for the full list of subcommands."
-    );
-    exit_codes::USAGE_ERROR
 }
 
 /// Categorize an error into the appropriate exit code
@@ -708,8 +696,7 @@ mod tests {
         assert!(!skips_launch_log(["codexbar", "--version"]));
     }
 
-    /// A usage error is the user's typo, already explained on stderr. Bare
-    /// `codexbar` returns it through the `Ok` path, not clap's own exit.
+    /// A usage error is the user's typo, already explained on stderr.
     #[test]
     fn only_real_failures_keep_their_log() {
         assert!(!keeps_launch_log(exit_codes::SUCCESS));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bare `codexbar` now runs `usage`, which is what CLI.md and `codexbar --help` already documented.

When the CLI stopped launching a GUI, the no-subcommand path started printing an error that asked for an explicit command. The clap schema still accepted top-level usage flags (`--provider`, `--brief`, …) and still labelled `usage` as the default command, so docs and shipped behavior disagreed.

This restores the documented default. `codexbar usage …` is unchanged. SBS-1027 is out of scope.

## Related issue

Closes SBS-1026.

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [x] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [x] Documentation
- [ ] Other:

## Validation

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` — Windows-only; not run here
- [x] Other:
  - `cargo test --manifest-path rust/Cargo.toml --lib cli::` — 77 passed
  - `cargo test --manifest-path rust/Cargo.toml --bin codexbar` — 32 passed
  - `cargo fmt --manifest-path rust/Cargo.toml -- --check` — clean
  - `cargo run --manifest-path rust/Cargo.toml -- --help` — `usage` is still labelled `(default command)` and `COMMAND` is optional
  - `cargo run --manifest-path rust/Cargo.toml --` — runs usage (provider fetch errors, not the old “CLI-only / explicit subcommand” message)
  - `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` — fails on two pre-existing unused items in `secure_file.rs` and `updater.rs`; not introduced here

## UI / tray proof

- [x] Not applicable

## Notes for reviewers

- `dispatch_command` now forwards a missing subcommand to `cli.to_usage_args()`, which already existed for this default.
- Tests cover bare parse, top-level usage flags, explicit `usage`, and `--help` still naming usage as the default.
- Do not merge (per ticket). Do not fold SBS-1027 into this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1327f771-a1b8-4cc4-8ab4-9179934ad27c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1327f771-a1b8-4cc4-8ab4-9179934ad27c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make bare `codexbar` run `usage` by default
> - Changes `dispatch_command` to accept the full `Cli` struct and run the `usage` command via `to_usage_args()` when no subcommand is given, instead of printing a missing-subcommand error.
> - Removes the `missing_subcommand` function and updates the CLI module doc to state that `codexbar` prints usage from enabled providers by default.
> - Adds tests covering bare invocation, top-level flag mapping onto the default command, and explicit `usage` subcommand parsing.
> - Behavioral Change: bare `codexbar` previously exited with a usage error; it now runs `cli::usage::run` with default args derived from top-level flags.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a9101e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->