### PR TITLE
Keep MCP get_status cheap for today_spend (SBS-1033)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Remembered window positions no longer drop a sibling when two surfaces save at once.** `window_geometry.json` was updated with an unlocked read-modify-write, so moving Settings while the float bar or Pop Out also wrote could replace the file with a snapshot that had never seen the other key. Geometry persist now holds the same cross-process state lock as settings and credentials. Closes SBS-1024.
 - **`codexbar` with no subcommand now runs `usage`.** CLI.md and `--help` already called usage the default command, but a bare `codexbar` printed an error asking for an explicit subcommand. It now does what those docs said. Closes SBS-1026.
 - **A corrupt `settings.json` is no longer renamed to `.bak` without the state lock.** SBS-954 moved an unparseable file aside so the next save could not overwrite it, but `Settings::load` did that rename before taking the lock. A concurrent `try_update` that had already written a good repair could then have that repair moved to `settings.json.bak`. The unlocked load now only parses; if the file is corrupt (or still carries embedded credentials) it takes the lock, re-reads, and quarantines only then. Closes SBS-1029.
+- **MCP `get_status` no longer runs a 30-day local cost scan to fill today's spend.** The tool is advertised as a cheap "am I about to hit my cap?" check, but it called the same 30-day Codex/Claude/Grok walk as `get_spend` just to read `today`. It now scans one inclusive local day for `today_spend`. Use `get_spend` for 7/30-day totals. Closes SBS-1033.
 
 ## [Ceiling] 1.5.35 - 2026-08-22
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -169,6 +169,8 @@ codexbar statusline --provider codex --no-cost
 
 Expose usage and spend over MCP stdio. Local-first, no network.
 
+Tools: `get_usage` reads the desktop widget snapshot (cache-only). `get_status` is the cheap cap check — snapshot quota plus today's estimated spend from a 1-day local log scan, not a 30-day rescan. `get_spend` walks local Codex/Claude/Grok logs for today, 7 days, and 30 days.
+
 ```text
 codexbar mcp [OPTIONS]
 ```

--- a/rust/src/cli/mcp.rs
+++ b/rust/src/cli/mcp.rs
@@ -2,8 +2,10 @@
 //!
 //! Speaks Model Context Protocol over stdio so Claude Code / Codex can query
 //! remaining quota and estimated spend mid-conversation. Quota comes from the
-//! desktop widget snapshot (cache-only, no network). Spend comes from local
-//! Codex, Claude, and Grok session logs via [`crate::cost_scanner`].
+//! desktop widget snapshot (cache-only, no network). `get_spend` walks local
+//! Codex, Claude, and Grok session logs via [`crate::cost_scanner`] for today,
+//! 7 days, and 30 days. `get_status` reuses the snapshot and a 1-day spend
+//! scan so a cap check does not pay for that 30-day walk.
 
 use clap::Args;
 use rmcp::{
@@ -93,7 +95,7 @@ impl CeilingMcp {
     }
 
     #[tool(
-        description = "Compact status: remaining quota + today's estimated spend for one provider (or the best available). Good for 'am I about to hit my cap?' checks."
+        description = "Cheap compact status: remaining quota from the desktop snapshot plus today's estimated spend from a 1-day local log scan (not the 30-day get_spend walk). Good for 'am I about to hit my cap?' checks. Use get_spend for 7/30-day totals."
     )]
     fn get_status(
         &self,
@@ -116,10 +118,11 @@ impl ServerHandler for CeilingMcp {
             .with_protocol_version(ProtocolVersion::V_2024_11_05)
             .with_instructions(
                 "Ceiling local usage/spend tools. get_usage reads the desktop widget snapshot \
-(cache-only). get_spend scans local Codex/Claude/Grok logs. Prefer get_status for a quick \
-remaining-quota + today-$ check before starting a large job. Values are estimated API \
-value, never a billed invoice. Account email and login method are omitted unless the \
-server was started with --include-identity."
+(cache-only). get_spend scans local Codex/Claude/Grok logs for today, 7 days, and 30 days. \
+Prefer get_status for a cheap remaining-quota + today-$ check before starting a large job; \
+it does not run the 30-day spend scan. Values are estimated API value, never a billed \
+invoice. Account email and login method are omitted unless the server was started with \
+--include-identity."
                     .to_string(),
             )
     }
@@ -260,6 +263,17 @@ fn window_json(window: Option<&RateWindow>) -> serde_json::Value {
     })
 }
 
+/// Inclusive local calendar days `get_spend` walks for today / 7-day / 30-day totals.
+const GET_SPEND_DAYS: u32 = 30;
+
+/// Inclusive local calendar days `get_status` walks for `today_spend`.
+///
+/// SBS-1033: agents treat get_status as a cheap cap check. Filling today's
+/// dollars with the 30-day chart scan made that entry point as expensive as
+/// get_spend. One day is enough for `today` and matches Codex/Claude
+/// `--days 1` (plus the scanner's usual one-day timezone padding).
+const STATUS_TODAY_SPEND_DAYS: u32 = 1;
+
 fn spend_payload(provider: Option<&str>, enabled: &[ProviderId]) -> serde_json::Value {
     let targets: Vec<&str> = match provider {
         Some(name) => {
@@ -283,7 +297,7 @@ fn spend_payload(provider: Option<&str>, enabled: &[ProviderId]) -> serde_json::
 
     let mut providers = Vec::new();
     for cli in targets {
-        match get_cost_usage_report(cli, 30) {
+        match get_cost_usage_report(cli, GET_SPEND_DAYS) {
             Some(report) => providers.push(json!({
                 "provider": cli,
                 "supported": true,
@@ -334,6 +348,22 @@ fn status_payload(
     enabled: &[ProviderId],
     include_identity: bool,
 ) -> serde_json::Value {
+    status_payload_with_spend(
+        snapshot,
+        provider,
+        enabled,
+        include_identity,
+        today_spend_summary,
+    )
+}
+
+fn status_payload_with_spend(
+    snapshot: Option<&WidgetSnapshot>,
+    provider: Option<&str>,
+    enabled: &[ProviderId],
+    include_identity: bool,
+    spend_for: impl Fn(&str) -> Option<serde_json::Value>,
+) -> serde_json::Value {
     if let Some(name) = provider
         && ProviderId::from_cli_name(name).is_none()
     {
@@ -361,7 +391,7 @@ fn status_payload(
         if !allowed {
             return None;
         }
-        get_cost_usage_report(cli, 30).map(|report| summary_json(&report.today))
+        spend_for(cli)
     });
 
     let remaining = usage
@@ -382,6 +412,10 @@ fn status_payload(
             None
         },
     })
+}
+
+fn today_spend_summary(cli: &str) -> Option<serde_json::Value> {
+    get_cost_usage_report(cli, STATUS_TODAY_SPEND_DAYS).map(|report| summary_json(&report.today))
 }
 
 fn choose_status_provider(
@@ -509,13 +543,20 @@ mod tests {
         assert_eq!(spend["providers"][0]["supported"], true);
     }
 
+    fn status_without_spend_scan(
+        snapshot: Option<&WidgetSnapshot>,
+        provider: Option<&str>,
+        enabled: &[ProviderId],
+    ) -> serde_json::Value {
+        status_payload_with_spend(snapshot, provider, enabled, false, |_| None)
+    }
+
     #[test]
     fn status_rejects_unknown_provider() {
-        let payload = status_payload(
+        let payload = status_without_spend_scan(
             Some(&sample_snapshot()),
             Some("not-a-provider"),
             &default_enabled(),
-            false,
         );
         assert_eq!(payload["ok"], false);
         assert!(
@@ -530,7 +571,7 @@ mod tests {
     #[test]
     fn status_prefers_claude_when_present() {
         let snap = sample_snapshot();
-        let payload = status_payload(Some(&snap), None, &default_enabled(), false);
+        let payload = status_without_spend_scan(Some(&snap), None, &default_enabled());
         assert_eq!(payload["provider"], "claude");
         assert_eq!(payload["remaining_percent"], 58.0);
     }
@@ -564,12 +605,66 @@ mod tests {
     #[test]
     fn status_skips_disabled_snapshot_providers() {
         let snap = sample_snapshot();
-        let payload = status_payload(Some(&snap), None, &[ProviderId::Codex], false);
+        let payload = status_without_spend_scan(Some(&snap), None, &[ProviderId::Codex]);
         assert!(payload["provider"].is_null(), "payload: {payload}");
         assert!(payload["usage"].is_null(), "payload: {payload}");
 
-        let explicit = status_payload(Some(&snap), Some("claude"), &[ProviderId::Codex], false);
+        let explicit = status_without_spend_scan(Some(&snap), Some("claude"), &[ProviderId::Codex]);
         assert_eq!(explicit["provider"], "claude");
         assert_eq!(explicit["remaining_percent"], 58.0);
+    }
+
+    /// SBS-1033: get_status is advertised as a cheap cap check. A 30-day
+    /// local-log walk just to fill `today_spend` made it as expensive as
+    /// get_spend. Today's dollars only need one inclusive local day.
+    #[test]
+    fn status_today_spend_uses_one_day_window_not_thirty() {
+        assert_eq!(STATUS_TODAY_SPEND_DAYS, 1);
+        assert_eq!(GET_SPEND_DAYS, 30);
+        assert_ne!(
+            STATUS_TODAY_SPEND_DAYS, GET_SPEND_DAYS,
+            "get_status must not reuse get_spend's 30-day scan window"
+        );
+    }
+
+    #[test]
+    fn status_includes_today_spend_from_one_day_lookup() {
+        let snap = sample_snapshot();
+        let mut scanned = Vec::new();
+        let payload = status_payload_with_spend(
+            Some(&snap),
+            Some("claude"),
+            &default_enabled(),
+            false,
+            |cli| {
+                scanned.push(cli.to_string());
+                Some(json!({
+                    "total_usd": 1.25,
+                    "has_data": true,
+                }))
+            },
+        );
+        assert_eq!(scanned, vec!["claude"]);
+        assert_eq!(payload["ok"], true);
+        assert_eq!(payload["today_spend"]["total_usd"], 1.25);
+        assert_eq!(payload["today_spend"]["has_data"], true);
+    }
+
+    #[test]
+    fn status_skips_today_spend_for_providers_without_local_logs() {
+        let snap = sample_snapshot();
+        let mut scanned = 0u32;
+        let payload = status_payload_with_spend(
+            Some(&snap),
+            Some("cursor"),
+            &default_enabled(),
+            false,
+            |_| {
+                scanned += 1;
+                Some(json!({ "total_usd": 9.99 }))
+            },
+        );
+        assert_eq!(scanned, 0);
+        assert!(payload["today_spend"].is_null(), "payload: {payload}");
     }
 }

--- a/rust/src/cli/mcp.rs
+++ b/rust/src/cli/mcp.rs
@@ -362,7 +362,7 @@ fn status_payload_with_spend(
     provider: Option<&str>,
     enabled: &[ProviderId],
     include_identity: bool,
-    spend_for: impl Fn(&str) -> Option<serde_json::Value>,
+    mut spend_for: impl FnMut(&str) -> Option<serde_json::Value>,
 ) -> serde_json::Value {
     if let Some(name) = provider
         && ProviderId::from_cli_name(name).is_none()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

MCP `get_status` advertised a cheap “am I about to hit my cap?” check, but filled `today_spend` by calling `get_cost_usage_report(..., 30)` — the same full 30-day Codex/Claude/Grok local-log walk as `get_spend`. That made the recommended agent entry point as expensive as the history tool.

`get_status` now derives `today_spend` from a **1-day** inclusive local calendar scan (`STATUS_TODAY_SPEND_DAYS = 1`). Codex still only walks today’s date-nested session dirs (plus the usual one-day timezone padding). Claude still only opens transcripts touched since local midnight. Grok’s cutoff is one day instead of thirty.

`get_spend` is unchanged: it still walks 30 days for today / 7-day / 30-day totals. Distinct from SBS-1031 (mislabel).

## Related issue

Closes SBS-1033.

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [x] CLI (`codexbar mcp` `get_status`)
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [x] Documentation
- [ ] Other:

## Validation

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` (Windows host script; not run here)
- [x] Other:
  - `cargo test --manifest-path rust/Cargo.toml --lib cli::mcp` — 13 passed
  - `cargo test --manifest-path rust/Cargo.toml --lib` — 1112 passed
  - `cargo fmt --all --manifest-path rust/Cargo.toml -- --check` — clean
  - `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` — not clean on Linux for two pre-existing unused items in `secure_file.rs` / `updater.rs` (Windows-only paths). CI clippy runs on `windows-latest`.

## UI / tray proof

- [x] Not applicable

## Notes for reviewers

**Perf:** `get_status` no longer pays for a 30-day transcript walk on every cap check. Agents should keep using `get_status` for remaining quota + today’s dollars, and call `get_spend` only when they need 7/30-day totals.

The JSON shape of `today_spend` is unchanged (`summary_json` of the `today` window). Only the scan window backing it is narrower.

Do not merge until review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3073b837-0458-4f03-909c-2cf02b0b6613?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3073b837-0458-4f03-909c-2cf02b0b6613&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP `get_status` to use 1-day local scan for `today_spend`
> - `get_status` now computes `today_spend` from a 1-day inclusive local log window instead of a 30-day `get_cost_usage_report` walk, keeping it cheap as a cap check
> - Extracts `GET_SPEND_DAYS` (30) and `STATUS_TODAY_SPEND_DAYS` (1) constants in [mcp.rs](https://github.com/tsouth89/ceiling/pull/374/files#diff-b95d11b9777f7600bb21233c37bc665b73766de3a7c1cca56e175ae0394c787d), replacing hardcoded literals
> - Refactors `status_payload` to delegate to a new `status_payload_with_spend` helper that takes an injectable spend closure; `today_spend_summary` provides the 1-day lookup
> - Updates module docs, tool descriptions, and [CLI.md](https://github.com/tsouth89/ceiling/pull/374/files#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761) to clarify the cost and intent of `get_status` vs `get_spend`
> - Behavioral Change: `status_payload` `today_spend` now reflects a 1-day window; providers without local logs yield `null` rather than triggering a scan
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c68c4d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->