### PR TITLE
Fail closed when Claude/Codex home is unresolved

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/accounts.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/accounts.rs
@@ -153,7 +153,9 @@ fn bridge_provider<I: Displayable>(data: &DirectoryAccountData<I>) -> ProviderAc
             .collect(),
         active_index: active,
         following_cli: !data.is_explicit(),
-        ambient_dir: I::ambient_dir().display().to_string(),
+        ambient_dir: I::ambient_dir()
+            .map(|dir| dir.display().to_string())
+            .unwrap_or_default(),
     }
 }
 
@@ -224,14 +226,19 @@ fn ensure_ambient_registered<I: Displayable>() {
     if !data.accounts.is_empty() {
         return;
     }
-    if !I::is_signed_in(&I::ambient_dir()) {
+    let Some(ambient) = I::ambient_dir() else {
+        return;
+    };
+    if !I::is_signed_in(&ambient) {
         return;
     }
     if let Err(error) = store.try_update(|data| {
         if !data.accounts.is_empty() {
             return Ok(());
         }
-        let ambient = I::ambient_dir();
+        let Some(ambient) = I::ambient_dir() else {
+            return Ok(());
+        };
         if I::is_signed_in(&ambient) {
             data.add_account(DirectoryAccount::<I>::new(None, ambient));
         }

--- a/apps/desktop-tauri/src-tauri/src/commands/accounts.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/accounts.rs
@@ -567,7 +567,7 @@ mod tests {
 
     #[test]
     fn missing_ambient_dir_serializes_as_json_null() {
-        let json = serde_json::to_value(&sample_bridge(None)).expect("serialize");
+        let json = serde_json::to_value(sample_bridge(None)).expect("serialize");
         assert_eq!(json["ambientDir"], serde_json::Value::Null);
         let text = serde_json::to_string(&sample_bridge(None)).expect("serialize");
         assert!(
@@ -579,7 +579,7 @@ mod tests {
     #[test]
     fn resolved_ambient_dir_serializes_as_a_string() {
         let json =
-            serde_json::to_value(&sample_bridge(Some(r"C:\codex".into()))).expect("serialize");
+            serde_json::to_value(sample_bridge(Some(r"C:\codex".into()))).expect("serialize");
         assert_eq!(
             json["ambientDir"],
             serde_json::Value::String(r"C:\codex".into())

--- a/apps/desktop-tauri/src-tauri/src/commands/accounts.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/accounts.rs
@@ -44,8 +44,9 @@ pub struct ProviderAccountsBridge {
     /// True when no accounts are configured and Ceiling follows whichever
     /// account the CLI is signed in as, which is the default.
     pub following_cli: bool,
-    /// The directory being followed in that case.
-    pub ambient_dir: String,
+    /// The directory being followed in that case. `None` when the provider
+    /// home cannot be resolved; never an empty string.
+    pub ambient_dir: Option<String>,
 }
 
 /// Result of inspecting a directory before adding it as an account.
@@ -153,9 +154,7 @@ fn bridge_provider<I: Displayable>(data: &DirectoryAccountData<I>) -> ProviderAc
             .collect(),
         active_index: active,
         following_cli: !data.is_explicit(),
-        ambient_dir: I::ambient_dir()
-            .map(|dir| dir.display().to_string())
-            .unwrap_or_default(),
+        ambient_dir: I::ambient_dir().map(|dir| dir.display().to_string()),
     }
 }
 
@@ -552,5 +551,38 @@ mod tests {
         assert!(parse_tint(Some("#4f8ff7; background: url(x)".into())).is_err());
         assert!(parse_tint(Some("var(--accent)".into())).is_err());
         assert!(parse_tint(Some("#zzzzzz".into())).is_err());
+    }
+
+    fn sample_bridge(ambient_dir: Option<String>) -> ProviderAccountsBridge {
+        ProviderAccountsBridge {
+            provider_id: "codex".into(),
+            display_name: "Codex".into(),
+            env_var: "CODEX_HOME".into(),
+            accounts: vec![],
+            active_index: 0,
+            following_cli: true,
+            ambient_dir,
+        }
+    }
+
+    #[test]
+    fn missing_ambient_dir_serializes_as_json_null() {
+        let json = serde_json::to_value(&sample_bridge(None)).expect("serialize");
+        assert_eq!(json["ambientDir"], serde_json::Value::Null);
+        let text = serde_json::to_string(&sample_bridge(None)).expect("serialize");
+        assert!(
+            !text.contains("\"ambientDir\":\"\""),
+            "empty string must not stand in for a missing home: {text}"
+        );
+    }
+
+    #[test]
+    fn resolved_ambient_dir_serializes_as_a_string() {
+        let json =
+            serde_json::to_value(&sample_bridge(Some(r"C:\codex".into()))).expect("serialize");
+        assert_eq!(
+            json["ambientDir"],
+            serde_json::Value::String(r"C:\codex".into())
+        );
     }
 }

--- a/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.test.tsx
@@ -48,6 +48,7 @@ describe("settings AccountsPanel", () => {
       );
     });
     expect(container.textContent).toContain("C:\\codex-work");
+    expect(container.textContent).toContain("AccountsFollowingCliHint");
     expect(screen.getByPlaceholderText("C:\\codex-work")).toBeTruthy();
   });
 
@@ -62,6 +63,9 @@ describe("settings AccountsPanel", () => {
       expect(container.querySelector(".accounts-following")).toBeTruthy();
     });
 
+    expect(container.textContent).toContain("AccountsFollowingCli");
+    expect(container.textContent).not.toContain("AccountsFollowingCliHint");
+    expect(container.querySelector(".accounts-following .accounts-path")).toBeNull();
     expect(container.textContent).not.toContain("-work");
     for (const path of container.querySelectorAll("code.accounts-path")) {
       expect(path.textContent?.trim()).not.toBe("");
@@ -81,6 +85,8 @@ describe("settings AccountsPanel", () => {
       expect(container.querySelector(".accounts-following")).toBeTruthy();
     });
 
+    expect(container.textContent).not.toContain("AccountsFollowingCliHint");
+    expect(container.querySelector(".accounts-following .accounts-path")).toBeNull();
     expect(container.textContent).not.toContain("-work");
     for (const path of container.querySelectorAll("code.accounts-path")) {
       expect(path.textContent?.trim()).not.toBe("");

--- a/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderAccountsBridge } from "../../../types/bridge";
+import { AccountsPanel } from "./AccountsPanel";
+
+const tauriMocks = vi.hoisted(() => ({
+  getDirectoryAccounts: vi.fn(),
+  probeAccountDirectory: vi.fn(),
+  addDirectoryAccount: vi.fn(),
+  removeDirectoryAccount: vi.fn(),
+}));
+
+vi.mock("../../../lib/tauri", () => tauriMocks);
+vi.mock("../../../hooks/useLocale", () => ({
+  useLocale: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+function provider(
+  overrides: Partial<ProviderAccountsBridge> = {},
+): ProviderAccountsBridge {
+  return {
+    providerId: "codex",
+    displayName: "Codex",
+    envVar: "CODEX_HOME",
+    accounts: [],
+    activeIndex: 0,
+    followingCli: true,
+    ambientDir: "C:\\codex",
+    ...overrides,
+  };
+}
+
+describe("settings AccountsPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the followed path and a -work setup suggestion when home is resolved", async () => {
+    tauriMocks.getDirectoryAccounts.mockResolvedValue([provider()]);
+
+    const { container } = render(<AccountsPanel />);
+
+    await waitFor(() => {
+      expect(container.querySelector(".accounts-path")?.textContent).toContain(
+        "C:\\codex",
+      );
+    });
+    expect(container.textContent).toContain("C:\\codex-work");
+    expect(screen.getByPlaceholderText("C:\\codex-work")).toBeTruthy();
+  });
+
+  it("does not treat a missing ambient dir as a path", async () => {
+    tauriMocks.getDirectoryAccounts.mockResolvedValue([
+      provider({ ambientDir: null }),
+    ]);
+
+    const { container } = render(<AccountsPanel />);
+
+    await waitFor(() => {
+      expect(container.querySelector(".accounts-following")).toBeTruthy();
+    });
+
+    expect(container.textContent).not.toContain("-work");
+    for (const path of container.querySelectorAll("code.accounts-path")) {
+      expect(path.textContent?.trim()).not.toBe("");
+    }
+    expect(container.textContent).toContain("$env:CODEX_HOME");
+    expect(screen.getByPlaceholderText("AccountsDirPlaceholder")).toBeTruthy();
+  });
+
+  it("does not treat an empty ambient dir as a path", async () => {
+    tauriMocks.getDirectoryAccounts.mockResolvedValue([
+      provider({ ambientDir: "   " }),
+    ]);
+
+    const { container } = render(<AccountsPanel />);
+
+    await waitFor(() => {
+      expect(container.querySelector(".accounts-following")).toBeTruthy();
+    });
+
+    expect(container.textContent).not.toContain("-work");
+    for (const path of container.querySelectorAll("code.accounts-path")) {
+      expect(path.textContent?.trim()).not.toBe("");
+    }
+  });
+});

--- a/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.tsx
@@ -155,15 +155,12 @@ function ProviderAccounts({ provider, busy, onRun }: ProviderProps) {
           <span className="credential-card__badge credential-card__badge--set">
             {t("AccountsFollowingCli")}
           </span>
-          <span className="credential-card__meta">
-            {t("AccountsFollowingCliHint")}
-            {ambientDir ? (
-              <>
-                {" "}
-                <code className="accounts-path">{ambientDir}</code>
-              </>
-            ) : null}
-          </span>
+          {ambientDir ? (
+            <span className="credential-card__meta">
+              {t("AccountsFollowingCliHint")}{" "}
+              <code className="accounts-path">{ambientDir}</code>
+            </span>
+          ) : null}
         </div>
       ) : (
         <ul className="credential-list accounts-list">

--- a/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.tsx
@@ -141,8 +141,10 @@ function ProviderAccounts({ provider, busy, onRun }: ProviderProps) {
 
   const cli = LOGIN_CLI[provider.providerId] ?? provider.providerId;
   // A literal path beats "<path>": it is copy-pasteable and shows the shape of
-  // the answer, sitting beside the directory already in use.
-  const suggestedDir = `${provider.ambientDir}-work`;
+  // the answer, sitting beside the directory already in use. Skip it when the
+  // provider home is unresolved — interpolating anyway yields "-work".
+  const ambientDir = provider.ambientDir?.trim() || null;
+  const suggestedDir = ambientDir ? `${ambientDir}-work` : null;
 
   return (
     <div className="accounts-provider">
@@ -154,8 +156,13 @@ function ProviderAccounts({ provider, busy, onRun }: ProviderProps) {
             {t("AccountsFollowingCli")}
           </span>
           <span className="credential-card__meta">
-            {t("AccountsFollowingCliHint")}{" "}
-            <code className="accounts-path">{provider.ambientDir}</code>
+            {t("AccountsFollowingCliHint")}
+            {ambientDir ? (
+              <>
+                {" "}
+                <code className="accounts-path">{ambientDir}</code>
+              </>
+            ) : null}
           </span>
         </div>
       ) : (
@@ -223,8 +230,16 @@ function ProviderAccounts({ provider, busy, onRun }: ProviderProps) {
           <li>
             {t("AccountsSetupStep1")}
             <code className="accounts-path accounts-setup__command">
-              mkdir &quot;{suggestedDir}&quot;; $env:{provider.envVar}=&quot;
-              {suggestedDir}&quot;; {cli} login
+              {suggestedDir ? (
+                <>
+                  mkdir &quot;{suggestedDir}&quot;; $env:{provider.envVar}=&quot;
+                  {suggestedDir}&quot;; {cli} login
+                </>
+              ) : (
+                <>
+                  $env:{provider.envVar}=&quot;&lt;path&gt;&quot;; {cli} login
+                </>
+              )}
             </code>
           </li>
           <li>{t("AccountsSetupStep2")}</li>
@@ -235,7 +250,7 @@ function ProviderAccounts({ provider, busy, onRun }: ProviderProps) {
         <input
           className="text-input"
           type="text"
-          placeholder={suggestedDir}
+          placeholder={suggestedDir ?? t("AccountsDirPlaceholder")}
           value={dir}
           onChange={(e) => {
             setDir(e.target.value);

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -975,7 +975,8 @@ export interface ProviderAccountsBridge {
   activeIndex: number;
   /** No accounts configured: Ceiling follows whichever the CLI is signed in as. */
   followingCli: boolean;
-  ambientDir: string;
+  /** Provider home being followed. `null` when that home cannot be resolved. */
+  ambientDir: string | null;
 }
 
 export interface AccountProbeBridge {

--- a/rust/src/agent_sessions.rs
+++ b/rust/src/agent_sessions.rs
@@ -365,7 +365,7 @@ impl LocalAgentSessionScanner {
         let sessions = self.scan_files(
             &host,
             now,
-            &Self::codex_sessions_root(),
+            Self::codex_sessions_root().as_deref(),
             &Self::claude_projects_roots(),
             &processes,
         );
@@ -400,16 +400,17 @@ impl LocalAgentSessionScanner {
         &self,
         host: &str,
         now: DateTime<Utc>,
-        codex_root: &Path,
+        codex_root: Option<&Path>,
         claude_roots: &[PathBuf],
         processes: &[AgentProcessRecord],
     ) -> Vec<AgentSession> {
         let mut agents = AgentPSOutputParser::agent_processes(processes);
         agents.sort_by_key(|process| std::cmp::Reverse(process.started_at));
-        let mut rollouts = VecDeque::from(Self::codex_rollouts(
-            codex_root,
-            now.with_timezone(&Local).date_naive(),
-        ));
+        let mut rollouts = VecDeque::from(
+            codex_root
+                .map(|root| Self::codex_rollouts(root, now.with_timezone(&Local).date_naive()))
+                .unwrap_or_default(),
+        );
         let claude_count = agents
             .iter()
             .filter(|process| process.provider == Some(AgentSessionProvider::Claude))
@@ -578,23 +579,16 @@ impl LocalAgentSessionScanner {
             })
     }
 
-    fn codex_sessions_root() -> PathBuf {
-        if let Ok(path) = std::env::var("CODEX_HOME")
-            && !path.trim().is_empty()
+    fn codex_sessions_root() -> Option<PathBuf> {
+        let home = crate::core::ambient_codex_home()?;
+        if home
+            .file_name()
+            .is_some_and(|name| name.eq_ignore_ascii_case("sessions"))
         {
-            let path = PathBuf::from(path.trim());
-            if path
-                .file_name()
-                .is_some_and(|name| name.eq_ignore_ascii_case("sessions"))
-            {
-                return path;
-            }
-            return path.join("sessions");
+            Some(home)
+        } else {
+            Some(home.join("sessions"))
         }
-        dirs::home_dir()
-            .unwrap_or_default()
-            .join(".codex")
-            .join("sessions")
     }
 
     fn claude_projects_roots() -> Vec<PathBuf> {

--- a/rust/src/agent_sessions.rs
+++ b/rust/src/agent_sessions.rs
@@ -580,7 +580,11 @@ impl LocalAgentSessionScanner {
     }
 
     fn codex_sessions_root() -> Option<PathBuf> {
-        let home = crate::core::ambient_codex_home()?;
+        Self::codex_sessions_root_from(crate::core::ambient_codex_home())
+    }
+
+    fn codex_sessions_root_from(home: Option<PathBuf>) -> Option<PathBuf> {
+        let home = home?;
         if home
             .file_name()
             .is_some_and(|name| name.eq_ignore_ascii_case("sessions"))

--- a/rust/src/agent_sessions/tests.rs
+++ b/rust/src/agent_sessions/tests.rs
@@ -238,6 +238,58 @@ bad line
         );
     }
 
+    /// Pins SBS-1021: an unresolved Codex home is not `./sessions` and does not
+    /// invent a file-only session from a relative rollout tree.
+    #[test]
+    fn unresolved_codex_home_does_not_scan_a_relative_sessions_path() {
+        assert_eq!(
+            LocalAgentSessionScanner::codex_sessions_root_from(None),
+            None,
+            "unresolved home must not become ./sessions"
+        );
+
+        let now = Utc.with_ymd_and_hms(2026, 7, 12, 12, 0, 0).unwrap();
+        let today = now.with_timezone(&Local).date_naive();
+        let decoy = tempfile::tempdir().expect("tempdir");
+        let day_dir = decoy
+            .path()
+            .join("sessions")
+            .join(today.format("%Y").to_string())
+            .join(today.format("%m").to_string())
+            .join(today.format("%d").to_string());
+        std::fs::create_dir_all(&day_dir).expect("decoy dir");
+        std::fs::write(
+            day_dir.join("rollout-unresolved.jsonl"),
+            r#"{"type":"session_meta","payload":{"session_id":"should-not-appear","cwd":"/tmp","originator":"codex_exec","source":"cli"}}"#,
+        )
+        .expect("decoy rollout");
+
+        let scanner = LocalAgentSessionScanner::default();
+        let found_when_resolved = scanner.scan_files(
+            "localhost",
+            now,
+            Some(&decoy.path().join("sessions")),
+            &[],
+            &[],
+        );
+        assert!(
+            found_when_resolved
+                .iter()
+                .any(|session| session.id == "should-not-appear" && session.pid.is_none()),
+            "the planted rollout must be discoverable when a home is resolved: {found_when_resolved:?}"
+        );
+
+        let unresolved = scanner.scan_files("localhost", now, None, &[], &[]);
+        assert!(
+            unresolved.is_empty(),
+            "unresolved home must not create file-only sessions: {unresolved:?}"
+        );
+        assert!(
+            unresolved.iter().all(|session| session.pid.is_some()),
+            "unresolved home must not invent file-only sessions"
+        );
+    }
+
     #[test]
     fn claude_metadata_parser_stops_after_session_and_cwd_are_known() {
         struct FirstLineOnly {

--- a/rust/src/core/account_dirs.rs
+++ b/rust/src/core/account_dirs.rs
@@ -620,10 +620,10 @@ mod tests {
         data.accounts.push(account("b", "/dirs/shared/"));
         data.accounts.push(account("c", "/dirs/other"));
 
-        assert_eq!(data.all_dirs(), vec![
-            PathBuf::from("/dirs/shared"),
-            PathBuf::from("/dirs/other")
-        ]);
+        assert_eq!(
+            data.all_dirs(),
+            vec![PathBuf::from("/dirs/shared"), PathBuf::from("/dirs/other")]
+        );
     }
 
     #[test]

--- a/rust/src/core/account_dirs.rs
+++ b/rust/src/core/account_dirs.rs
@@ -22,8 +22,10 @@ use uuid::Uuid;
 /// Provider-specific behavior for a directory-backed account.
 pub trait AccountIdentity: Clone + PartialEq + Serialize + DeserializeOwned {
     /// The directory the CLI itself would use when the user has configured no
-    /// accounts explicitly.
-    fn ambient_dir() -> PathBuf;
+    /// accounts explicitly. `None` when that directory cannot be resolved
+    /// (no provider env var and no home). The working directory is not a
+    /// substitute (SBS-1021 / SBS-950).
+    fn ambient_dir() -> Option<PathBuf>;
 
     /// File name this provider's accounts are persisted under.
     fn store_file_name() -> &'static str;
@@ -191,11 +193,12 @@ impl<I: AccountIdentity> DirectoryAccountData<I> {
     /// Falls back to the ambient directory when no accounts are configured, so
     /// users who never open the Accounts UI keep today's behavior exactly: the
     /// CLI stays the source of truth and switching there is still picked up
-    /// automatically.
-    pub fn active_dir(&self) -> PathBuf {
+    /// automatically. `None` when there is no configured account and no
+    /// resolvable ambient directory — never the working directory (SBS-1021).
+    pub fn active_dir(&self) -> Option<PathBuf> {
         self.active_account()
             .map(|account| account.config_dir.clone())
-            .unwrap_or_else(I::ambient_dir)
+            .or_else(I::ambient_dir)
     }
 
     /// Whether Ceiling is tracking accounts explicitly rather than following
@@ -279,10 +282,11 @@ impl<I: AccountIdentity> DirectoryAccountData<I> {
     }
 
     /// Every distinct directory Ceiling should scan for local activity. Includes
-    /// the ambient directory when no accounts are configured.
+    /// the ambient directory when no accounts are configured and one can be
+    /// resolved. A missing home yields no scan roots, not cwd (SBS-1021).
     pub fn all_dirs(&self) -> Vec<PathBuf> {
         if self.accounts.is_empty() {
-            return vec![I::ambient_dir()];
+            return I::ambient_dir().into_iter().collect();
         }
         let mut seen = HashSet::new();
         self.accounts
@@ -462,8 +466,8 @@ mod tests {
     }
 
     impl AccountIdentity for TestIdentity {
-        fn ambient_dir() -> PathBuf {
-            PathBuf::from("/ambient")
+        fn ambient_dir() -> Option<PathBuf> {
+            Some(PathBuf::from("/ambient"))
         }
         fn store_file_name() -> &'static str {
             "test-accounts.json"
@@ -498,8 +502,38 @@ mod tests {
         let data = Data::new();
         assert!(data.active_account().is_none());
         assert!(!data.is_explicit());
-        assert_eq!(data.active_dir(), PathBuf::from("/ambient"));
+        assert_eq!(data.active_dir(), Some(PathBuf::from("/ambient")));
         assert_eq!(data.all_dirs(), vec![PathBuf::from("/ambient")]);
+    }
+
+    /// Pins SBS-1021: following the CLI with no resolvable ambient directory
+    /// must not invent `.` as the config/session root.
+    #[test]
+    fn missing_ambient_dir_is_not_the_working_directory() {
+        #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        struct NoHomeIdentity;
+
+        impl AccountIdentity for NoHomeIdentity {
+            fn ambient_dir() -> Option<PathBuf> {
+                None
+            }
+            fn store_file_name() -> &'static str {
+                "no-home-accounts.json"
+            }
+            fn read(_config_dir: &Path) -> Option<Self> {
+                None
+            }
+            fn is_signed_in(_config_dir: &Path) -> bool {
+                false
+            }
+            fn suggested_label(&self) -> Option<String> {
+                None
+            }
+        }
+
+        let data = DirectoryAccountData::<NoHomeIdentity>::new();
+        assert_eq!(data.active_dir(), None);
+        assert!(data.all_dirs().is_empty());
     }
 
     #[test]
@@ -512,7 +546,7 @@ mod tests {
         assert!(data.has_multiple());
         assert!(data.is_explicit());
         assert_eq!(data.active_account().map(|a| a.id), Some(id));
-        assert_eq!(data.active_dir(), PathBuf::from("/dirs/work"));
+        assert_eq!(data.active_dir(), Some(PathBuf::from("/dirs/work")));
     }
 
     #[test]
@@ -554,7 +588,7 @@ mod tests {
         data.remove_account(second);
 
         assert_eq!(data.active_account().map(|a| a.id), Some(first));
-        assert_eq!(data.active_dir(), PathBuf::from("/dirs/personal"));
+        assert_eq!(data.active_dir(), Some(PathBuf::from("/dirs/personal")));
     }
 
     #[test]
@@ -566,7 +600,7 @@ mod tests {
 
         assert_eq!(data.count(), 0);
         assert!(!data.is_explicit());
-        assert_eq!(data.active_dir(), PathBuf::from("/ambient"));
+        assert_eq!(data.active_dir(), Some(PathBuf::from("/ambient")));
     }
 
     #[test]
@@ -576,7 +610,7 @@ mod tests {
         data.active_index = 17;
 
         assert_eq!(data.clamped_active_index(), 0);
-        assert_eq!(data.active_dir(), PathBuf::from("/dirs/personal"));
+        assert_eq!(data.active_dir(), Some(PathBuf::from("/dirs/personal")));
     }
 
     #[test]
@@ -586,10 +620,10 @@ mod tests {
         data.accounts.push(account("b", "/dirs/shared/"));
         data.accounts.push(account("c", "/dirs/other"));
 
-        assert_eq!(
-            data.all_dirs(),
-            vec![PathBuf::from("/dirs/shared"), PathBuf::from("/dirs/other")]
-        );
+        assert_eq!(data.all_dirs(), vec![
+            PathBuf::from("/dirs/shared"),
+            PathBuf::from("/dirs/other")
+        ]);
     }
 
     #[test]
@@ -680,8 +714,8 @@ mod tests {
     }
 
     impl AccountIdentity for UnserializableIdentity {
-        fn ambient_dir() -> PathBuf {
-            PathBuf::from("/ambient")
+        fn ambient_dir() -> Option<PathBuf> {
+            Some(PathBuf::from("/ambient"))
         }
         fn store_file_name() -> &'static str {
             "unserializable-accounts.json"

--- a/rust/src/core/claude_accounts.rs
+++ b/rust/src/core/claude_accounts.rs
@@ -33,16 +33,27 @@ pub type ClaudeAccountStore = DirectoryAccountStore<ClaudeIdentity>;
 
 /// Resolve the Claude config directory the CLI itself would use:
 /// `CLAUDE_CONFIG_DIR` when set to a non-empty value, otherwise `~/.claude`.
-pub fn ambient_claude_config_dir() -> PathBuf {
-    if let Ok(dir) = std::env::var("CLAUDE_CONFIG_DIR") {
+///
+/// No resolvable home is not the working directory. Returning `./.claude`
+/// would treat a checkout as the ambient config root (SBS-1021 / SBS-950).
+pub fn ambient_claude_config_dir() -> Option<PathBuf> {
+    ambient_claude_config_dir_from(
+        std::env::var("CLAUDE_CONFIG_DIR").ok().as_deref(),
+        dirs::home_dir(),
+    )
+}
+
+pub(crate) fn ambient_claude_config_dir_from(
+    claude_config_dir: Option<&str>,
+    home_dir: Option<PathBuf>,
+) -> Option<PathBuf> {
+    if let Some(dir) = claude_config_dir {
         let trimmed = dir.trim();
         if !trimmed.is_empty() {
-            return PathBuf::from(trimmed);
+            return Some(PathBuf::from(trimmed));
         }
     }
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(DEFAULT_CLAUDE_DIR)
+    Some(home_dir?.join(DEFAULT_CLAUDE_DIR))
 }
 
 /// The OAuth credential file for a config directory.
@@ -97,7 +108,7 @@ impl ClaudeIdentity {
 }
 
 impl AccountIdentity for ClaudeIdentity {
-    fn ambient_dir() -> PathBuf {
+    fn ambient_dir() -> Option<PathBuf> {
         ambient_claude_config_dir()
     }
 
@@ -317,6 +328,32 @@ mod tests {
         assert!(
             ClaudeAccountStore::default_path().ends_with("claude-accounts.json"),
             "claude accounts must not share a file with another provider"
+        );
+    }
+
+    /// Pins SBS-1021: a missing home is not the working directory. Returning
+    /// `Some("./.claude")` here is what loaded a checkout as the ambient
+    /// config root (the Gemini leftover from SBS-950).
+    #[test]
+    fn missing_home_is_not_the_working_directory() {
+        assert_eq!(ambient_claude_config_dir_from(None, None), None);
+        assert_eq!(ambient_claude_config_dir_from(Some("  "), None), None);
+        assert_eq!(ambient_claude_config_dir_from(Some(""), None), None);
+    }
+
+    #[test]
+    fn an_explicit_config_dir_does_not_need_a_home() {
+        assert_eq!(
+            ambient_claude_config_dir_from(Some("/work"), None),
+            Some(PathBuf::from("/work"))
+        );
+    }
+
+    #[test]
+    fn default_config_dir_joins_the_home() {
+        assert_eq!(
+            ambient_claude_config_dir_from(None, Some(PathBuf::from("/home/me"))),
+            Some(PathBuf::from("/home/me").join(".claude"))
         );
     }
 }

--- a/rust/src/core/codex_accounts.rs
+++ b/rust/src/core/codex_accounts.rs
@@ -23,16 +23,27 @@ pub type CodexAccountStore = DirectoryAccountStore<CodexIdentity>;
 
 /// Resolve the Codex home the CLI itself would use: `CODEX_HOME` when set to a
 /// non-empty value, otherwise `~/.codex`.
-pub fn ambient_codex_home() -> PathBuf {
-    if let Ok(home) = std::env::var("CODEX_HOME") {
+///
+/// No resolvable home is not the working directory. Returning `./.codex`
+/// would treat a checkout as the ambient session root (SBS-1021 / SBS-950).
+pub fn ambient_codex_home() -> Option<PathBuf> {
+    ambient_codex_home_from(
+        std::env::var("CODEX_HOME").ok().as_deref(),
+        dirs::home_dir(),
+    )
+}
+
+pub(crate) fn ambient_codex_home_from(
+    codex_home: Option<&str>,
+    home_dir: Option<PathBuf>,
+) -> Option<PathBuf> {
+    if let Some(home) = codex_home {
         let trimmed = home.trim();
         if !trimmed.is_empty() {
-            return PathBuf::from(trimmed);
+            return Some(PathBuf::from(trimmed));
         }
     }
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(DEFAULT_CODEX_DIR)
+    Some(home_dir?.join(DEFAULT_CODEX_DIR))
 }
 
 /// Identity read from a Codex home's `auth.json`.
@@ -61,7 +72,7 @@ impl CodexIdentity {
 }
 
 impl AccountIdentity for CodexIdentity {
-    fn ambient_dir() -> PathBuf {
+    fn ambient_dir() -> Option<PathBuf> {
         ambient_codex_home()
     }
 
@@ -179,6 +190,32 @@ mod tests {
         assert!(
             CodexAccountStore::default_path().ends_with("codex-accounts.json"),
             "codex accounts must not share a file with another provider"
+        );
+    }
+
+    /// Pins SBS-1021: a missing home is not the working directory. Returning
+    /// `Some("./.codex")` here is what loaded a checkout as the ambient
+    /// session root (the Gemini leftover from SBS-950).
+    #[test]
+    fn missing_home_is_not_the_working_directory() {
+        assert_eq!(ambient_codex_home_from(None, None), None);
+        assert_eq!(ambient_codex_home_from(Some("  "), None), None);
+        assert_eq!(ambient_codex_home_from(Some(""), None), None);
+    }
+
+    #[test]
+    fn an_explicit_codex_home_does_not_need_a_home_directory() {
+        assert_eq!(
+            ambient_codex_home_from(Some("/homes/work"), None),
+            Some(PathBuf::from("/homes/work"))
+        );
+    }
+
+    #[test]
+    fn default_codex_home_joins_the_home() {
+        assert_eq!(
+            ambient_codex_home_from(None, Some(PathBuf::from("/home/me"))),
+            Some(PathBuf::from("/home/me").join(".codex"))
         );
     }
 }

--- a/rust/src/core/configured_accounts.rs
+++ b/rust/src/core/configured_accounts.rs
@@ -80,8 +80,16 @@ impl ConfiguredAccounts {
     /// snapshotted when the refresh cycle started.
     pub fn active_dir_for(&self, provider: ProviderId) -> Option<PathBuf> {
         match provider {
-            ProviderId::Codex => self.codex.is_explicit().then(|| self.codex.active_dir()),
-            ProviderId::Claude => self.claude.is_explicit().then(|| self.claude.active_dir()),
+            ProviderId::Codex => self
+                .codex
+                .is_explicit()
+                .then(|| self.codex.active_dir())
+                .flatten(),
+            ProviderId::Claude => self
+                .claude
+                .is_explicit()
+                .then(|| self.claude.active_dir())
+                .flatten(),
             _ => None,
         }
     }

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -47,6 +47,20 @@ fn configured_account_homes(provider: ProviderId) -> Vec<PathBuf> {
         .collect()
 }
 
+/// Ambient Claude `projects/` root from the user's home.
+///
+/// No home is not `.claude/projects` under the working directory
+/// (SBS-1021 / SBS-950).
+fn claude_projects_dir_from_home(home: Option<PathBuf>) -> Option<PathBuf> {
+    let home = home?;
+    let primary = home.join(".claude").join("projects");
+    if primary.exists() {
+        Some(primary)
+    } else {
+        Some(home.join(".config").join("claude").join("projects"))
+    }
+}
+
 /// Cost summary from scanning local logs
 #[derive(Debug, Clone, Default)]
 pub struct CostSummary {
@@ -965,18 +979,8 @@ impl CostScanner {
                     PathBuf::from(trimmed).join("projects"),
                 );
             }
-        } else {
-            let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-            let primary = home.join(".claude").join("projects");
-            if primary.exists() {
-                push(&mut dirs, &mut seen, primary);
-            } else {
-                push(
-                    &mut dirs,
-                    &mut seen,
-                    home.join(".config").join("claude").join("projects"),
-                );
-            }
+        } else if let Some(projects) = claude_projects_dir_from_home(dirs::home_dir()) {
+            push(&mut dirs, &mut seen, projects);
         }
 
         for account_home in self.account_homes(ProviderId::Claude) {
@@ -2729,6 +2733,12 @@ mod tests {
     use super::*;
     use crate::core::ProviderId;
     use std::io::Write;
+
+    /// Pins SBS-1021: a missing home is not `.claude/projects` under cwd.
+    #[test]
+    fn missing_home_is_not_the_working_directory_for_claude_projects() {
+        assert_eq!(claude_projects_dir_from_home(None), None);
+    }
 
     #[test]
     fn project_from_cwd_extracts_basename() {

--- a/rust/src/providers/claude/oauth/credentials_store.rs
+++ b/rust/src/providers/claude/oauth/credentials_store.rs
@@ -125,9 +125,12 @@ pub(super) fn load_credentials(
 /// Whether `config_dir` names an account other than the one the CLI is signed
 /// in as. Passing the ambient directory explicitly is still the ambient account.
 fn is_explicit_account(config_dir: Option<&Path>) -> bool {
-    match config_dir {
-        Some(dir) => !crate::core::same_dir(dir, &crate::core::ambient_claude_config_dir()),
-        None => false,
+    match (config_dir, crate::core::ambient_claude_config_dir()) {
+        (Some(dir), Some(ambient)) => !crate::core::same_dir(dir, &ambient),
+        // No ambient home: a caller-supplied directory cannot be the CLI's
+        // default account, so treat it as explicit (SBS-1021).
+        (Some(_), None) => true,
+        (None, _) => false,
     }
 }
 
@@ -346,13 +349,18 @@ fn push_keyring_candidate(candidates: &mut Vec<String>, value: String) {
     candidates.push(value.to_string());
 }
 
-/// Get the credentials file path
 /// Resolve the credentials file for a config directory, defaulting to the one
 /// the CLI itself would use (`CLAUDE_CONFIG_DIR`, else `~/.claude`).
+///
+/// No resolvable ambient directory is an explicit error, not `./.claude`
+/// (SBS-1021 / SBS-950).
 fn credentials_path(config_dir: Option<&Path>) -> Result<PathBuf, ProviderError> {
     let dir = config_dir
         .map(Path::to_path_buf)
-        .unwrap_or_else(crate::core::ambient_claude_config_dir);
+        .or_else(crate::core::ambient_claude_config_dir)
+        .ok_or_else(|| {
+            ProviderError::NotInstalled("Could not resolve Claude config directory.".to_string())
+        })?;
     Ok(crate::core::claude_credentials_path(&dir))
 }
 

--- a/rust/src/providers/claude/oauth/credentials_store.rs
+++ b/rust/src/providers/claude/oauth/credentials_store.rs
@@ -355,9 +355,16 @@ fn push_keyring_candidate(candidates: &mut Vec<String>, value: String) {
 /// No resolvable ambient directory is an explicit error, not `./.claude`
 /// (SBS-1021 / SBS-950).
 fn credentials_path(config_dir: Option<&Path>) -> Result<PathBuf, ProviderError> {
+    credentials_path_from(config_dir, crate::core::ambient_claude_config_dir())
+}
+
+fn credentials_path_from(
+    config_dir: Option<&Path>,
+    ambient_dir: Option<PathBuf>,
+) -> Result<PathBuf, ProviderError> {
     let dir = config_dir
         .map(Path::to_path_buf)
-        .or_else(crate::core::ambient_claude_config_dir)
+        .or(ambient_dir)
         .ok_or_else(|| {
             ProviderError::NotInstalled("Could not resolve Claude config directory.".to_string())
         })?;
@@ -581,10 +588,12 @@ fn apply_refresh_to_credentials_json(
 mod tests {
     use super::{
         CredentialSource, ENV_TOKEN_KEY, KEYRING_SERVICE, apply_refresh_to_credentials_json,
-        cached_refreshed_if_fresher, credentials_path, disk_still_holds_exchanged_refresh,
-        load_credentials, merge_refreshed_credentials_json, parse_credentials_json,
-        persist_refreshed_credentials, persist_refreshed_for_source, store_refreshed,
+        cached_refreshed_if_fresher, credentials_path, credentials_path_from,
+        disk_still_holds_exchanged_refresh, load_credentials, merge_refreshed_credentials_json,
+        parse_credentials_json, persist_refreshed_credentials, persist_refreshed_for_source,
+        store_refreshed,
     };
+    use crate::core::ProviderError;
     use crate::providers::claude::oauth::ClaudeOAuthCredentials;
     use std::path::Path;
 
@@ -1078,6 +1087,27 @@ mod tests {
         let path = credentials_path(None).expect("path");
 
         assert_eq!(path, dir.path().join(".credentials.json"));
+    }
+
+    /// Pins SBS-1021: no ambient Claude home is `NotInstalled`, not `./.claude`.
+    #[test]
+    fn unresolved_ambient_dir_is_not_installed_and_does_not_probe_relative_claude() {
+        let planted = tempfile::tempdir().expect("tempdir");
+        write_credentials(&planted.path().join(".claude"));
+
+        let error = credentials_path_from(None, None).expect_err("unresolved home");
+        assert!(
+            matches!(error, ProviderError::NotInstalled(_)),
+            "expected NotInstalled, got {error:?}"
+        );
+        assert!(
+            planted
+                .path()
+                .join(".claude")
+                .join(".credentials.json")
+                .exists(),
+            "decoy exists so a relative .claude probe would have succeeded"
+        );
     }
 
     #[test]

--- a/rust/src/providers/claude/oauth/mod.rs
+++ b/rust/src/providers/claude/oauth/mod.rs
@@ -169,7 +169,7 @@ impl ClaudeOAuthFetcher {
         let dir = self
             .config_dir
             .clone()
-            .unwrap_or_else(crate::core::ambient_claude_config_dir);
+            .or_else(crate::core::ambient_claude_config_dir)?;
         crate::core::ClaudeIdentity::read(&dir)
     }
 

--- a/rust/src/providers/codex/api.rs
+++ b/rust/src/providers/codex/api.rs
@@ -73,17 +73,20 @@ impl CodexApi {
     }
 
     /// The `CODEX_HOME` this client reads from.
-    fn codex_home(&self) -> PathBuf {
+    ///
+    /// `None` when following the CLI and no home can be resolved. The working
+    /// directory is not a substitute (SBS-1021 / SBS-950).
+    fn codex_home(&self) -> Option<PathBuf> {
         self.codex_home
             .clone()
-            .unwrap_or_else(crate::core::ambient_codex_home)
+            .or_else(crate::core::ambient_codex_home)
     }
 
     /// Identity claims for this client's home, for labeling and for keying usage
     /// by account. Never includes token material.
     pub fn identity(&self) -> Option<crate::core::CodexIdentity> {
         use crate::core::AccountIdentity;
-        crate::core::CodexIdentity::read(&self.codex_home())
+        crate::core::CodexIdentity::read(&self.codex_home()?)
     }
 
     /// Fetch usage information from Codex API
@@ -166,7 +169,9 @@ impl CodexApi {
     }
 
     fn load_credentials(&self) -> Result<CodexCredentials, ProviderError> {
-        let auth_path = self.get_auth_path();
+        let auth_path = self.get_auth_path().ok_or_else(|| {
+            ProviderError::NotInstalled("Could not resolve Codex home directory.".to_string())
+        })?;
 
         if !auth_path.exists() {
             return Err(ProviderError::NotInstalled(format!(
@@ -268,14 +273,17 @@ impl CodexApi {
         }
     }
 
-    fn get_auth_path(&self) -> PathBuf {
-        self.codex_home().join("auth.json")
+    fn get_auth_path(&self) -> Option<PathBuf> {
+        Some(self.codex_home()?.join("auth.json"))
     }
 
     fn resolve_base_url(&self) -> String {
         // Each home carries its own config.toml, so a per-account base URL
         // override follows the account rather than leaking across them.
-        let config_path = self.codex_home().join("config.toml");
+        let Some(home) = self.codex_home() else {
+            return DEFAULT_BASE_URL.to_string();
+        };
+        let config_path = home.join("config.toml");
 
         if let Ok(content) = std::fs::read_to_string(&config_path)
             && let Some(base_url) = parse_chatgpt_base_url(&content)
@@ -1053,7 +1061,7 @@ mod tests {
 
         assert_eq!(credentials.access_token, "from-account-dir");
         assert_eq!(credentials.account_id.as_deref(), Some("acct-scoped"));
-        assert_eq!(api.get_auth_path(), home.path().join("auth.json"));
+        assert_eq!(api.get_auth_path(), Some(home.path().join("auth.json")));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Without a resolvable home, Claude and Codex ambient path helpers fell back to cwd (`.` or an empty `PathBuf`). Gemini already fail-closes that case (SBS-950); this is the leftover for Claude/Codex (SBS-1021).

`ambient_claude_config_dir` and `ambient_codex_home` now return `Option<PathBuf>`. Callers treat a missing home as `None` / `NotInstalled` instead of probing `./.claude` or `./.codex`.

Swept the same cwd fallback in:

- Claude/Codex ambient helpers and `AccountIdentity::ambient_dir`
- Claude cost-scan `projects/` roots
- Codex agent-session roots (`unwrap_or_default()` then join)
- Claude OAuth credentials path / Codex `auth.json` resolution

## Related issue

Fixes SBS-1021 (leftover from SBS-950).

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [x] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

Hosted CI runs the main frontend and Rust checks.

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` (Windows script; not run here)
- [x] Other: `cargo test --manifest-path rust/Cargo.toml` — 1117 lib + 32 bin tests passed
- [x] Other: `cargo fmt --all --check --manifest-path rust/Cargo.toml` — passed after rustfmt follow-up
- [ ] Other: `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` — not run; this Linux environment is missing `gdk-3.0` / GTK
- [ ] Other: `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` — not clean on this branch; failures are pre-existing (`secure_file.rs` unused `error`, `updater.rs` unused `verify_installer_signature_or_delete`)

Tests that fail without the fix:

- `ambient_claude_config_dir_from(None, None)` / `ambient_codex_home_from(None, None)` must be `None`, not `./.claude` / `./.codex`
- `claude_projects_dir_from_home(None)` must be `None`
- empty account store with no ambient dir yields `active_dir() == None` and no scan roots

## UI / tray proof

- [x] Not applicable

## Notes for reviewers

CodexBar's own store paths (`token-accounts.json`, `state-write.lock`, cost cache) still fall back to `.` / `.codexbar` when `config_dir` is missing. Those are not Claude/Codex ambient config/session roots and were left alone.

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e62772cf-da82-4229-98a2-32687e8fc71b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e62772cf-da82-4229-98a2-32687e8fc71b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail closed when `ClaudeIdentity` and `CodexIdentity` ambient home is unresolved
> - Changes `AccountIdentity::ambient_dir` to return `Option<PathBuf>`, preventing fallback to the working directory for `ClaudeIdentity` and `CodexIdentity` in [account_dirs.rs](https://github.com/tsouth89/ceiling/pull/378/files#diff-df8434fa9e33e370ff95cd79da451f0994bc76b8ef318de80af05fc3d0914f9e)
> - Updates consumers in `CostScanner`, `CodexApi`, and `LocalAgentSessionScanner` to skip operations or return `ProviderError::NotInstalled` when the ambient home is `None`
> - Updates the `ProviderAccounts` UI to hide path hints and use generic placeholders when `ambientDir` is `null`
> - Behavioral Change: `ProviderAccountsBridge` serializes `ambientDir` as `null`; `CodexApi.load_credentials` returns `ProviderError::NotInstalled`; `CostScanner.claude_projects_dirs` and `LocalAgentSessionScanner` skip directory walks when home is unresolved
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0dcad4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account and provider directory handling when a home or configuration path cannot be resolved.
  * Prevented fallback to the current working directory for Claude and Codex data.
  * Account setup guidance now displays appropriate placeholders and omits unavailable paths.
  * Provider discovery and credential loading now fail safely when required directories are unavailable.
* **Tests**
  * Added coverage for missing, blank, and resolved ambient directories, including path display and setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->