### PR TITLE
Gate keyring I/O with keychain opt-out flags

### DIFF
--- a/docs/SETTINGS_JSON.md
+++ b/docs/SETTINGS_JSON.md
@@ -43,7 +43,7 @@ fields marked safe, but Ceiling may overwrite the file when the app exits.
 | `show_all_token_accounts_in_menu` | boolean | `false` | Show all token accounts instead of collapsing behind switchers. Safe to edit. |
 | `provider_configs` | object | `{}` | Per-provider configuration map. See below. Safe to edit. |
 | `unrecognized_provider_configs` | object | `{}` | Written by Ceiling, not by you. Holds `provider_configs` entries whose provider id this build does not recognize, so they survive until a build that knows them folds them back in. Leave it unchanged. |
-| `disable_keychain_access` | boolean | `false` | Disable keychain-style credential reads where supported. Safe to edit. |
+| `disable_keychain_access` | boolean | `false` | Disable all OS keychain reads and writes (SBS-1023). Credential paths skip the keyring and fall through to Preferences, environment, or files. Safe to edit. |
 | `hide_personal_info` | boolean | `false` | Hide emails and account names for streaming/sharing. Safe to edit. |
 | `update_channel` | string | `"stable"` | `"stable"` or `"beta"`. Safe to edit. |
 | `provider_metrics` | object | `{}` | Per-provider metric preference by CLI name; values include `automatic`, `session`, `weekly`, `model`, `tertiary`, `credits`, `extraUsage`, and `average`. Safe to edit. |
@@ -95,7 +95,7 @@ Each key is a provider CLI name. Values are objects with optional fields:
 | `openai_web_extras` | boolean | Codex-only; opt out of OpenAI web extras surfaces. |
 | `spark_usage_visible` | boolean | Codex-only; show Codex Spark quota rows. |
 | `historical_tracking` | boolean | Codex-only; default `false`. |
-| `avoid_keychain_prompts` | boolean | Claude-only; default `false`. |
+| `avoid_keychain_prompts` | boolean | Claude-only; default `false`. When true, Claude does not read or write the OS keychain (SBS-1023). |
 
 Legacy flat fields such as `codex_cookie_source`, `claude_cookie_source`, and
 `alibaba_api_region` are accepted on load and migrated into `provider_configs`.

--- a/rust/src/keychain.rs
+++ b/rust/src/keychain.rs
@@ -148,9 +148,7 @@ mod test_backend {
     ) -> Option<Result<String, Error>> {
         STORE.with(|store| {
             let mut store = store.borrow_mut();
-            let Some(map) = store.as_mut() else {
-                return None;
-            };
+            let map = store.as_mut()?;
             let key = (service.to_string(), user.to_string());
             Some(match operation {
                 Operation::Get => map.get(&key).cloned().ok_or(Error::NotFound),
@@ -233,8 +231,10 @@ mod tests {
     use crate::core::ProviderId;
 
     fn settings_with(disable: bool, avoid_claude: bool) -> Settings {
-        let mut settings = Settings::default();
-        settings.disable_keychain_access = disable;
+        let mut settings = Settings {
+            disable_keychain_access: disable,
+            ..Default::default()
+        };
         settings.set_avoid_keychain_prompts(ProviderId::Claude, avoid_claude);
         settings
     }

--- a/rust/src/keychain.rs
+++ b/rust/src/keychain.rs
@@ -1,0 +1,312 @@
+//! OS keychain access gated by settings flags (SBS-1023).
+//!
+//! `disable_keychain_access` skips every keyring read and write.
+//! Claude's `avoid_keychain_prompts` additionally skips Claude keyring
+//! reads and token writes. Both prefer skip / fail-closed over prompting.
+
+use crate::settings::Settings;
+use thiserror::Error;
+
+/// Which settings flags apply to a keychain operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Scope {
+    /// Global reads/writes (`disable_keychain_access`).
+    Any,
+    /// Claude credential reads/writes (global flag or `avoid_keychain_prompts`).
+    Claude,
+}
+
+/// Why a keychain operation did not return a secret.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub(crate) enum Error {
+    #[error("keychain access is disabled (SBS-1023)")]
+    Disabled,
+    #[error("keychain entry not found")]
+    NotFound,
+    #[error("keychain storage error: {0}")]
+    Storage(String),
+}
+
+/// Whether `settings` allows keychain access for `scope`.
+pub(crate) fn allowed_for(settings: &Settings, scope: Scope) -> bool {
+    match scope {
+        Scope::Any => settings.keychain_access_allowed(),
+        Scope::Claude => settings.claude_keychain_access_allowed(),
+    }
+}
+
+/// Live settings snapshot used by UI and CLI credential paths.
+pub(crate) fn allowed(scope: Scope) -> bool {
+    #[cfg(test)]
+    if let Some(override_allowed) = test_backend::allowed_override(scope) {
+        return override_allowed;
+    }
+    allowed_for(&Settings::load(), scope)
+}
+
+/// Read a non-empty secret, or `None` when disabled, missing, or unreadable.
+pub(crate) fn get_secret(scope: Scope, service: &str, user: &str) -> Option<String> {
+    match get_password(scope, service, user) {
+        Ok(value) if !value.trim().is_empty() => Some(value),
+        _ => None,
+    }
+}
+
+pub(crate) fn get_password(scope: Scope, service: &str, user: &str) -> Result<String, Error> {
+    operate(scope, service, user, Operation::Get)
+}
+
+pub(crate) fn set_password(
+    scope: Scope,
+    service: &str,
+    user: &str,
+    value: &str,
+) -> Result<(), Error> {
+    operate(scope, service, user, Operation::Set(value))?;
+    Ok(())
+}
+
+pub(crate) fn delete_credential(scope: Scope, service: &str, user: &str) -> Result<(), Error> {
+    operate(scope, service, user, Operation::Delete)?;
+    Ok(())
+}
+
+enum Operation<'a> {
+    Get,
+    Set(&'a str),
+    Delete,
+}
+
+fn operate(
+    scope: Scope,
+    service: &str,
+    user: &str,
+    operation: Operation<'_>,
+) -> Result<String, Error> {
+    if !allowed(scope) {
+        return Err(Error::Disabled);
+    }
+    #[cfg(test)]
+    if let Some(result) = test_backend::operate(service, user, &operation) {
+        return result;
+    }
+    os_operate(service, user, operation)
+}
+
+fn os_operate(service: &str, user: &str, operation: Operation<'_>) -> Result<String, Error> {
+    let entry =
+        keyring::Entry::new(service, user).map_err(|error| Error::Storage(error.to_string()))?;
+    match operation {
+        Operation::Get => entry.get_password().map_err(map_keyring_error),
+        Operation::Set(value) => {
+            entry
+                .set_password(value)
+                .map_err(|error| Error::Storage(error.to_string()))?;
+            Ok(String::new())
+        }
+        Operation::Delete => match entry.delete_credential() {
+            Ok(()) => Ok(String::new()),
+            Err(keyring::Error::NoEntry) => Err(Error::NotFound),
+            Err(error) => Err(Error::Storage(error.to_string())),
+        },
+    }
+}
+
+fn map_keyring_error(error: keyring::Error) -> Error {
+    match error {
+        keyring::Error::NoEntry => Error::NotFound,
+        other => Error::Storage(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod test_backend {
+    use super::{Error, Operation, Scope};
+    use std::cell::{Cell, RefCell};
+    use std::collections::HashMap;
+
+    thread_local! {
+        static ANY_OVERRIDE: Cell<Option<bool>> = const { Cell::new(None) };
+        static CLAUDE_OVERRIDE: Cell<Option<bool>> = const { Cell::new(None) };
+        static STORE: RefCell<Option<HashMap<(String, String), String>>> =
+            const { RefCell::new(None) };
+    }
+
+    pub(super) fn allowed_override(scope: Scope) -> Option<bool> {
+        match scope {
+            Scope::Any => ANY_OVERRIDE.with(Cell::get),
+            Scope::Claude => CLAUDE_OVERRIDE
+                .with(Cell::get)
+                .or_else(|| ANY_OVERRIDE.with(Cell::get)),
+        }
+    }
+
+    pub(super) fn operate(
+        service: &str,
+        user: &str,
+        operation: &Operation<'_>,
+    ) -> Option<Result<String, Error>> {
+        STORE.with(|store| {
+            let mut store = store.borrow_mut();
+            let Some(map) = store.as_mut() else {
+                return None;
+            };
+            let key = (service.to_string(), user.to_string());
+            Some(match operation {
+                Operation::Get => map.get(&key).cloned().ok_or(Error::NotFound),
+                Operation::Set(value) => {
+                    map.insert(key, (*value).to_string());
+                    Ok(String::new())
+                }
+                Operation::Delete => match map.remove(&key) {
+                    Some(_) => Ok(String::new()),
+                    None => Err(Error::NotFound),
+                },
+            })
+        })
+    }
+
+    pub(crate) struct OverrideGuard {
+        previous_any: Option<bool>,
+        previous_claude: Option<bool>,
+        previous_store: Option<HashMap<(String, String), String>>,
+    }
+
+    impl Drop for OverrideGuard {
+        fn drop(&mut self) {
+            ANY_OVERRIDE.with(|cell| cell.set(self.previous_any));
+            CLAUDE_OVERRIDE.with(|cell| cell.set(self.previous_claude));
+            STORE.with(|store| {
+                *store.borrow_mut() = self.previous_store.take();
+            });
+        }
+    }
+
+    pub(crate) fn with_state(
+        any: Option<bool>,
+        claude: Option<bool>,
+        store: Option<HashMap<(String, String), String>>,
+    ) -> OverrideGuard {
+        let previous_any = ANY_OVERRIDE.with(|cell| cell.replace(any));
+        let previous_claude = CLAUDE_OVERRIDE.with(|cell| cell.replace(claude));
+        let previous_store = STORE.with(|cell| cell.replace(store));
+        OverrideGuard {
+            previous_any,
+            previous_claude,
+            previous_store,
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn with_reads_allowed(allowed: bool) -> test_backend::OverrideGuard {
+    test_backend::with_state(Some(allowed), None, None)
+}
+
+#[cfg(test)]
+pub(crate) fn with_claude_allowed(allowed: bool) -> test_backend::OverrideGuard {
+    test_backend::with_state(None, Some(allowed), None)
+}
+
+#[cfg(test)]
+pub(crate) fn with_mock_store(
+    allowed: bool,
+    entries: &[(&str, &str, &str)],
+) -> test_backend::OverrideGuard {
+    let store = entries
+        .iter()
+        .map(|(service, user, value)| {
+            (
+                (*service).to_string(),
+                (*user).to_string(),
+                (*value).to_string(),
+            )
+        })
+        .map(|(service, user, value)| ((service, user), value))
+        .collect();
+    test_backend::with_state(Some(allowed), Some(allowed), Some(store))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ProviderId;
+
+    fn settings_with(disable: bool, avoid_claude: bool) -> Settings {
+        let mut settings = Settings::default();
+        settings.disable_keychain_access = disable;
+        settings.set_avoid_keychain_prompts(ProviderId::Claude, avoid_claude);
+        settings
+    }
+
+    #[test]
+    fn disable_keychain_access_blocks_every_scope() {
+        let settings = settings_with(true, false);
+        assert!(!allowed_for(&settings, Scope::Any));
+        assert!(!allowed_for(&settings, Scope::Claude));
+    }
+
+    #[test]
+    fn avoid_keychain_prompts_blocks_only_claude() {
+        let settings = settings_with(false, true);
+        assert!(allowed_for(&settings, Scope::Any));
+        assert!(!allowed_for(&settings, Scope::Claude));
+    }
+
+    #[test]
+    fn defaults_allow_keychain_access() {
+        let settings = Settings::default();
+        assert!(allowed_for(&settings, Scope::Any));
+        assert!(allowed_for(&settings, Scope::Claude));
+    }
+
+    #[test]
+    fn disabled_get_never_opens_the_os_keyring() {
+        let _guard = with_reads_allowed(false);
+        assert_eq!(
+            get_password(Scope::Any, "ceiling-sbs-1023", "must-not-open"),
+            Err(Error::Disabled)
+        );
+        assert_eq!(
+            get_secret(Scope::Any, "ceiling-sbs-1023", "must-not-open"),
+            None
+        );
+    }
+
+    #[test]
+    fn disabled_set_never_opens_the_os_keyring() {
+        let _guard = with_reads_allowed(false);
+        assert_eq!(
+            set_password(Scope::Any, "ceiling-sbs-1023", "must-not-open", "secret"),
+            Err(Error::Disabled)
+        );
+    }
+
+    #[test]
+    fn mock_store_is_ignored_when_access_is_disabled() {
+        let _guard = with_mock_store(false, &[("svc", "api_key", "from-keyring")]);
+        assert_eq!(get_secret(Scope::Any, "svc", "api_key"), None);
+        assert_eq!(
+            get_password(Scope::Any, "svc", "api_key"),
+            Err(Error::Disabled)
+        );
+    }
+
+    #[test]
+    fn mock_store_returns_the_secret_when_access_is_allowed() {
+        let _guard = with_mock_store(true, &[("svc", "api_key", "from-keyring")]);
+        assert_eq!(
+            get_secret(Scope::Any, "svc", "api_key").as_deref(),
+            Some("from-keyring")
+        );
+    }
+
+    #[test]
+    fn claude_scope_stays_disabled_when_only_avoid_prompts_is_set() {
+        let _guard = with_claude_allowed(false);
+        assert_eq!(
+            get_password(Scope::Claude, "Claude Code-credentials", "acct"),
+            Err(Error::Disabled)
+        );
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,6 +12,7 @@ pub mod cost_scanner;
 pub mod cursor_activity;
 mod grok_costs;
 pub mod host;
+mod keychain;
 pub mod locale;
 pub mod logging;
 pub mod login;

--- a/rust/src/providers/claude/oauth/credentials_store.rs
+++ b/rust/src/providers/claude/oauth/credentials_store.rs
@@ -114,6 +114,7 @@ pub(super) fn load_credentials(
     }
 
     // Current Claude Code builds store the same JSON payload in the OS credential store.
+    // SBS-1023: skip when the user opted out of keychain reads.
     if let Some((creds, source)) = load_from_keyring()? {
         return Ok((creds, source));
     }
@@ -182,23 +183,25 @@ pub(super) fn credentials_file_available(config_dir: Option<&Path>) -> bool {
 /// Load credentials from Claude Code's OS keychain / credential manager entry.
 fn load_from_keyring() -> Result<Option<(ClaudeOAuthCredentials, CredentialSource)>, ProviderError>
 {
-    for account in keyring_account_candidates() {
-        let entry = match keyring::Entry::new(KEYRING_SERVICE, &account) {
-            Ok(entry) => entry,
-            Err(err) => {
-                tracing::debug!(
-                    "Failed to open Claude Code credential entry for account {}: {}",
-                    account,
-                    err
-                );
-                continue;
-            }
-        };
+    if !crate::keychain::allowed(crate::keychain::Scope::Claude) {
+        tracing::debug!("Skipping Claude keyring read; keychain access disabled (SBS-1023)");
+        return Ok(None);
+    }
 
-        let content = match entry.get_password() {
+    for account in keyring_account_candidates() {
+        let content = match crate::keychain::get_password(
+            crate::keychain::Scope::Claude,
+            KEYRING_SERVICE,
+            &account,
+        ) {
             Ok(content) => content,
-            Err(keyring::Error::NoEntry) => continue,
-            Err(keyring::Error::Ambiguous(_)) => continue,
+            Err(crate::keychain::Error::Disabled) => {
+                tracing::debug!(
+                    "Skipping Claude keyring read; keychain access disabled (SBS-1023)"
+                );
+                return Ok(None);
+            }
+            Err(crate::keychain::Error::NotFound) => continue,
             Err(err) => {
                 tracing::debug!(
                     "Failed to read Claude Code credential entry for account {}: {}",
@@ -433,20 +436,30 @@ fn persist_refreshed_keyring(
     account: &str,
     exchanged_refresh_token: &str,
 ) -> Result<Option<ClaudeOAuthCredentials>, ProviderError> {
-    let entry = keyring::Entry::new(KEYRING_SERVICE, account).map_err(|err| {
-        ProviderError::OAuth(format!(
-            "Failed to open Claude Code credential entry for account {account}: {err}"
-        ))
-    })?;
-    let content = entry.get_password().map_err(|err| {
-        ProviderError::OAuth(format!(
-            "Failed to read Claude Code credential entry for account {account}: {err}"
-        ))
-    })?;
+    if !crate::keychain::allowed(crate::keychain::Scope::Claude) {
+        return Err(ProviderError::OAuth(
+            "Claude keychain writes are disabled (SBS-1023). The refreshed token was not stored."
+                .to_string(),
+        ));
+    }
+
+    let content =
+        crate::keychain::get_password(crate::keychain::Scope::Claude, KEYRING_SERVICE, account)
+            .map_err(|err| {
+                ProviderError::OAuth(format!(
+                    "Failed to read Claude Code credential entry for account {account}: {err}"
+                ))
+            })?;
     match merge_refreshed_credentials_json(&content, credentials, exchanged_refresh_token)? {
         Err(live) => Ok(Some(live)),
         Ok(serialized) => {
-            entry.set_password(&serialized).map_err(|err| {
+            crate::keychain::set_password(
+                crate::keychain::Scope::Claude,
+                KEYRING_SERVICE,
+                account,
+                &serialized,
+            )
+            .map_err(|err| {
                 ProviderError::OAuth(format!(
                     "Failed to write Claude Code credential entry for account {account}: {err}"
                 ))
@@ -559,10 +572,10 @@ fn apply_refresh_to_credentials_json(
 #[cfg(test)]
 mod tests {
     use super::{
-        CredentialSource, ENV_TOKEN_KEY, apply_refresh_to_credentials_json,
+        CredentialSource, ENV_TOKEN_KEY, KEYRING_SERVICE, apply_refresh_to_credentials_json,
         cached_refreshed_if_fresher, credentials_path, disk_still_holds_exchanged_refresh,
         load_credentials, merge_refreshed_credentials_json, parse_credentials_json,
-        persist_refreshed_credentials, store_refreshed,
+        persist_refreshed_credentials, persist_refreshed_for_source, store_refreshed,
     };
     use crate::providers::claude::oauth::ClaudeOAuthCredentials;
     use std::path::Path;
@@ -1324,6 +1337,66 @@ mod tests {
         assert_eq!(
             same_source_result.map(|c| c.access_token),
             Some("file-refreshed-token".to_string())
+        );
+    }
+
+    /// SBS-1023: a keyring-resident Claude token must not be read when the
+    /// user opted out. Without the gate this returns `from-keyring`.
+    #[test]
+    fn keychain_flags_skip_claude_keyring_reads() {
+        let _guard = env_lock().lock().expect("env lock");
+        let ambient = tempfile::tempdir().expect("tempdir");
+        let _config = EnvGuard::set("CLAUDE_CONFIG_DIR", ambient.path());
+        let _token = EnvGuard::unset(ENV_TOKEN_KEY);
+        let _user = EnvGuard::set_str("USER", "sbs-1023-user");
+        let _username = EnvGuard::unset("USERNAME");
+        let payload =
+            r#"{"accessToken":"from-keyring","refreshToken":"r","scopes":["user:profile"]}"#;
+        let _keychain =
+            crate::keychain::with_mock_store(false, &[(KEYRING_SERVICE, "sbs-1023-user", payload)]);
+
+        let error = load_credentials(None).expect_err("disabled keychain must not use the keyring");
+        assert!(
+            error.to_string().contains("credentials not found"),
+            "expected a file-miss error, got {error}"
+        );
+    }
+
+    /// SBS-1023: the same mock secret is used when access is allowed, so the
+    /// skip test above is not a missing-entry false pass.
+    #[test]
+    fn keychain_flags_still_read_claude_keyring_when_allowed() {
+        let _guard = env_lock().lock().expect("env lock");
+        let ambient = tempfile::tempdir().expect("tempdir");
+        let _config = EnvGuard::set("CLAUDE_CONFIG_DIR", ambient.path());
+        let _token = EnvGuard::unset(ENV_TOKEN_KEY);
+        let _user = EnvGuard::set_str("USER", "sbs-1023-user");
+        let _username = EnvGuard::unset("USERNAME");
+        let payload =
+            r#"{"accessToken":"from-keyring","refreshToken":"r","scopes":["user:profile"]}"#;
+        let _keychain =
+            crate::keychain::with_mock_store(true, &[(KEYRING_SERVICE, "sbs-1023-user", payload)]);
+
+        let (credentials, source) = load_credentials(None).expect("keyring credentials");
+        assert_eq!(credentials.access_token, "from-keyring");
+        assert_eq!(source, CredentialSource::Keyring("sbs-1023-user".into()));
+    }
+
+    /// SBS-1023: a refreshed Claude token must not be written back to the
+    /// keyring when the user opted out. Without the gate this opens the OS
+    /// entry instead of returning the opt-out error.
+    #[test]
+    fn keychain_flags_skip_claude_token_writes() {
+        let _keychain = crate::keychain::with_claude_allowed(false);
+        let error = persist_refreshed_for_source(
+            &refreshed_credentials("new-access"),
+            &CredentialSource::Keyring("sbs-1023-user".into()),
+            "old-refresh",
+        )
+        .expect_err("disabled keychain must not write");
+        assert!(
+            error.to_string().contains("SBS-1023"),
+            "expected the opt-out error, got {error}"
         );
     }
 }

--- a/rust/src/providers/codebuff/mod.rs
+++ b/rust/src/providers/codebuff/mod.rs
@@ -75,8 +75,12 @@ impl CodebuffProvider {
     }
 
     fn api_key_from_keyring() -> Option<String> {
-        let entry = keyring::Entry::new(CODEBUFF_CREDENTIAL_TARGET, "api_key").ok()?;
-        clean_api_key(&entry.get_password().ok()?)
+        crate::keychain::get_secret(
+            crate::keychain::Scope::Any,
+            CODEBUFF_CREDENTIAL_TARGET,
+            "api_key",
+        )
+        .and_then(|key| clean_api_key(&key))
     }
 
     fn api_key_from_env() -> Option<String> {

--- a/rust/src/providers/crof/mod.rs
+++ b/rust/src/providers/crof/mod.rs
@@ -151,9 +151,8 @@ fn super_key(
     {
         return Ok(key.trim().to_string());
     }
-    if let Ok(entry) = keyring::Entry::new(credential_target, "api_key")
-        && let Ok(key) = entry.get_password()
-        && !key.trim().is_empty()
+    if let Some(key) =
+        crate::keychain::get_secret(crate::keychain::Scope::Any, credential_target, "api_key")
     {
         return Ok(key);
     }

--- a/rust/src/providers/deepgram/mod.rs
+++ b/rust/src/providers/deepgram/mod.rs
@@ -347,9 +347,8 @@ fn resolve_api_key(
     {
         return Ok(key.trim().to_string());
     }
-    if let Ok(entry) = keyring::Entry::new(credential_target, "api_key")
-        && let Ok(key) = entry.get_password()
-        && !key.trim().is_empty()
+    if let Some(key) =
+        crate::keychain::get_secret(crate::keychain::Scope::Any, credential_target, "api_key")
     {
         return Ok(key);
     }

--- a/rust/src/providers/deepseek/mod.rs
+++ b/rust/src/providers/deepseek/mod.rs
@@ -149,10 +149,11 @@ impl DeepSeekProvider {
             return Ok(key.trim().to_string());
         }
 
-        if let Ok(entry) = keyring::Entry::new(DEEPSEEK_CREDENTIAL_TARGET, "api_key")
-            && let Ok(token) = entry.get_password()
-            && !token.trim().is_empty()
-        {
+        if let Some(token) = crate::keychain::get_secret(
+            crate::keychain::Scope::Any,
+            DEEPSEEK_CREDENTIAL_TARGET,
+            "api_key",
+        ) {
             return Ok(token);
         }
 

--- a/rust/src/providers/doubao/mod.rs
+++ b/rust/src/providers/doubao/mod.rs
@@ -665,9 +665,8 @@ fn resolve_api_key(
     {
         return Ok(key.trim().to_string());
     }
-    if let Ok(entry) = keyring::Entry::new(credential_target, "api_key")
-        && let Ok(key) = entry.get_password()
-        && !key.trim().is_empty()
+    if let Some(key) =
+        crate::keychain::get_secret(crate::keychain::Scope::Any, credential_target, "api_key")
     {
         return Ok(key);
     }

--- a/rust/src/providers/elevenlabs/mod.rs
+++ b/rust/src/providers/elevenlabs/mod.rs
@@ -214,9 +214,8 @@ fn resolve_api_key(
     {
         return Ok(key.trim().to_string());
     }
-    if let Ok(entry) = keyring::Entry::new(credential_target, "api_key")
-        && let Ok(key) = entry.get_password()
-        && !key.trim().is_empty()
+    if let Some(key) =
+        crate::keychain::get_secret(crate::keychain::Scope::Any, credential_target, "api_key")
     {
         return Ok(key);
     }

--- a/rust/src/providers/groq/mod.rs
+++ b/rust/src/providers/groq/mod.rs
@@ -265,9 +265,8 @@ fn resolve_api_key(
     {
         return Ok(key.trim().to_string());
     }
-    if let Ok(entry) = keyring::Entry::new(credential_target, "api_key")
-        && let Ok(key) = entry.get_password()
-        && !key.trim().is_empty()
+    if let Some(key) =
+        crate::keychain::get_secret(crate::keychain::Scope::Any, credential_target, "api_key")
     {
         return Ok(key);
     }

--- a/rust/src/providers/kilo/mod.rs
+++ b/rust/src/providers/kilo/mod.rs
@@ -200,11 +200,11 @@ fn direct_kilo_api_key(api_key: Option<&str>) -> Option<String> {
 }
 
 fn keyring_kilo_api_key() -> Option<String> {
-    keyring::Entry::new(KILO_CREDENTIAL_TARGET, "api_key")
-        .ok()?
-        .get_password()
-        .ok()
-        .filter(|token| !token.is_empty())
+    crate::keychain::get_secret(
+        crate::keychain::Scope::Any,
+        KILO_CREDENTIAL_TARGET,
+        "api_key",
+    )
 }
 
 fn env_kilo_api_key() -> Option<String> {

--- a/rust/src/providers/llmproxy/mod.rs
+++ b/rust/src/providers/llmproxy/mod.rs
@@ -397,9 +397,8 @@ fn resolve_api_key(
     {
         return Ok(key.trim().to_string());
     }
-    if let Ok(entry) = keyring::Entry::new(credential_target, "api_key")
-        && let Ok(key) = entry.get_password()
-        && !key.trim().is_empty()
+    if let Some(key) =
+        crate::keychain::get_secret(crate::keychain::Scope::Any, credential_target, "api_key")
     {
         return Ok(key);
     }

--- a/rust/src/providers/mod.rs
+++ b/rust/src/providers/mod.rs
@@ -139,9 +139,8 @@ pub(crate) fn resolve_api_key(
     {
         return Ok(key.trim().to_string());
     }
-    if let Ok(entry) = keyring::Entry::new(credential_target, "api_key")
-        && let Ok(key) = entry.get_password()
-        && !key.trim().is_empty()
+    if let Some(key) =
+        crate::keychain::get_secret(crate::keychain::Scope::Any, credential_target, "api_key")
     {
         return Ok(key);
     }
@@ -246,5 +245,32 @@ mod browser_cookie_policy_tests {
     fn clear_persisted_credentials_is_noop_for_providers_without_a_shadow_store() {
         assert!(clear_persisted_credentials(crate::core::ProviderId::Claude).is_ok());
         assert!(clear_persisted_credentials(crate::core::ProviderId::Codex).is_ok());
+    }
+
+    /// SBS-1023: a keyring-resident API key must not authenticate when the
+    /// user disabled keychain access. Without the gate this returns the mock
+    /// secret.
+    #[test]
+    fn resolve_api_key_skips_keyring_when_disabled() {
+        let _guard = crate::keychain::with_mock_store(
+            false,
+            &[("ceiling-sbs-1023", "api_key", "from-keyring")],
+        );
+        let error = resolve_api_key(None, "ceiling-sbs-1023", &[]).expect_err("skip");
+        assert!(matches!(error, crate::core::ProviderError::NotInstalled(_)));
+    }
+
+    /// SBS-1023: the same mock secret is used when access is allowed, so the
+    /// skip test above is not a missing-entry false pass.
+    #[test]
+    fn resolve_api_key_uses_keyring_when_enabled() {
+        let _guard = crate::keychain::with_mock_store(
+            true,
+            &[("ceiling-sbs-1023", "api_key", "from-keyring")],
+        );
+        assert_eq!(
+            resolve_api_key(None, "ceiling-sbs-1023", &[]).expect("keyring"),
+            "from-keyring"
+        );
     }
 }

--- a/rust/src/providers/nanogpt/mod.rs
+++ b/rust/src/providers/nanogpt/mod.rs
@@ -86,21 +86,18 @@ impl NanoGPTProvider {
             return Ok(key.to_string());
         }
 
-        match keyring::Entry::new(NANOGPT_CREDENTIAL_TARGET, "api_token") {
-            Ok(entry) => match entry.get_password() {
-                Ok(token) => Ok(token),
-                Err(_) => std::env::var("NANOGPT_API_KEY").map_err(|_| {
-                    ProviderError::NotInstalled(
-                        "NanoGPT API key not found. Set in Preferences → Providers or NANOGPT_API_KEY environment variable.".to_string(),
-                    )
-                }),
-            },
-            Err(_) => std::env::var("NANOGPT_API_KEY").map_err(|_| {
-                ProviderError::NotInstalled(
-                    "NanoGPT API key not found. Set in Preferences → Providers or NANOGPT_API_KEY environment variable.".to_string(),
-                )
-            }),
+        if let Some(token) = crate::keychain::get_secret(
+            crate::keychain::Scope::Any,
+            NANOGPT_CREDENTIAL_TARGET,
+            "api_token",
+        ) {
+            return Ok(token);
         }
+        std::env::var("NANOGPT_API_KEY").map_err(|_| {
+            ProviderError::NotInstalled(
+                "NanoGPT API key not found. Set in Preferences → Providers or NANOGPT_API_KEY environment variable.".to_string(),
+            )
+        })
     }
 
     /// Convert millisecond epoch to DateTime<Utc>

--- a/rust/src/providers/openaiapi/mod.rs
+++ b/rust/src/providers/openaiapi/mod.rs
@@ -508,9 +508,8 @@ fn resolve_api_key(
     {
         return Ok(key.trim().to_string());
     }
-    if let Ok(entry) = keyring::Entry::new(credential_target, "api_key")
-        && let Ok(key) = entry.get_password()
-        && !key.trim().is_empty()
+    if let Some(key) =
+        crate::keychain::get_secret(crate::keychain::Scope::Any, credential_target, "api_key")
     {
         return Ok(key);
     }

--- a/rust/src/providers/openrouter/mod.rs
+++ b/rust/src/providers/openrouter/mod.rs
@@ -103,21 +103,18 @@ impl OpenRouterProvider {
             return Ok(key.to_string());
         }
 
-        match keyring::Entry::new(OPENROUTER_CREDENTIAL_TARGET, "api_token") {
-            Ok(entry) => match entry.get_password() {
-                Ok(token) => Ok(token),
-                Err(_) => std::env::var("OPENROUTER_API_KEY").map_err(|_| {
-                    ProviderError::NotInstalled(
-                        "OpenRouter API key not found. Set in Preferences → Providers or OPENROUTER_API_KEY environment variable.".to_string(),
-                    )
-                }),
-            },
-            Err(_) => std::env::var("OPENROUTER_API_KEY").map_err(|_| {
-                ProviderError::NotInstalled(
-                    "OpenRouter API key not found. Set in Preferences → Providers or OPENROUTER_API_KEY environment variable.".to_string(),
-                )
-            }),
+        if let Some(token) = crate::keychain::get_secret(
+            crate::keychain::Scope::Any,
+            OPENROUTER_CREDENTIAL_TARGET,
+            "api_token",
+        ) {
+            return Ok(token);
         }
+        std::env::var("OPENROUTER_API_KEY").map_err(|_| {
+            ProviderError::NotInstalled(
+                "OpenRouter API key not found. Set in Preferences → Providers or OPENROUTER_API_KEY environment variable.".to_string(),
+            )
+        })
     }
 
     /// Fetch usage from OpenRouter API

--- a/rust/src/providers/stepfun/mod.rs
+++ b/rust/src/providers/stepfun/mod.rs
@@ -501,8 +501,7 @@ impl TokenSecretStore for OsTokenSecretStore {
     fn get(&self, service: &str, user: &str) -> Result<Option<String>, String> {
         match crate::keychain::get_password(crate::keychain::Scope::Any, service, user) {
             Ok(value) if !value.trim().is_empty() => Ok(Some(value)),
-            Ok(_) => Ok(None),
-            Err(crate::keychain::Error::Disabled | crate::keychain::Error::NotFound) => Ok(None),
+            Ok(_) | Err(crate::keychain::Error::NotFound) => Ok(None),
             Err(error) => Err(error.to_string()),
         }
     }
@@ -514,9 +513,7 @@ impl TokenSecretStore for OsTokenSecretStore {
 
     fn delete(&self, service: &str, user: &str) -> Result<(), String> {
         match crate::keychain::delete_credential(crate::keychain::Scope::Any, service, user) {
-            Ok(()) | Err(crate::keychain::Error::Disabled | crate::keychain::Error::NotFound) => {
-                Ok(())
-            }
+            Ok(()) | Err(crate::keychain::Error::NotFound) => Ok(()),
             Err(error) => Err(error.to_string()),
         }
     }
@@ -787,6 +784,28 @@ mod tests {
         assert_eq!(
             resolve_token_in(&FailingDeleteStore, None, STEPFUN_CREDENTIAL_TARGET, &[]).unwrap(),
             "leftover-oasis-token"
+        );
+    }
+
+    #[test]
+    fn clear_persisted_credentials_fails_closed_when_keychain_is_disabled() {
+        let _guard = crate::keychain::with_mock_store(
+            false,
+            &[(STEPFUN_CREDENTIAL_TARGET, "api_key", "leftover")],
+        );
+        let error = clear_token_secret(&OsTokenSecretStore)
+            .expect_err("a disabled keychain must fail revoke");
+        let message = error.to_string();
+        assert!(
+            message.contains("Could not delete StepFun keyring token")
+                && message.contains("disabled"),
+            "got {error}"
+        );
+        assert!(
+            OsTokenSecretStore
+                .get(STEPFUN_CREDENTIAL_TARGET, "api_key")
+                .is_err(),
+            "Disabled must not look like a missing token"
         );
     }
 

--- a/rust/src/providers/stepfun/mod.rs
+++ b/rust/src/providers/stepfun/mod.rs
@@ -499,25 +499,24 @@ struct OsTokenSecretStore;
 
 impl TokenSecretStore for OsTokenSecretStore {
     fn get(&self, service: &str, user: &str) -> Result<Option<String>, String> {
-        let entry = keyring::Entry::new(service, user).map_err(|error| error.to_string())?;
-        match entry.get_password() {
+        match crate::keychain::get_password(crate::keychain::Scope::Any, service, user) {
             Ok(value) if !value.trim().is_empty() => Ok(Some(value)),
             Ok(_) => Ok(None),
-            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(crate::keychain::Error::Disabled | crate::keychain::Error::NotFound) => Ok(None),
             Err(error) => Err(error.to_string()),
         }
     }
 
     fn set(&self, service: &str, user: &str, value: &str) -> Result<(), String> {
-        let entry = keyring::Entry::new(service, user).map_err(|error| error.to_string())?;
-        entry.set_password(value).map_err(|error| error.to_string())
+        crate::keychain::set_password(crate::keychain::Scope::Any, service, user, value)
+            .map_err(|error| error.to_string())
     }
 
     fn delete(&self, service: &str, user: &str) -> Result<(), String> {
-        let entry = keyring::Entry::new(service, user).map_err(|error| error.to_string())?;
-        match entry.delete_credential() {
-            Ok(()) => Ok(()),
-            Err(keyring::Error::NoEntry) => Ok(()),
+        match crate::keychain::delete_credential(crate::keychain::Scope::Any, service, user) {
+            Ok(()) | Err(crate::keychain::Error::Disabled | crate::keychain::Error::NotFound) => {
+                Ok(())
+            }
             Err(error) => Err(error.to_string()),
         }
     }

--- a/rust/src/providers/venice/mod.rs
+++ b/rust/src/providers/venice/mod.rs
@@ -179,9 +179,8 @@ fn resolve_api_key(
     {
         return Ok(key.trim().to_string());
     }
-    if let Ok(entry) = keyring::Entry::new(credential_target, "api_key")
-        && let Ok(key) = entry.get_password()
-        && !key.trim().is_empty()
+    if let Some(key) =
+        crate::keychain::get_secret(crate::keychain::Scope::Any, credential_target, "api_key")
     {
         return Ok(key);
     }

--- a/rust/src/providers/warp/mod.rs
+++ b/rust/src/providers/warp/mod.rs
@@ -145,21 +145,18 @@ impl WarpProvider {
             return Ok(key.to_string());
         }
 
-        match keyring::Entry::new(WARP_CREDENTIAL_TARGET, "api_token") {
-            Ok(entry) => match entry.get_password() {
-                Ok(token) => Ok(token),
-                Err(_) => std::env::var("WARP_API_KEY").map_err(|_| {
-                    ProviderError::NotInstalled(
-                        "Warp API key not found. Set in Preferences → Providers or WARP_API_KEY environment variable.".to_string(),
-                    )
-                }),
-            },
-            Err(_) => std::env::var("WARP_API_KEY").map_err(|_| {
-                ProviderError::NotInstalled(
-                    "Warp API key not found. Set in Preferences → Providers or WARP_API_KEY environment variable.".to_string(),
-                )
-            }),
+        if let Some(token) = crate::keychain::get_secret(
+            crate::keychain::Scope::Any,
+            WARP_CREDENTIAL_TARGET,
+            "api_token",
+        ) {
+            return Ok(token);
         }
+        std::env::var("WARP_API_KEY").map_err(|_| {
+            ProviderError::NotInstalled(
+                "Warp API key not found. Set in Preferences → Providers or WARP_API_KEY environment variable.".to_string(),
+            )
+        })
     }
 
     /// Fetch usage from Warp GraphQL API

--- a/rust/src/providers/zai/mod.rs
+++ b/rust/src/providers/zai/mod.rs
@@ -117,14 +117,14 @@ impl ZaiProvider {
             return Ok(cleaned);
         }
 
-        // Try Windows Credential Manager
-        match keyring::Entry::new(ZAI_CREDENTIAL_TARGET, "api_token") {
-            Ok(entry) => match entry.get_password() {
-                Ok(token) => Ok(token),
-                Err(_) => Self::api_token_from_env(),
-            },
-            Err(_) => Self::api_token_from_env(),
+        if let Some(token) = crate::keychain::get_secret(
+            crate::keychain::Scope::Any,
+            ZAI_CREDENTIAL_TARGET,
+            "api_token",
+        ) {
+            return Ok(token);
         }
+        Self::api_token_from_env()
     }
 
     fn api_token_from_env() -> Result<String, ProviderError> {

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -279,7 +279,7 @@ pub struct Settings {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub unrecognized_provider_configs: HashMap<String, ProviderConfig>,
 
-    /// Disable credential/keychain-style reads where supported
+    /// Disable OS keychain reads and writes (SBS-1023).
     #[serde(default)]
     pub disable_keychain_access: bool,
 
@@ -1393,6 +1393,16 @@ impl Settings {
 
     pub fn set_historical_tracking(&mut self, id: ProviderId, value: bool) {
         self.provider_config_mut(id).historical_tracking = value;
+    }
+
+    /// SBS-1023: master switch. When false, no keyring read or write runs.
+    pub fn keychain_access_allowed(&self) -> bool {
+        !self.disable_keychain_access
+    }
+
+    /// SBS-1023: Claude keyring reads and token writes.
+    pub fn claude_keychain_access_allowed(&self) -> bool {
+        self.keychain_access_allowed() && !self.claude_avoid_keychain_prompts()
     }
 
     /// Per-provider "avoid keychain prompts" toggle (currently claude-only).

--- a/rust/src/settings/tests.rs
+++ b/rust/src/settings/tests.rs
@@ -1060,6 +1060,23 @@ fn test_per_provider_defaults_applied() {
     assert!(!settings.avoid_keychain_prompts(ProviderId::Claude));
 }
 
+/// SBS-1023: the stored flags must actually decide whether keyring I/O runs.
+#[test]
+fn keychain_access_flags_gate_reads_and_claude_writes() {
+    let mut settings = Settings::default();
+    assert!(settings.keychain_access_allowed());
+    assert!(settings.claude_keychain_access_allowed());
+
+    settings.set_claude_avoid_keychain_prompts(true);
+    assert!(settings.keychain_access_allowed());
+    assert!(!settings.claude_keychain_access_allowed());
+
+    settings.disable_keychain_access = true;
+    settings.set_claude_avoid_keychain_prompts(false);
+    assert!(!settings.keychain_access_allowed());
+    assert!(!settings.claude_keychain_access_allowed());
+}
+
 #[test]
 fn codex_spark_usage_visibility_defaults_to_visible_and_roundtrips() {
     let mut settings = Settings::default();

--- a/rust/src/settings/types.rs
+++ b/rust/src/settings/types.rs
@@ -305,7 +305,7 @@ pub struct ProviderConfig {
     /// Codex-only: enable historical usage tracking in UI.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub historical_tracking: bool,
-    /// Claude-only: avoid keychain prompts when reading credentials.
+    /// Claude-only: skip OS keychain reads and token writes (SBS-1023).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub avoid_keychain_prompts: bool,
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Settings flags `disable_keychain_access` and Claude's `avoid_keychain_prompts` were persisted and shown in the UI, but live credential paths still called `keyring::Entry` directly. Users who opted out still hit the OS keychain.

This routes every live keyring read/write through `rust/src/keychain.rs` (SBS-1023):

- `disable_keychain_access` skips all keyring reads and writes (UI + CLI).
- `avoid_keychain_prompts` additionally skips Claude keyring reads and refreshed-token writes.
- Disabled paths fail closed: skip the keyring and fall through to Preferences / env / files, or return a clear "not stored" error for Claude token writes.

Tests fail without the gate: a mock keyring secret is ignored when the flags are on, and used when they are off.

## Related issue

Cites SBS-1023.

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [x] Config file / settings persistence
- [x] CLI
- [x] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [x] Documentation
- [x] Other: OS keychain / credential resolution

## Validation

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` (Windows script; not run on this Linux agent)
- [x] Other:
  - `cargo test --manifest-path rust/Cargo.toml` — 1123 lib + 32 bin tests passed
  - `cargo fmt --all --manifest-path rust/Cargo.toml`
  - `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` — clean for this change. Two pre-existing crate warnings (`secure_file.rs` unused `error`, `updater.rs` unused `verify_installer_signature_or_delete`) were allowed so the new gate could be checked.

## UI / tray proof

- [x] Not applicable

No UI chrome changed. The existing Advanced / Claude toggles now actually gate backend keyring I/O.

## Notes for reviewers

Call-site audit (`keyring::` / `get_password` / `set_password`):

**Gated (live UI + CLI):**
- Shared `resolve_api_key` and the per-provider copies (ElevenLabs, Venice, Doubao, OpenAI API, Groq, Deepgram, LLM Proxy, Crof, DeepSeek)
- Kilo, Codebuff, OpenRouter, Warp, NanoGPT, z.ai
- Claude OAuth load + refreshed-token persist (including the macOS `/usr/bin/security` fallback, which sits behind the same Claude allow-check)
- StepFun Oasis token get/set/delete

**Gaps (not production-wired; left alone):**
- `rust/src/core/credentials.rs` — `WindowsCredentialStore` is not compiled (`core/mod.rs` does not include it)
- `rust/src/core/credential_migration.rs` — compiled and exported, but `migrate_if_needed` / `migrate_provider_credential` have no UI or CLI callers. Wiring it through the new module would create a `core` → `settings` cycle.

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26e5bcd1-0d49-4307-a9dc-1fc551bd9fd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26e5bcd1-0d49-4307-a9dc-1fc551bd9fd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate all OS keychain I/O behind `disable_keychain_access` and Claude `avoid_keychain_prompts` flags
> - Adds a new `keychain` module that wraps every `keyring::Entry` call behind a settings gate, using `Scope::Any` for global access and `Scope::Claude` for Claude-specific access
> - Adds `Settings::keychain_access_allowed` and `Settings::claude_keychain_access_allowed` methods that serve as the master switch and Claude-specific switch respectively
> - Migrates all provider API-key lookups (Codebuff, Deepgram, DeepSeek, Doubao, Groq, Kilo, LLM Proxy, NanoGPT, OpenAI, OpenRouter, StepFun, Venice, Warp, z.ai, and shared `resolve_api_key`) from direct `keyring` calls to `keychain::get_secret`/`get_password`/`set_password`
> - Claude OAuth credential load/persist in `credentials_store.rs` now skips keyring reads and errors on writes when disabled, falling back to env/file sources instead
> - Behavioral Change: when `disable_keychain_access` is true, all providers return `None`/skip keyring instead of prompting the OS; StepFun's `OsTokenSecretStore` now returns `Err` on `Disabled` rather than treating it as `NotFound`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba63b6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->