### PR TITLE
Hold the state lock around settings.json quarantine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - **`codexbar` with no subcommand now runs `usage`.** CLI.md and `--help` already called usage the default command, but a bare `codexbar` printed an error asking for an explicit subcommand. It now does what those docs said. Closes SBS-1026.
+- **A corrupt `settings.json` is no longer renamed to `.bak` without the state lock.** SBS-954 moved an unparseable file aside so the next save could not overwrite it, but `Settings::load` did that rename before taking the lock. A concurrent `try_update` that had already written a good repair could then have that repair moved to `settings.json.bak`. The unlocked load now only parses; if the file is corrupt (or still carries embedded credentials) it takes the lock, re-reads, and quarantines only then. Closes SBS-1029.
 
 ## [Ceiling] 1.5.35 - 2026-08-22
 

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -812,18 +812,19 @@ impl Settings {
 
     /// Load settings from disk
     pub fn load() -> Self {
-        let settings = Self::load_from_disk();
-        if !settings.has_legacy_credentials() {
+        let (settings, pending_quarantine) = Self::load_from_disk(false);
+        if !pending_quarantine && !settings.has_legacy_credentials() {
             return settings;
         }
 
-        // Loading can become a write when an older settings file still embeds
-        // credentials. Re-read after taking the lock so two processes cannot
-        // migrate stale snapshots over newer secure-store contents.
+        // Loading can become a write: an older file may still embed
+        // credentials, and SBS-954's quarantine rename is a write too.
+        // Re-read after taking the lock so those writes cannot move a
+        // concurrent try_update repair to settings.json.bak (SBS-1029).
         match crate::secure_file::with_state_write_lock(|| Ok(Self::load_unlocked())) {
             Ok(settings) => settings,
             Err(error) => {
-                tracing::warn!(%error, "Failed to lock legacy settings credential migration");
+                tracing::warn!(%error, "Failed to lock settings load that may write");
                 settings
             }
         }
@@ -831,7 +832,7 @@ impl Settings {
 
     /// Load and migrate settings while the caller holds the state write lock.
     fn load_unlocked() -> Self {
-        let mut settings = Self::load_from_disk();
+        let (mut settings, _) = Self::load_from_disk(true);
 
         if let Some(sanitized) = settings.migrate_legacy_credentials() {
             match sanitized.and_then(|sanitized| {
@@ -848,16 +849,19 @@ impl Settings {
         settings
     }
 
-    fn load_from_disk() -> Self {
+    /// Read `settings.json`. `allow_quarantine` is the rename from SBS-954;
+    /// only the locked path may set it. The second value is `true` when the
+    /// file existed, failed to parse, and was left in place so `load` can
+    /// retry under the state lock (SBS-1029).
+    fn load_from_disk(allow_quarantine: bool) -> (Self, bool) {
+        let mut pending_quarantine = false;
         #[allow(unused_mut)]
         let mut settings = match Self::settings_path() {
-            Some(path) if path.exists() => match crate::secure_file::read_string(&path) {
-                Ok(content) => Self::parse_or_quarantine(&path, &content),
-                Err(error) => {
-                    tracing::warn!(%error, "settings.json could not be read; using defaults");
-                    Self::default()
-                }
-            },
+            Some(path) if path.exists() => {
+                let (settings, pending) = Self::read_path(&path, allow_quarantine);
+                pending_quarantine = pending;
+                settings
+            }
             _ => Self::default(),
         };
 
@@ -867,30 +871,58 @@ impl Settings {
             settings.start_at_login = Self::sync_start_at_login_registry();
         }
 
-        settings
+        (settings, pending_quarantine)
+    }
+
+    fn read_path(path: &std::path::Path, allow_quarantine: bool) -> (Self, bool) {
+        match crate::secure_file::read_string(path) {
+            Ok(content) => match Self::parse_settings_json(&content) {
+                Ok(settings) => (settings, false),
+                Err(error) if allow_quarantine => {
+                    Self::quarantine_unparseable(path, &error);
+                    (Self::default(), false)
+                }
+                Err(_) => (Self::default(), true),
+            },
+            Err(error) => {
+                tracing::warn!(%error, "settings.json could not be read; using defaults");
+                (Self::default(), false)
+            }
+        }
+    }
+
+    fn parse_settings_json(content: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(content.trim_start_matches('\u{feff}'))
     }
 
     /// Parse `settings.json`, or move a corrupt file aside so the next save
     /// cannot overwrite the user's last known contents.
+    ///
+    /// The caller must hold the state write lock. Renaming without it can
+    /// move a concurrent [`Self::try_update`] repair to `.bak` (SBS-1029).
     pub(crate) fn parse_or_quarantine(path: &std::path::Path, content: &str) -> Self {
-        match serde_json::from_str(content.trim_start_matches('\u{feff}')) {
+        match Self::parse_settings_json(content) {
             Ok(settings) => settings,
             Err(error) => {
-                let backup = Self::backup_path(path);
-                match std::fs::rename(path, &backup) {
-                    Ok(()) => tracing::warn!(
-                        %error,
-                        backup = %backup.display(),
-                        "settings.json could not be parsed; original moved aside and defaults loaded"
-                    ),
-                    Err(rename_error) => tracing::warn!(
-                        %error,
-                        %rename_error,
-                        "settings.json could not be parsed; falling back to defaults without a backup"
-                    ),
-                }
+                Self::quarantine_unparseable(path, &error);
                 Self::default()
             }
+        }
+    }
+
+    fn quarantine_unparseable(path: &std::path::Path, error: &serde_json::Error) {
+        let backup = Self::backup_path(path);
+        match std::fs::rename(path, &backup) {
+            Ok(()) => tracing::warn!(
+                %error,
+                backup = %backup.display(),
+                "settings.json could not be parsed; original moved aside and defaults loaded"
+            ),
+            Err(rename_error) => tracing::warn!(
+                %error,
+                %rename_error,
+                "settings.json could not be parsed; falling back to defaults without a backup"
+            ),
         }
     }
 

--- a/rust/src/settings/tests.rs
+++ b/rust/src/settings/tests.rs
@@ -1640,6 +1640,58 @@ fn unparseable_settings_are_moved_aside_instead_of_overwritten() {
     );
 }
 
+/// SBS-1029: `Settings::load` used to call [`Settings::parse_or_quarantine`]
+/// without the state lock. A concurrent locked [`Settings::try_update`] can
+/// write a good repair after this thread read the corrupt bytes; renaming
+/// then would move that repair to `.bak`.
+#[test]
+fn unlocked_corrupt_read_does_not_rename_a_concurrent_repair() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("settings.json");
+    let original = "{\"refresh_interval_secs\":\"60\"";
+    std::fs::write(&path, original).expect("write corrupt settings");
+
+    let (loaded, pending_quarantine) = Settings::read_path(&path, false);
+    assert!(
+        pending_quarantine,
+        "an unlocked parse failure must ask load() to retry under the lock"
+    );
+    assert_eq!(
+        loaded.refresh_interval_secs,
+        Settings::default().refresh_interval_secs
+    );
+    assert!(
+        path.exists(),
+        "the unlocked path must leave the live file in place"
+    );
+    assert!(
+        !Settings::backup_path(&path).exists(),
+        "the unlocked path must not create a backup"
+    );
+
+    // Locked try_update repair occupies the live path (SBS-954 / SBS-1029).
+    let repaired = "{\n  \"refresh_interval_secs\": 42\n}";
+    std::fs::write(&path, repaired).expect("write repair");
+
+    // load() re-reads under the lock. The file is valid now, so quarantine
+    // must not run and the repair must stay.
+    let (reloaded, pending_after_repair) = Settings::read_path(&path, true);
+    assert!(
+        !pending_after_repair,
+        "a successful locked re-read has nothing left to quarantine"
+    );
+    assert_eq!(reloaded.refresh_interval_secs, 42);
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read live"),
+        repaired,
+        "the repair must stay at the live path"
+    );
+    assert!(
+        !Settings::backup_path(&path).exists(),
+        "a good repair must not be moved to .bak"
+    );
+}
+
 /// SBS-964: a privacy-conscious reader who leaves incident badges off still
 /// sees models.dev and GitHub traffic. Claiming the badge is the only
 /// non-provider outbound request is false; the copy has to name those hosts.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SBS-954/#344 renamed an unparseable `settings.json` to `settings.json.bak` so the next save could not overwrite the user's last known contents. That rename ran from `Settings::load` → `parse_or_quarantine` **outside** the shared state lock.

A concurrent locked `try_update` can write a good repair at the live path after the unlocked load has already read the corrupt bytes. The unlocked rename then moves that repair to `.bak`.

`Settings::load` now parses without renaming. If the file is corrupt (or still carries embedded credentials) it takes the state lock, re-reads, and quarantines only then — the same protocol already used for legacy credential migration.

Closes SBS-1029. Completes the lock coverage left open by SBS-954.

## Related issue

Fixes SBS-1029 (incomplete SBS-954 / #344)

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [x] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [x] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

Hosted CI is the Windows/frontend gate. Local checks run here:

- [x] `cargo test --manifest-path rust/Cargo.toml --lib -- unparseable_settings unlocked_corrupt_read` — 2 passed
- [x] `cargo test --manifest-path rust/Cargo.toml --lib settings::` — 92 passed
- [x] `cargo fmt --all --manifest-path rust/Cargo.toml` on the touched files
- [x] Hosted CI: Frontend, Rust / shared, Rust / desktop, CodeQL, Bugbot, Cursor Security — all passed
- [ ] `github-advanced-security` (Copilot Autofind) failed with `You are not licensed to use Copilot` — org/license infra, not a finding on this diff
- [ ] `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` — not clean on this branch: two pre-existing errors on `main` (`unused variable: error` in `rust/src/secure_file.rs:824`, unused `verify_installer_signature_or_delete` in `rust/src/updater.rs:514`). Neither is in this change.
- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` — not run (Linux agent)

## UI / tray proof

- [x] Not applicable

## Notes for reviewers

- Happy-path `Settings::load` still does not take the write lock (same as today). Only a parse failure or leftover embedded credentials take it, then re-read.
- `parse_or_quarantine` is still the rename helper and still requires the caller to hold the lock. The new test drives `read_path` unlocked then locked to show a concurrent repair is left in place.
- Do not merge from this agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54175812-bf21-4a6a-b588-8d9e5ea68942?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54175812-bf21-4a6a-b588-8d9e5ea68942&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hold state lock before quarantining corrupt `settings.json`
> - `Settings::load` no longer renames a corrupt `settings.json` to `.bak` on the unlocked path. It parses first and defers quarantine to the locked path via `load_from_disk(false)`.
> - `load_from_disk` now returns `(Self, bool)` where the bool signals `pending_quarantine`; `read_path` and `quarantine_unparseable` centralize the read/parse/rename logic.
> - New test `unlocked_corrupt_read_does_not_rename_a_concurrent_repair` verifies an unlocked read does not rename and a later locked read after external repair preserves the live file.
> - Risk: `load_from_disk` signature changed to return `(Self, bool)`; all callers in [settings.rs](https://github.com/tsouth89/ceiling/pull/376/files#diff-e942ff1cc196680bb9d65bc031007c839badedb1435f2c5ac11ccea8b882055d) are updated, but out-of-tree callers would break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9288d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->