### PR TITLE
Stop cloning one Claude session across configured accounts

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -329,26 +329,7 @@ fn spawn_provider_refreshes(
         // One fetch per configured account, so several accounts on one provider
         // are read side by side rather than replacing each other. With none
         // configured this is a single ambient fetch, exactly as before.
-        let targets = inputs.account_dirs.targets_for(id);
-        let fetches: Vec<(FetchContext, AccountBadge)> = if targets.is_empty() {
-            vec![(base_ctx, AccountBadge::default())]
-        } else {
-            targets
-                .into_iter()
-                .map(|target| {
-                    let mut ctx = base_ctx.clone();
-                    ctx.account_config_dir = Some(target.config_dir);
-                    // Carried alongside the reading so every surface can say
-                    // which account it shows, rather than re-reading the store.
-                    let badge = AccountBadge {
-                        id: Some(target.id),
-                        label: Some(target.label),
-                        tint: target.tint,
-                    };
-                    (ctx, badge)
-                })
-                .collect()
-        };
+        let fetches = account_fetches(id, base_ctx, &inputs.account_dirs);
 
         for (ctx, account) in fetches {
             let app_handle = app.clone();
@@ -363,6 +344,37 @@ fn spawn_provider_refreshes(
     }
 
     handles
+}
+
+/// One fetch context per configured account, or a single ambient fetch.
+///
+/// Claude directory accounts drop the global session cookie/key here so Web
+/// mode cannot paint every card from one `sessionKey` (SBS-1034 / SBS-695).
+pub(crate) fn account_fetches(
+    id: ProviderId,
+    base_ctx: FetchContext,
+    account_dirs: &ConfiguredAccounts,
+) -> Vec<(FetchContext, AccountBadge)> {
+    let targets = account_dirs.targets_for(id);
+    if targets.is_empty() {
+        return vec![(base_ctx, AccountBadge::default())];
+    }
+    targets
+        .into_iter()
+        .map(|target| {
+            // Carried alongside the reading so every surface can say
+            // which account it shows, rather than re-reading the store.
+            let badge = AccountBadge {
+                id: Some(target.id),
+                label: Some(target.label),
+                tint: target.tint,
+            };
+            let ctx = base_ctx
+                .clone()
+                .pinned_to_account_dir(id, target.config_dir);
+            (ctx, badge)
+        })
+        .collect()
 }
 
 /// The active account's display identity, attached to each reading.

--- a/apps/desktop-tauri/src-tauri/src/commands/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/tests.rs
@@ -603,6 +603,91 @@ fn fetch_context_copilot_token_account_uses_oauth_api_key() {
 }
 
 #[test]
+fn configured_claude_accounts_do_not_inherit_the_global_session_cookie() {
+    let mut settings = Settings::default();
+    settings.set_cookie_source(ProviderId::Claude, "manual");
+    let mut cookies = ManualCookies::default();
+    cookies.set("claude", "sessionKey=sk-ant-global");
+    let api_keys = ApiKeys::default();
+    let token_accounts = HashMap::new();
+
+    let base_ctx = super::build_fetch_context(
+        ProviderId::Claude,
+        &settings,
+        &cookies,
+        &api_keys,
+        &token_accounts,
+    );
+    assert_eq!(base_ctx.source_mode, SourceMode::Web);
+    assert_eq!(
+        base_ctx.manual_cookie_header.as_deref(),
+        Some("sessionKey=sk-ant-global")
+    );
+
+    let mut accounts = ConfiguredAccounts::default();
+    accounts
+        .claude
+        .add_account(codexbar::core::DirectoryAccount::<
+            codexbar::core::ClaudeIdentity,
+        >::new(
+            Some("personal".into()),
+            std::path::PathBuf::from("/dirs/personal"),
+        ));
+    accounts
+        .claude
+        .add_account(codexbar::core::DirectoryAccount::<
+            codexbar::core::ClaudeIdentity,
+        >::new(
+            Some("work".into()),
+            std::path::PathBuf::from("/dirs/work"),
+        ));
+
+    let fetches = super::account_fetches(ProviderId::Claude, base_ctx, &accounts);
+    assert_eq!(fetches.len(), 2);
+    for (ctx, badge) in &fetches {
+        assert!(
+            ctx.manual_cookie_header.is_none(),
+            "account {} inherited the global sessionKey",
+            badge.label.as_deref().unwrap_or("?")
+        );
+        assert!(ctx.account_config_dir.is_some());
+    }
+    let dirs: Vec<_> = fetches
+        .iter()
+        .filter_map(|(ctx, _)| ctx.account_config_dir.clone())
+        .collect();
+    assert!(dirs.contains(&std::path::PathBuf::from("/dirs/personal")));
+    assert!(dirs.contains(&std::path::PathBuf::from("/dirs/work")));
+}
+
+#[test]
+fn ambient_claude_fetch_keeps_the_manual_session_cookie() {
+    let mut settings = Settings::default();
+    settings.set_cookie_source(ProviderId::Claude, "manual");
+    let mut cookies = ManualCookies::default();
+    cookies.set("claude", "sessionKey=sk-ant-global");
+    let api_keys = ApiKeys::default();
+    let token_accounts = HashMap::new();
+
+    let base_ctx = super::build_fetch_context(
+        ProviderId::Claude,
+        &settings,
+        &cookies,
+        &api_keys,
+        &token_accounts,
+    );
+    let fetches =
+        super::account_fetches(ProviderId::Claude, base_ctx, &ConfiguredAccounts::default());
+
+    assert_eq!(fetches.len(), 1);
+    assert_eq!(
+        fetches[0].0.manual_cookie_header.as_deref(),
+        Some("sessionKey=sk-ant-global")
+    );
+    assert!(fetches[0].0.account_config_dir.is_none());
+}
+
+#[test]
 fn fetch_context_claude_session_token_account_uses_web_cookie() {
     let settings = Settings::default();
     let cookies = ManualCookies::default();

--- a/rust/src/cli/diagnose.rs
+++ b/rust/src/cli/diagnose.rs
@@ -180,10 +180,14 @@ async fn collect_provider_diagnostic(
         api_region: settings
             .provider_config(provider_id)
             .and_then(|config| config.api_region.clone()),
-        account_config_dir: ConfiguredAccounts::load().active_dir_for(provider_id),
+        account_config_dir: None,
         gateway_url: settings
             .provider_config(provider_id)
             .and_then(|config| config.gateway_url.clone()),
+    };
+    let ctx = match ConfiguredAccounts::load().active_dir_for(provider_id) {
+        Some(dir) => ctx.pinned_to_account_dir(provider_id, dir),
+        None => ctx,
     };
 
     let fetch_result = provider.fetch_usage(&ctx).await;

--- a/rust/src/core/provider.rs
+++ b/rust/src/core/provider.rs
@@ -829,13 +829,13 @@ mod tests {
 
     #[test]
     fn for_account_strips_claude_session_cookie_when_a_directory_is_configured() {
-        let mut accounts = super::ConfiguredAccounts::default();
-        accounts
-            .claude
-            .add_account(super::DirectoryAccount::<super::ClaudeIdentity>::new(
+        let mut accounts = crate::core::ConfiguredAccounts::default();
+        accounts.claude.add_account(
+            crate::core::DirectoryAccount::<crate::core::ClaudeIdentity>::new(
                 Some("work".to_string()),
                 std::path::PathBuf::from("/dirs/work"),
-            ));
+            ),
+        );
 
         let ctx = FetchContext {
             manual_cookie_header: Some("sessionKey=sk-ant-global".to_string()),
@@ -856,7 +856,10 @@ mod tests {
             manual_cookie_header: Some("sessionKey=sk-ant-global".to_string()),
             ..FetchContext::default()
         }
-        .for_account(ProviderId::Claude, &super::ConfiguredAccounts::default());
+        .for_account(
+            ProviderId::Claude,
+            &crate::core::ConfiguredAccounts::default(),
+        );
 
         assert!(ctx.account_config_dir.is_none());
         assert_eq!(

--- a/rust/src/core/provider.rs
+++ b/rust/src/core/provider.rs
@@ -536,12 +536,27 @@ impl Default for FetchContext {
 impl FetchContext {
     /// Aim this context at whichever account is configured for `provider`,
     /// leaving it following the CLI when none is.
-    pub fn for_account(
+    pub fn for_account(self, provider: ProviderId, accounts: &super::ConfiguredAccounts) -> Self {
+        match accounts.active_dir_for(provider) {
+            Some(dir) => self.pinned_to_account_dir(provider, dir),
+            None => self,
+        }
+    }
+
+    /// Pin this fetch to one configured account directory.
+    ///
+    /// A global session cookie or key has no account identity. Cloning it onto
+    /// every `account_config_dir` fetch paints every configured Claude card
+    /// from one seat (SBS-1034 / SBS-695).
+    pub fn pinned_to_account_dir(
         mut self,
         provider: ProviderId,
-        accounts: &super::ConfiguredAccounts,
+        config_dir: std::path::PathBuf,
     ) -> Self {
-        self.account_config_dir = accounts.active_dir_for(provider);
+        self.account_config_dir = Some(config_dir);
+        if provider == ProviderId::Claude {
+            self.manual_cookie_header = None;
+        }
         self
     }
 }
@@ -768,6 +783,86 @@ mod tests {
         assert!(!ctx.verbose);
         assert!(ctx.manual_cookie_header.is_none());
         assert!(ctx.api_key.is_none());
+    }
+
+    #[test]
+    fn pinning_a_claude_account_drops_the_global_session_cookie() {
+        let ctx = FetchContext {
+            source_mode: SourceMode::Web,
+            manual_cookie_header: Some("sessionKey=sk-ant-global".to_string()),
+            api_key: Some("sk-ant-oat01-ambient".to_string()),
+            ..FetchContext::default()
+        };
+
+        let work = ctx
+            .clone()
+            .pinned_to_account_dir(ProviderId::Claude, std::path::PathBuf::from("/dirs/work"));
+        let personal = ctx.pinned_to_account_dir(
+            ProviderId::Claude,
+            std::path::PathBuf::from("/dirs/personal"),
+        );
+
+        assert_eq!(
+            work.account_config_dir.as_deref(),
+            Some(std::path::Path::new("/dirs/work"))
+        );
+        assert_eq!(
+            personal.account_config_dir.as_deref(),
+            Some(std::path::Path::new("/dirs/personal"))
+        );
+        assert!(work.manual_cookie_header.is_none());
+        assert!(personal.manual_cookie_header.is_none());
+        assert_eq!(work.api_key.as_deref(), Some("sk-ant-oat01-ambient"));
+        assert_ne!(work.account_config_dir, personal.account_config_dir);
+    }
+
+    #[test]
+    fn pinning_a_codex_account_keeps_unrelated_context_fields() {
+        let ctx = FetchContext {
+            manual_cookie_header: Some("session=abc".to_string()),
+            ..FetchContext::default()
+        };
+        let pinned =
+            ctx.pinned_to_account_dir(ProviderId::Codex, std::path::PathBuf::from("/homes/work"));
+        assert_eq!(pinned.manual_cookie_header.as_deref(), Some("session=abc"));
+    }
+
+    #[test]
+    fn for_account_strips_claude_session_cookie_when_a_directory_is_configured() {
+        let mut accounts = super::ConfiguredAccounts::default();
+        accounts
+            .claude
+            .add_account(super::DirectoryAccount::<super::ClaudeIdentity>::new(
+                Some("work".to_string()),
+                std::path::PathBuf::from("/dirs/work"),
+            ));
+
+        let ctx = FetchContext {
+            manual_cookie_header: Some("sessionKey=sk-ant-global".to_string()),
+            ..FetchContext::default()
+        }
+        .for_account(ProviderId::Claude, &accounts);
+
+        assert_eq!(
+            ctx.account_config_dir.as_deref(),
+            Some(std::path::Path::new("/dirs/work"))
+        );
+        assert!(ctx.manual_cookie_header.is_none());
+    }
+
+    #[test]
+    fn for_account_keeps_the_session_cookie_when_following_the_cli() {
+        let ctx = FetchContext {
+            manual_cookie_header: Some("sessionKey=sk-ant-global".to_string()),
+            ..FetchContext::default()
+        }
+        .for_account(ProviderId::Claude, &super::ConfiguredAccounts::default());
+
+        assert!(ctx.account_config_dir.is_none());
+        assert_eq!(
+            ctx.manual_cookie_header.as_deref(),
+            Some("sessionKey=sk-ant-global")
+        );
     }
 
     #[test]

--- a/rust/src/providers/claude/mod.rs
+++ b/rust/src/providers/claude/mod.rs
@@ -81,6 +81,56 @@ fn claude_oauth_source(ctx: &FetchContext) -> ClaudeOAuthSource<'_> {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum ClaudeWebSource<'a> {
+    /// Pasted / token-account cookie. Ambient fetches only: a configured
+    /// directory account must not inherit this global session (SBS-1034).
+    ManualCookie(&'a str),
+    /// Env session key or Claude Desktop cookies. Same global-session rule.
+    Ambient,
+    /// Configured `CLAUDE_CONFIG_DIR`: use that directory's OAuth only.
+    ScopedOAuthOnly,
+}
+
+fn claude_web_source(ctx: &FetchContext) -> ClaudeWebSource<'_> {
+    if ctx.account_config_dir.is_some() {
+        return ClaudeWebSource::ScopedOAuthOnly;
+    }
+    match ctx
+        .manual_cookie_header
+        .as_deref()
+        .filter(|header| !header.trim().is_empty())
+    {
+        Some(header) => ClaudeWebSource::ManualCookie(header),
+        None => ClaudeWebSource::Ambient,
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ClaudeCliSource<'a> {
+    Scoped(&'a std::path::Path),
+    Ambient,
+}
+
+fn claude_cli_source(ctx: &FetchContext) -> ClaudeCliSource<'_> {
+    match ctx.account_config_dir.as_deref() {
+        Some(dir) => ClaudeCliSource::Scoped(dir),
+        None => ClaudeCliSource::Ambient,
+    }
+}
+
+fn apply_claude_cli_config_dir(
+    env: &mut std::collections::HashMap<String, String>,
+    config_dir: Option<&std::path::Path>,
+) {
+    if let Some(dir) = config_dir {
+        env.insert(
+            "CLAUDE_CONFIG_DIR".to_string(),
+            dir.to_string_lossy().into_owned(),
+        );
+    }
+}
+
 impl ClaudeProvider {
     pub fn new() -> Self {
         Self {
@@ -259,11 +309,13 @@ struct ClaudePtyProbeOptions {
     script_char_delay_secs: f64,
     script_line_delay_secs: f64,
     send_on_substring: Option<(&'static str, &'static str)>,
+    config_dir: Option<std::path::PathBuf>,
 }
 
 async fn run_claude_usage_pty_probe(
     claude_path: std::path::PathBuf,
     working_directory: std::path::PathBuf,
+    config_dir: Option<std::path::PathBuf>,
 ) -> Result<String, ProviderError> {
     run_claude_pty_probe(
         claude_path,
@@ -276,6 +328,7 @@ async fn run_claude_usage_pty_probe(
             script_char_delay_secs: 0.04,
             script_line_delay_secs: 0.0,
             send_on_substring: None,
+            config_dir,
         },
     )
     .await
@@ -284,6 +337,7 @@ async fn run_claude_usage_pty_probe(
 async fn run_claude_trust_preflight(
     claude_path: std::path::PathBuf,
     working_directory: std::path::PathBuf,
+    config_dir: Option<std::path::PathBuf>,
 ) -> Result<String, ProviderError> {
     run_claude_pty_probe(
         claude_path,
@@ -296,6 +350,7 @@ async fn run_claude_trust_preflight(
             script_char_delay_secs: 0.0,
             script_line_delay_secs: 0.0,
             send_on_substring: Some(("Enter", "\n/exit\n")),
+            config_dir,
         },
     )
     .await
@@ -311,24 +366,29 @@ fn resolve_claude_cli_path() -> Result<std::path::PathBuf, ProviderError> {
 
 async fn fetch_claude_cli_usage_text(
     claude_path: std::path::PathBuf,
+    config_dir: Option<&std::path::Path>,
 ) -> Result<String, ProviderError> {
     let probe_dir = claude_usage_probe_dir()?;
-    let combined = run_claude_usage_pty_probe(claude_path.clone(), probe_dir.clone()).await?;
+    let config_dir = config_dir.map(std::path::Path::to_path_buf);
+    let combined =
+        run_claude_usage_pty_probe(claude_path.clone(), probe_dir.clone(), config_dir.clone())
+            .await?;
 
-    rerun_claude_usage_after_trust_prompt(claude_path, probe_dir, combined).await
+    rerun_claude_usage_after_trust_prompt(claude_path, probe_dir, config_dir, combined).await
 }
 
 async fn rerun_claude_usage_after_trust_prompt(
     claude_path: std::path::PathBuf,
     probe_dir: std::path::PathBuf,
+    config_dir: Option<std::path::PathBuf>,
     combined: String,
 ) -> Result<String, ProviderError> {
     if !is_workspace_trust_prompt(&strip_ansi(&combined).to_lowercase()) {
         return Ok(combined);
     }
 
-    run_claude_trust_preflight(claude_path.clone(), probe_dir.clone()).await?;
-    run_claude_usage_pty_probe(claude_path, probe_dir).await
+    run_claude_trust_preflight(claude_path.clone(), probe_dir.clone(), config_dir.clone()).await?;
+    run_claude_usage_pty_probe(claude_path, probe_dir, config_dir).await
 }
 
 fn claude_cli_error_from_output(output: &str) -> Option<ProviderError> {
@@ -392,6 +452,7 @@ async fn run_claude_pty_probe(
     tokio::task::spawn_blocking(move || {
         let mut env = TtyCommandRunner::enriched_environment();
         env.insert("NO_COLOR".to_string(), "1".to_string());
+        apply_claude_cli_config_dir(&mut env, probe.config_dir.as_deref());
 
         let mut options = TtyCommandOptions::new()
             .with_timeout(probe.timeout_secs)
@@ -566,27 +627,40 @@ impl ClaudeProvider {
     ) -> Result<ProviderFetchResult, ProviderError> {
         tracing::debug!("Attempting Web API fetch for Claude");
 
-        // Check for manual cookie header first
-        if let Some(ref cookie_header) = ctx.manual_cookie_header {
-            tracing::debug!("Using manual cookie header");
-            return self
-                .web_fetcher
-                .fetch_with_cookie_header(cookie_header)
-                .await;
+        match claude_web_source(ctx) {
+            ClaudeWebSource::ScopedOAuthOnly => {
+                // A configured account is a promise that this reading belongs
+                // to one CLAUDE_CONFIG_DIR. The pasted sessionKey, env key,
+                // and Claude Desktop cookie are one global session, so using
+                // them here clones that seat onto every configured card.
+                tracing::debug!(
+                    config_dir = ?ctx.account_config_dir,
+                    "refusing global Claude session cookie for configured account"
+                );
+                self.fetch_via_oauth(ctx).await
+            }
+            ClaudeWebSource::ManualCookie(cookie_header) => {
+                tracing::debug!("Using manual cookie header");
+                self.web_fetcher
+                    .fetch_with_cookie_header(cookie_header)
+                    .await
+            }
+            ClaudeWebSource::Ambient => self.web_fetcher.fetch_with_cookies().await,
         }
-
-        // Otherwise, try to extract cookies from browser
-        self.web_fetcher.fetch_with_cookies().await
     }
 
     async fn fetch_via_cli(
         &self,
-        _ctx: &FetchContext,
+        ctx: &FetchContext,
     ) -> Result<ProviderFetchResult, ProviderError> {
         tracing::debug!("Attempting CLI probe for Claude");
 
         let claude_path = resolve_claude_cli_path()?;
-        let combined = fetch_claude_cli_usage_text(claude_path).await?;
+        let config_dir = match claude_cli_source(ctx) {
+            ClaudeCliSource::Scoped(dir) => Some(dir),
+            ClaudeCliSource::Ambient => None,
+        };
+        let combined = fetch_claude_cli_usage_text(claude_path, config_dir).await?;
 
         if let Some(error) = claude_cli_error_from_output(&combined) {
             return Err(error);
@@ -1102,6 +1176,78 @@ mod tests {
         assert_eq!(
             claude_auto_policy(&ambient),
             ClaudeAutoPolicy::FallbackChain
+        );
+    }
+
+    #[test]
+    fn configured_account_web_refuses_global_session_cookie() {
+        let configured = FetchContext {
+            account_config_dir: Some(std::path::PathBuf::from(r"C:\Users\person\.claude-work")),
+            manual_cookie_header: Some("sessionKey=sk-ant-global".to_string()),
+            ..FetchContext::default()
+        };
+        assert_eq!(
+            claude_web_source(&configured),
+            ClaudeWebSource::ScopedOAuthOnly
+        );
+
+        let configured_without_cookie = FetchContext {
+            account_config_dir: Some(std::path::PathBuf::from(r"C:\Users\person\.claude-work")),
+            ..FetchContext::default()
+        };
+        assert_eq!(
+            claude_web_source(&configured_without_cookie),
+            ClaudeWebSource::ScopedOAuthOnly,
+            "env / Claude Desktop cookies are also a global session"
+        );
+
+        let ambient = FetchContext {
+            manual_cookie_header: Some("sessionKey=sk-ant-global".to_string()),
+            ..FetchContext::default()
+        };
+        assert_eq!(
+            claude_web_source(&ambient),
+            ClaudeWebSource::ManualCookie("sessionKey=sk-ant-global")
+        );
+
+        assert_eq!(
+            claude_web_source(&FetchContext::default()),
+            ClaudeWebSource::Ambient
+        );
+    }
+
+    #[test]
+    fn configured_account_cli_is_directory_scoped() {
+        let dir = std::path::PathBuf::from(r"C:\Users\person\.claude-work");
+        let configured = FetchContext {
+            account_config_dir: Some(dir.clone()),
+            ..FetchContext::default()
+        };
+        assert_eq!(
+            claude_cli_source(&configured),
+            ClaudeCliSource::Scoped(std::path::Path::new(r"C:\Users\person\.claude-work"))
+        );
+        assert_eq!(
+            claude_cli_source(&FetchContext::default()),
+            ClaudeCliSource::Ambient
+        );
+
+        let mut env = std::collections::HashMap::new();
+        env.insert(
+            "CLAUDE_CONFIG_DIR".to_string(),
+            r"C:\Users\person\.claude".to_string(),
+        );
+        apply_claude_cli_config_dir(&mut env, Some(dir.as_path()));
+        assert_eq!(
+            env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
+            Some(r"C:\Users\person\.claude-work")
+        );
+
+        let mut ambient_env = std::collections::HashMap::new();
+        apply_claude_cli_config_dir(&mut ambient_env, None);
+        assert!(
+            !ambient_env.contains_key("CLAUDE_CONFIG_DIR"),
+            "ambient CLI must not invent a config dir"
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SBS-695 (`ScopedOAuthOnly`) only gated Auto. Default Claude `cookie_source=manual` plus a pasted `sessionKey` still forced Web, and that global cookie was cloned onto every configured `CLAUDE_CONFIG_DIR` fetch. Web/Cli ignored scoped OAuth, so every account card was painted from one session.

This closes that leftover for SBS-1034:

- Pinning a fetch to a Claude directory account drops the global session cookie so it cannot ride along.
- Web on a configured account refuses the pasted cookie, env session key, and Claude Desktop cookie, then uses directory-scoped OAuth.
- Cli on a configured account sets `CLAUDE_CONFIG_DIR` for that account instead of probing the ambient CLI session.
- Ambient (no configured directories) still uses the manual cookie / Web path.

## Related issue

Linear: SBS-1034 (completes the SBS-695 Web/Cli/manual-cookie sink)

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [x] CLI
- [x] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

- [x] GitHub CI on this branch: all 10 checks passed (Frontend, Rust / shared, Rust / desktop, Rust, CodeQL, CodeRabbit)
- [x] `cargo test --manifest-path rust/Cargo.toml` — 1115 lib + 32 bin tests passed
- [x] `cargo fmt --all` on `rust/Cargo.toml` and `apps/desktop-tauri/src-tauri/Cargo.toml`
- [ ] `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` — failed locally on pre-existing main issues (`secure_file.rs` unused `error`, `updater.rs` unused `verify_installer_signature_or_delete`); Windows CI clippy passed
- [x] Desktop crate tests ran in GitHub CI (`CI / Rust / desktop`)
- [ ] `powershell.exe ... scripts\local-check.ps1` — Windows-only; not run here

## UI / tray proof

- [x] Not applicable

## Notes for reviewers

- The desktop refresh clone path is the original sink (`base_ctx` + `sessionKey` copied onto every account). `account_fetches` now goes through `FetchContext::pinned_to_account_dir`.
- Provider-level Web/Cli gates are the backstop for diagnose/usage and any other caller that still attaches a cookie.
- Configured Web cards with no OAuth in that directory will error instead of showing the wrong seat. That is the intended SBS-695 behavior.

Do not merge from this agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-968de01c-fc2a-41bc-9134-148002e04f31?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-968de01c-fc2a-41bc-9134-148002e04f31&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin Claude fetch contexts to configured account directories
> - Adds `FetchContext::pinned_to_account_dir` which sets `account_config_dir` and, for Claude only, clears `manual_cookie_header` so each configured account no longer shares one global session cookie/key
> - Adds `account_fetches` helper in [providers.rs](https://github.com/tsouth89/ceiling/pull/379/files#diff-3248357642e86f56167cd6fd4d31117a591622790738676c888e0a5e83000164) that builds one pinned context per configured account (or a single ambient pair when no accounts are set), and updates the diagnose routine in [diagnose.rs](https://github.com/tsouth89/ceiling/pull/379/files#diff-f395a515368d5d5c379cc88d815c3c8fc45c20d34ff12220c53719bac2745282) to pin similarly
> - Rewrites `ClaudeProvider::fetch_via_web` around a new `ClaudeWebSource` classifier: configured accounts use OAuth and ignore any global session cookie; ambient behavior with manual or browser cookies is unchanged
> - Threads an optional `config_dir` through the Claude CLI probe helpers (`run_claude_pty_probe`, `run_claude_usage_pty_probe`, `run_claude_trust_preflight`, etc.) so CLI usage fetches set `CLAUDE_CONFIG_DIR` to the configured account directory when scoped
> - Behavioral Change: `FetchContext::for_account` now takes `self` by value; for Claude it clears `manual_cookie_header` when an account directory is active, and CLI probes run under `CLAUDE_CONFIG_DIR` — non-Claude providers retain prior cookie/key behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7db0d91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Claude account handling so configured accounts use their own credentials and configuration directories.
  - Added stronger separation between configured accounts and global manual sessions.
  - Claude CLI checks now respect the selected account’s configuration.

- **Bug Fixes**
  - Prevented credentials from one Claude account affecting another.
  - Preserved existing manual-session behavior when no configured account is selected.
  - Improved provider diagnostics for account-specific configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->