### PR TITLE
Fix clipboard copy controls that report success after failure

### DIFF
--- a/apps/desktop-tauri/src/components/CopyIconButton.test.tsx
+++ b/apps/desktop-tauri/src/components/CopyIconButton.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const tauriMocks = vi.hoisted(() => ({
@@ -103,6 +103,56 @@ describe("CopyIconButton", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
     }, { timeout: 1500 });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the latest copy result when writes settle out of order", async () => {
+    function deferred<T>() {
+      let resolve!: (value: T) => void;
+      let reject!: (reason?: unknown) => void;
+      const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+      });
+      return { promise, resolve, reject };
+    }
+
+    const first = deferred<void>();
+    const second = deferred<void>();
+    const writeTextSpy = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: writeTextSpy,
+      },
+    });
+
+    render(
+      <LocaleProvider>
+        <CopyIconButton text="test-race" />
+      </LocaleProvider>,
+    );
+
+    const btn = await screen.findByRole("button", { name: "Copy" });
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+
+    expect(writeTextSpy).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      second.resolve();
+    });
+    const successBtn = await screen.findByRole("button", { name: "Copied" });
+    expect(successBtn).toHaveTextContent("✓");
+
+    await act(async () => {
+      first.reject(new Error("Clipboard access denied"));
+    });
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy error" })).toBeNull();
 
     vi.unstubAllGlobals();
   });

--- a/apps/desktop-tauri/src/components/CopyIconButton.test.tsx
+++ b/apps/desktop-tauri/src/components/CopyIconButton.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const tauriMocks = vi.hoisted(() => ({
+  getLocaleStrings: vi.fn(),
+}));
+
+const eventMocks = vi.hoisted(() => ({
+  listen: vi.fn(),
+}));
+
+vi.mock("../lib/tauri", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/tauri")>()),
+  ...tauriMocks,
+}));
+vi.mock("@tauri-apps/api/event", () => eventMocks);
+
+import { LocaleProvider } from "../i18n/LocaleProvider";
+import { buildBundle } from "../test/localeHarness";
+import { CopyIconButton } from "./MenuCard";
+
+describe("CopyIconButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tauriMocks.getLocaleStrings.mockResolvedValue(
+      buildBundle({
+        PanelCopied: "Copied",
+        ActionCopyError: "Copy error",
+        ProviderIssueCopy: "Copy",
+      }),
+    );
+    eventMocks.listen.mockResolvedValue(() => {});
+  });
+
+  it("exposes the neutral copy label in the idle state", async () => {
+    render(
+      <LocaleProvider>
+        <CopyIconButton text="hello" />
+      </LocaleProvider>,
+    );
+
+    const btn = await screen.findByRole("button", { name: "Copy" });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute("title", "Copy");
+  });
+
+  it("handles resolved clipboard promise and displays success state", async () => {
+    const writeTextSpy = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: writeTextSpy,
+      },
+    });
+
+    render(
+      <LocaleProvider>
+        <CopyIconButton text="test-copy" />
+      </LocaleProvider>,
+    );
+
+    const btn = await screen.findByRole("button", { name: "Copy" });
+    fireEvent.click(btn);
+
+    expect(writeTextSpy).toHaveBeenCalledWith("test-copy");
+
+    // Success state should show "Copied"
+    const successBtn = await screen.findByRole("button", { name: "Copied" });
+    expect(successBtn).toBeInTheDocument();
+    expect(successBtn).toHaveTextContent("✓");
+
+    // Wait for the timeout to revert back to idle
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+    }, { timeout: 1500 });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("handles rejected clipboard promise and displays failure state", async () => {
+    const writeTextSpy = vi.fn().mockRejectedValue(new Error("Clipboard access denied"));
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: writeTextSpy,
+      },
+    });
+
+    render(
+      <LocaleProvider>
+        <CopyIconButton text="test-fail" />
+      </LocaleProvider>,
+    );
+
+    const btn = await screen.findByRole("button", { name: "Copy" });
+    fireEvent.click(btn);
+
+    expect(writeTextSpy).toHaveBeenCalledWith("test-fail");
+
+    // Failure state should show "Copy error"
+    const failureBtn = await screen.findByRole("button", { name: "Copy error" });
+    expect(failureBtn).toBeInTheDocument();
+
+    // Wait for the timeout to revert back to idle
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+    }, { timeout: 1500 });
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/desktop-tauri/src/components/MenuCard.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.tsx
@@ -33,18 +33,25 @@ export function CopyIconButton({ text }: { text: string }) {
   const { t } = useLocale();
   const [state, setState] = useState<"idle" | "success" | "failure">("idle");
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const copyRequestRef = useRef(0);
 
   const handleCopy = useCallback(async () => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
     }
+    const requestId = ++copyRequestRef.current;
+    let next: "success" | "failure";
     try {
       await navigator.clipboard.writeText(text);
-      setState("success");
+      next = "success";
     } catch {
-      setState("failure");
+      next = "failure";
     }
+    if (requestId !== copyRequestRef.current) return;
+    setState(next);
     timeoutRef.current = setTimeout(() => {
+      if (requestId !== copyRequestRef.current) return;
       setState("idle");
     }, 900);
   }, [text]);

--- a/apps/desktop-tauri/src/components/MenuCard.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   PaceSnapshot,
   ProviderChartData,
@@ -31,21 +31,47 @@ import { maskEmail } from "../lib/privacy";
 /** Small copy-to-clipboard button matching macOS CopyIconButton (doc.on.doc → checkmark). */
 export function CopyIconButton({ text }: { text: string }) {
   const { t } = useLocale();
-  const [copied, setCopied] = useState(false);
-  const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(text).catch(() => {});
-    setCopied(true);
-    setTimeout(() => setCopied(false), 900);
+  const [state, setState] = useState<"idle" | "success" | "failure">("idle");
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleCopy = useCallback(async () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    try {
+      await navigator.clipboard.writeText(text);
+      setState("success");
+    } catch {
+      setState("failure");
+    }
+    timeoutRef.current = setTimeout(() => {
+      setState("idle");
+    }, 900);
   }, [text]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const label = state === "success"
+    ? t("PanelCopied")
+    : state === "failure"
+      ? t("ActionCopyError")
+      : t("ProviderIssueCopy");
+
   return (
     <button
       type="button"
       className="menu-card__copy-btn"
       onClick={handleCopy}
-      aria-label={copied ? t("PanelCopied") : t("ActionCopyError")}
-      title={copied ? t("PanelCopied") : t("ActionCopyError")}
+      aria-label={label}
+      title={label}
     >
-      {copied ? "✓" : (
+      {state === "success" ? "✓" : (
         <svg width="12" height="12" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect x="5" y="5" width="9" height="9" rx="1.5" stroke="currentColor" strokeWidth="1.5"/>
           <path d="M11 3V2.5A1.5 1.5 0 009.5 1H2.5A1.5 1.5 0 001 2.5v7A1.5 1.5 0 002.5 11H3" stroke="currentColor" strokeWidth="1.5"/>

--- a/apps/desktop-tauri/src/components/MenuCard.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.tsx
@@ -32,7 +32,7 @@ import { maskEmail } from "../lib/privacy";
 export function CopyIconButton({ text }: { text: string }) {
   const { t } = useLocale();
   const [state, setState] = useState<"idle" | "success" | "failure">("idle");
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copyRequestRef = useRef(0);
 
   const handleCopy = useCallback(async () => {


### PR DESCRIPTION
Fixes #266

Modified CopyIconButton to await clipboard writes, expose the failure state when the promise rejects, and use the neutral Copy label in the idle state.

**Testing:** Added unit tests verifying idle, success, and failure states of CopyIconButton, which all pass successfully in the test suite.

---

## Summary

Describe what changed and why.

## Related issue

Fixes #

## Affected areas

Check every area this PR changes or could affect:

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

Hosted CI runs the main frontend and Rust checks. Run the relevant local checks
before pushing and list the exact commands/results. If a check is not relevant,
say why.

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1`
- [ ] For full pre-release validation: `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -All -Version <version>`
- [ ] For installer/release changes: `powershell.exe -File scripts\windows-release-build.ps1 -Ref <ref> -SmokeInstall`
- [ ] Other:

## UI / tray proof

For UI, tray, settings, or visual behavior changes, attach a screenshot, short
recording, or equivalent manual proof.

- [ ] Not applicable
- [ ] Visual proof attached
- [ ] Visual proof was not practical; manual validation and explanation attached

## Notes for reviewers

Call out risky areas, follow-up work, or anything reviewers should focus on.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix clipboard copy controls that report success after failure
> - Reworks the copy logic in `CopyIconButton` from a boolean `copied` flag to a tri-state state machine: `idle` | `success` | `failure`, awaiting `navigator.clipboard.writeText` and setting state based on the promise outcome.
> - Adds a monotonically increasing copy request id and refs for an expiration timeout so the latest write result wins when promises settle out of order; state reverts to `idle` after 900ms, with cleanup on unmount and new clicks.
> - Updates aria-label/title to derive from state (`PanelCopied`, `ActionCopyError`, `ProviderIssueCopy`) and renders a checkmark only on success.
> - Adds a Vitest suite in [CopyIconButton.test.tsx](https://github.com/tsouth89/ceiling/pull/381/files#diff-e66f890e45f4b4f9492d26538ef82c518e9302fca30984a00564b5b782520df5) covering idle, success, failure, and race scenarios.
> - Behavioral Change: `MenuCard.tsx` copy button previously always showed 'Copied' on click; it now shows 'Copy error' on write failures and only reports success after the clipboard promise resolves.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d73f6bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Copy actions now provide clear localized feedback for successful and failed clipboard operations.
  - The button temporarily displays “Copied” after a successful copy and “Copy error” when copying fails.

- **Bug Fixes**
  - Improved handling of repeated copy actions to prevent stale status messages.
  - Copy status reliably returns to its idle state after feedback is shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->