### PR TITLE
Lock window geometry persist so sibling positions cannot clobber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Ceiling] Unreleased
 
 ### Fixed
+- **Remembered window positions no longer drop a sibling when two surfaces save at once.** `window_geometry.json` was updated with an unlocked read-modify-write, so moving Settings while the float bar or Pop Out also wrote could replace the file with a snapshot that had never seen the other key. Geometry persist now holds the same cross-process state lock as settings and credentials. Closes SBS-1024.
 - **`codexbar` with no subcommand now runs `usage`.** CLI.md and `--help` already called usage the default command, but a bare `codexbar` printed an error asking for an explicit subcommand. It now does what those docs said. Closes SBS-1026.
 
 ## [Ceiling] 1.5.35 - 2026-08-22

--- a/apps/desktop-tauri/src-tauri/src/geometry_store.rs
+++ b/apps/desktop-tauri/src-tauri/src/geometry_store.rs
@@ -10,7 +10,8 @@
 //! carry fabricated `x`/`y` coordinates.
 
 use std::fs;
-use std::path::PathBuf;
+use std::io;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -86,7 +87,11 @@ fn load_file() -> GeometryFile {
     let Some(path) = geometry_path() else {
         return GeometryFile::default();
     };
-    let Ok(raw) = fs::read_to_string(&path) else {
+    load_file_from(&path)
+}
+
+fn load_file_from(path: &Path) -> GeometryFile {
+    let Ok(raw) = fs::read_to_string(path) else {
         return GeometryFile::default();
     };
     let mut file: GeometryFile = serde_json::from_str(&raw).unwrap_or_default();
@@ -109,15 +114,39 @@ fn migrate(file: &mut GeometryFile) {
     }
 }
 
-fn save_file(file: &GeometryFile) -> Result<(), String> {
+fn save_file_to(path: &Path, file: &GeometryFile) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(file).map_err(io::Error::other)?;
+    codexbar::secure_file::atomic_write(path, json.as_bytes())
+}
+
+/// Load, mutate, and atomically replace the geometry file while holding the
+/// same cross-process lock as settings and credentials (SBS-1024).
+///
+/// Each persist is a full-file rewrite. Without the lock, two surfaces that
+/// move at once can each load a snapshot that lacks the other's key and the
+/// later write drops that sibling position.
+fn persist(mutate: impl FnOnce(&mut GeometryFile)) -> Result<(), String> {
     let Some(path) = geometry_path() else {
         return Err("No config directory available".into());
     };
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-    }
-    let json = serde_json::to_string_pretty(file).map_err(|e| e.to_string())?;
-    codexbar::secure_file::atomic_write(&path, json.as_bytes()).map_err(|e| e.to_string())
+    persist_at(&path, mutate)
+}
+
+fn persist_at(path: &Path, mutate: impl FnOnce(&mut GeometryFile)) -> Result<(), String> {
+    persist_locked(path, mutate).map_err(|e| e.to_string())
+}
+
+fn persist_locked(path: &Path, mutate: impl FnOnce(&mut GeometryFile)) -> io::Result<()> {
+    codexbar::secure_file::with_state_write_lock(|| {
+        let mut file = load_file_from(path);
+        mutate(&mut file);
+        #[cfg(test)]
+        linger_after_load_for_tests();
+        save_file_to(path, &file)
+    })
 }
 
 /// Look up remembered geometry for a surface mode. Returns `None` when the
@@ -146,10 +175,10 @@ pub fn load_entry(key: &str) -> Option<StoredGeometry> {
 
 /// Persist geometry under an arbitrary key.
 pub fn save_entry(key: &str, geometry: StoredGeometry) {
-    let mut file = load_file();
-    file.version = GEOMETRY_VERSION;
-    file.entries.insert(key.to_string(), geometry);
-    if let Err(err) = save_file(&file) {
+    if let Err(err) = persist(|file| {
+        file.version = GEOMETRY_VERSION;
+        file.entries.insert(key.to_string(), geometry);
+    }) {
         tracing::warn!(target: "codexbar::geometry", %err, "failed to persist geometry");
     }
 }
@@ -194,17 +223,63 @@ pub fn load_size(key: &str) -> Option<StoredSize> {
 
 /// Persist a size-only entry under an arbitrary key.
 pub fn save_size(key: &str, size: StoredSize) {
-    let mut file = load_file();
-    file.version = GEOMETRY_VERSION;
-    file.size_entries.insert(key.to_string(), size);
-    if let Err(err) = save_file(&file) {
+    if let Err(err) = persist(|file| {
+        file.version = GEOMETRY_VERSION;
+        file.size_entries.insert(key.to_string(), size);
+    }) {
         tracing::warn!(target: "codexbar::geometry", %err, "failed to persist size");
+    }
+}
+
+#[cfg(test)]
+static LINGER_AFTER_LOAD: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Widen the unlocked RMW window so the sibling-key race is not a flake.
+/// Held lock + linger only delays the other writer; that is the SBS-1024 window.
+#[cfg(test)]
+fn linger_after_load_for_tests() {
+    if LINGER_AFTER_LOAD.load(std::sync::atomic::Ordering::SeqCst) > 0 {
+        std::thread::sleep(std::time::Duration::from_millis(80));
+    }
+}
+
+#[cfg(test)]
+struct LingerOn;
+
+#[cfg(test)]
+impl LingerOn {
+    fn arm() -> Self {
+        LINGER_AFTER_LOAD.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for LingerOn {
+    fn drop(&mut self) {
+        LINGER_AFTER_LOAD.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn save_entry_at(path: &Path, key: &str, geometry: StoredGeometry) {
+        persist_at(path, |file| {
+            file.version = GEOMETRY_VERSION;
+            file.entries.insert(key.to_string(), geometry);
+        })
+        .expect("persist geometry");
+    }
+
+    fn save_size_at(path: &Path, key: &str, size: StoredSize) {
+        persist_at(path, |file| {
+            file.version = GEOMETRY_VERSION;
+            file.size_entries.insert(key.to_string(), size);
+        })
+        .expect("persist size");
+    }
 
     #[test]
     fn pop_out_and_settings_are_remembered() {
@@ -226,30 +301,24 @@ mod tests {
     #[test]
     fn non_remembered_mode_save_is_noop() {
         // Call should not panic or error for ineligible modes.
-        save(
-            SurfaceMode::Hidden,
-            StoredGeometry {
-                x: 1,
-                y: 2,
-                width: Some(420),
-                height: Some(560),
-            },
-        );
+        save(SurfaceMode::Hidden, StoredGeometry {
+            x: 1,
+            y: 2,
+            width: Some(420),
+            height: Some(560),
+        });
         assert!(load(SurfaceMode::Hidden).is_none());
     }
 
     #[test]
     fn geometry_file_round_trip() {
         let mut f = GeometryFile::default();
-        f.entries.insert(
-            "settings".into(),
-            StoredGeometry {
-                x: 100,
-                y: 200,
-                width: Some(520),
-                height: Some(600),
-            },
-        );
+        f.entries.insert("settings".into(), StoredGeometry {
+            x: 100,
+            y: 200,
+            width: Some(520),
+            height: Some(600),
+        });
         let json = serde_json::to_string(&f).unwrap();
         let parsed: GeometryFile = serde_json::from_str(&json).unwrap();
         let entry = parsed.entries.get("settings").unwrap();
@@ -301,13 +370,10 @@ mod tests {
     #[test]
     fn stored_size_round_trips_without_position_fields() {
         let mut f = GeometryFile::default();
-        f.size_entries.insert(
-            "flyout".into(),
-            StoredSize {
-                width: 400,
-                height: 820,
-            },
-        );
+        f.size_entries.insert("flyout".into(), StoredSize {
+            width: 400,
+            height: 820,
+        });
         let json = serde_json::to_string(&f).unwrap();
         // The size-only entry must never carry x/y — that's the whole point
         // of keeping it out of `entries: BTreeMap<String, StoredGeometry>`.
@@ -322,22 +388,17 @@ mod tests {
     #[test]
     fn resolve_size_prefers_new_key_over_legacy() {
         let mut file = GeometryFile::default();
-        file.size_entries.insert(
-            "flyout".into(),
-            StoredSize {
-                width: 500,
-                height: 900,
-            },
-        );
-        file.entries.insert(
-            LEGACY_FLYOUT_SIZE_KEY.into(),
-            StoredGeometry {
+        file.size_entries.insert("flyout".into(), StoredSize {
+            width: 500,
+            height: 900,
+        });
+        file.entries
+            .insert(LEGACY_FLYOUT_SIZE_KEY.into(), StoredGeometry {
                 x: 0,
                 y: 0,
                 width: Some(640),
                 height: Some(720),
-            },
-        );
+            });
 
         let resolved = resolve_size(&file, "flyout").expect("size present");
         assert_eq!(resolved.width, 500);
@@ -349,15 +410,13 @@ mod tests {
         // Simulates an upgrading user: pre-refactor size lived under the
         // `SurfaceMode::TrayPanel` shared-window geometry key.
         let mut file = GeometryFile::default();
-        file.entries.insert(
-            LEGACY_FLYOUT_SIZE_KEY.into(),
-            StoredGeometry {
+        file.entries
+            .insert(LEGACY_FLYOUT_SIZE_KEY.into(), StoredGeometry {
                 x: 0,
                 y: 0,
                 width: Some(640),
                 height: Some(720),
-            },
-        );
+            });
 
         let resolved = resolve_size(&file, "flyout").expect("legacy size migrates");
         assert_eq!(resolved.width, 640);
@@ -367,15 +426,13 @@ mod tests {
     #[test]
     fn resolve_size_ignores_legacy_entry_missing_width_or_height() {
         let mut file = GeometryFile::default();
-        file.entries.insert(
-            LEGACY_FLYOUT_SIZE_KEY.into(),
-            StoredGeometry {
+        file.entries
+            .insert(LEGACY_FLYOUT_SIZE_KEY.into(), StoredGeometry {
                 x: 0,
                 y: 0,
                 width: Some(640),
                 height: None,
-            },
-        );
+            });
 
         assert!(resolve_size(&file, "flyout").is_none());
     }
@@ -393,5 +450,98 @@ mod tests {
         // infinite fallback to itself.
         let file = GeometryFile::default();
         assert!(resolve_size(&file, LEGACY_FLYOUT_SIZE_KEY).is_none());
+    }
+
+    /// SBS-1024: two surfaces writing at once must not drop each other's
+    /// remembered position. The linger after load makes an unlocked RMW lose
+    /// one key; the shared state lock is what keeps both.
+    #[test]
+    fn concurrent_entry_saves_keep_sibling_positions() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = std::sync::Arc::new(dir.path().join("window_geometry.json"));
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+        let _linger = LingerOn::arm();
+
+        let settings = StoredGeometry {
+            x: 10,
+            y: 20,
+            width: Some(520),
+            height: Some(600),
+        };
+        let floatbar = StoredGeometry {
+            x: 30,
+            y: 40,
+            width: None,
+            height: None,
+        };
+
+        let writers: Vec<_> = [("settings", settings), ("floatbar", floatbar)]
+            .into_iter()
+            .map(|(key, geometry)| {
+                let path = path.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    save_entry_at(&path, key, geometry);
+                })
+            })
+            .collect();
+        barrier.wait();
+        for writer in writers {
+            writer.join().expect("writer thread");
+        }
+
+        let file = load_file_from(&path);
+        assert_eq!(
+            file.entries.get("settings").copied(),
+            Some(settings),
+            "settings geometry must survive a concurrent floatbar persist"
+        );
+        assert_eq!(
+            file.entries.get("floatbar").copied(),
+            Some(floatbar),
+            "floatbar geometry must survive a concurrent settings persist"
+        );
+    }
+
+    /// A size-only persist is the same full-file rewrite, so a flyout resize
+    /// racing a window move used to wipe the moved window (SBS-1024).
+    #[test]
+    fn concurrent_entry_and_size_saves_keep_both_maps() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = std::sync::Arc::new(dir.path().join("window_geometry.json"));
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+        let _linger = LingerOn::arm();
+
+        let settings = StoredGeometry {
+            x: 100,
+            y: 200,
+            width: Some(520),
+            height: Some(600),
+        };
+        let flyout = StoredSize {
+            width: 400,
+            height: 820,
+        };
+
+        let path_entry = path.clone();
+        let barrier_entry = barrier.clone();
+        let entry_writer = std::thread::spawn(move || {
+            barrier_entry.wait();
+            save_entry_at(&path_entry, "settings", settings);
+        });
+        let path_size = path.clone();
+        let barrier_size = barrier.clone();
+        let size_writer = std::thread::spawn(move || {
+            barrier_size.wait();
+            save_size_at(&path_size, "flyout", flyout);
+        });
+        barrier.wait();
+        entry_writer.join().expect("entry writer");
+        size_writer.join().expect("size writer");
+
+        let file = load_file_from(&path);
+        assert_eq!(file.entries.get("settings").copied(), Some(settings));
+        assert_eq!(file.size_entries.get("flyout").copied(), Some(flyout));
     }
 }

--- a/apps/desktop-tauri/src-tauri/src/geometry_store.rs
+++ b/apps/desktop-tauri/src-tauri/src/geometry_store.rs
@@ -301,24 +301,30 @@ mod tests {
     #[test]
     fn non_remembered_mode_save_is_noop() {
         // Call should not panic or error for ineligible modes.
-        save(SurfaceMode::Hidden, StoredGeometry {
-            x: 1,
-            y: 2,
-            width: Some(420),
-            height: Some(560),
-        });
+        save(
+            SurfaceMode::Hidden,
+            StoredGeometry {
+                x: 1,
+                y: 2,
+                width: Some(420),
+                height: Some(560),
+            },
+        );
         assert!(load(SurfaceMode::Hidden).is_none());
     }
 
     #[test]
     fn geometry_file_round_trip() {
         let mut f = GeometryFile::default();
-        f.entries.insert("settings".into(), StoredGeometry {
-            x: 100,
-            y: 200,
-            width: Some(520),
-            height: Some(600),
-        });
+        f.entries.insert(
+            "settings".into(),
+            StoredGeometry {
+                x: 100,
+                y: 200,
+                width: Some(520),
+                height: Some(600),
+            },
+        );
         let json = serde_json::to_string(&f).unwrap();
         let parsed: GeometryFile = serde_json::from_str(&json).unwrap();
         let entry = parsed.entries.get("settings").unwrap();
@@ -370,10 +376,13 @@ mod tests {
     #[test]
     fn stored_size_round_trips_without_position_fields() {
         let mut f = GeometryFile::default();
-        f.size_entries.insert("flyout".into(), StoredSize {
-            width: 400,
-            height: 820,
-        });
+        f.size_entries.insert(
+            "flyout".into(),
+            StoredSize {
+                width: 400,
+                height: 820,
+            },
+        );
         let json = serde_json::to_string(&f).unwrap();
         // The size-only entry must never carry x/y — that's the whole point
         // of keeping it out of `entries: BTreeMap<String, StoredGeometry>`.
@@ -388,17 +397,22 @@ mod tests {
     #[test]
     fn resolve_size_prefers_new_key_over_legacy() {
         let mut file = GeometryFile::default();
-        file.size_entries.insert("flyout".into(), StoredSize {
-            width: 500,
-            height: 900,
-        });
-        file.entries
-            .insert(LEGACY_FLYOUT_SIZE_KEY.into(), StoredGeometry {
+        file.size_entries.insert(
+            "flyout".into(),
+            StoredSize {
+                width: 500,
+                height: 900,
+            },
+        );
+        file.entries.insert(
+            LEGACY_FLYOUT_SIZE_KEY.into(),
+            StoredGeometry {
                 x: 0,
                 y: 0,
                 width: Some(640),
                 height: Some(720),
-            });
+            },
+        );
 
         let resolved = resolve_size(&file, "flyout").expect("size present");
         assert_eq!(resolved.width, 500);
@@ -410,13 +424,15 @@ mod tests {
         // Simulates an upgrading user: pre-refactor size lived under the
         // `SurfaceMode::TrayPanel` shared-window geometry key.
         let mut file = GeometryFile::default();
-        file.entries
-            .insert(LEGACY_FLYOUT_SIZE_KEY.into(), StoredGeometry {
+        file.entries.insert(
+            LEGACY_FLYOUT_SIZE_KEY.into(),
+            StoredGeometry {
                 x: 0,
                 y: 0,
                 width: Some(640),
                 height: Some(720),
-            });
+            },
+        );
 
         let resolved = resolve_size(&file, "flyout").expect("legacy size migrates");
         assert_eq!(resolved.width, 640);
@@ -426,13 +442,15 @@ mod tests {
     #[test]
     fn resolve_size_ignores_legacy_entry_missing_width_or_height() {
         let mut file = GeometryFile::default();
-        file.entries
-            .insert(LEGACY_FLYOUT_SIZE_KEY.into(), StoredGeometry {
+        file.entries.insert(
+            LEGACY_FLYOUT_SIZE_KEY.into(),
+            StoredGeometry {
                 x: 0,
                 y: 0,
                 width: Some(640),
                 height: None,
-            });
+            },
+        );
 
         assert!(resolve_size(&file, "flyout").is_none());
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`window_geometry.json` was updated with an unlocked read-modify-write: `save_entry` / `save_size` loaded the whole file, inserted one key, and atomically replaced it. Two surfaces writing at once (Settings move + float bar, or a flyout resize racing a window move) could each load a snapshot that lacked the other's key; the later write dropped that sibling position.

Geometry persist now holds `with_state_write_lock` across the load-mutate-write, the same cross-process lock settings and credentials already use. The file is still replaced atomically.

Closes SBS-1024.

## Related issue

Fixes SBS-1024.

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [x] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [x] Other: remembered window geometry (`window_geometry.json`)

## Validation

Hosted CI runs the main frontend and Rust checks. Local Linux cannot compile the desktop crate without GTK; those packages were installed here so the geometry tests could run.

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` (Windows-only; not run here)
- [x] Other:
  - `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml geometry_store` — 16 passed
  - The two concurrent tests fail if the lock is removed (verified locally): `concurrent_entry_saves_keep_sibling_positions` loses `floatbar`; `concurrent_entry_and_size_saves_keep_both_maps` loses the flyout size
  - `cargo fmt` on `geometry_store.rs`
  - Desktop `cargo clippy --all-targets -- -D warnings` was not used as a pass/fail here: it fails on pre-existing Linux-only unused items in `codexbar` (`secure_file.rs` / `updater.rs`), not on this change. Hosted CI runs that clippy on Windows.

## UI / tray proof

- [x] Not applicable

## Notes for reviewers

- The concurrent tests linger after load so an unlocked RMW loses a sibling key instead of passing by scheduling luck. With the lock held, that linger only delays the other writer.
- Production persist goes through the global Ceiling `state-write.lock`, matching settings / API keys / cookies / token accounts.
- Do not merge (agent instruction).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb907f6d-e069-4a1e-b1c6-7fd8cf623b9c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb907f6d-e069-4a1e-b1c6-7fd8cf623b9c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lock window geometry persistence to prevent sibling position clobbering
> - Rewrites `save_entry` and `save_size` in [geometry_store.rs](https://github.com/tsouth89/ceiling/pull/377/files#diff-f57b9dd97d0039653289f124954a9b55dd3cf1953c0064d990e2ba88a75d5faa) to load, mutate, and save the geometry file under `codexbar::secure_file::with_state_write_lock`, so concurrent writes no longer drop sibling entries.
> - Adds helpers `load_file_from`, `save_file_to`, `persist`, `persist_at`, and `persist_locked` that encapsulate the locked read-modify-write flow with atomic file writes.
> - Adds two concurrency tests using a test-only linger guard to widen the RMW window, verifying both entry keys and the entries/size_entries maps survive concurrent persists.
> - Behavioral Change: all geometry mutations now acquire the shared cross-process state write lock; any existing caller that bypasses the new `persist` path and writes the geometry file directly will not be serialized.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93a1ff3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->