### PR TITLE
Document dead menu_bar_* tray settings (SBS-1052)

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
@@ -406,15 +406,13 @@ fn presentation_snapshots(
 
 /// Update the tray icon pixels and tooltip text to reflect current provider usage.
 ///
-/// Behaviour mirrors egui's `choose_tray_update_plan` (rust/src/native_ui/app.rs):
-/// - If `menu_bar_shows_highest_usage` is on OR `menu_bar_display_mode == "minimal"`,
-///   render the bar from the healthy provider with the highest session usage.
-/// - Otherwise render from the first enabled healthy provider (catalog order).
-/// - When any provider exposes a weekly/secondary window, the icon shows both
-///   bars from the same picked provider.
-/// - With zero healthy providers but at least one error, fall back to an
-///   error-styled icon using the last known max percentage so the tray
-///   still communicates "something is wrong".
+/// One branded tray icon represents Ceiling as a whole. Its severity color
+/// follows the most constrained healthy provider. Legacy icon-selection
+/// settings (`menu_bar_shows_highest_usage`, `menu_bar_shows_percent`,
+/// `menu_bar_display_mode`) are intentionally ignored.
+///
+/// With zero healthy providers but at least one error, fall back to an
+/// error-styled icon so the tray still communicates "something is wrong".
 pub fn update_tray_icon_and_tooltip(
     app: &AppHandle,
     snapshots: &[crate::commands::ProviderUsageSnapshot],

--- a/docs/SETTINGS_JSON.md
+++ b/docs/SETTINGS_JSON.md
@@ -32,14 +32,14 @@ fields marked safe, but Ceiling may overwrite the file when the app exits.
 | `notification_policy_version` | number | `1` | Internal migration marker. Not a UI preference. |
 | `provider_usage_thresholds` | object | `{}` | Per-provider overrides; keys are CLI names, optionally suffixed with `:session` or `:weekly`; values are `{ "high": number, "critical": number }`. Safe to edit. |
 | `switcher_shows_icons` | boolean | `true` | Show provider icons in merged switcher UI. Safe to edit. |
-| `menu_bar_shows_highest_usage` | boolean | `false` | Prefer the provider closest to its limit in merged display. Safe to edit. |
-| `menu_bar_shows_percent` | boolean | `false` | Replace bar-only tray display with provider branding plus percent where supported. Safe to edit. |
+| `menu_bar_shows_highest_usage` | boolean | `false` | Legacy compatibility field. The branded tray always follows the most constrained healthy provider and ignores this flag. Leave it unchanged. |
+| `menu_bar_shows_percent` | boolean | `false` | Legacy compatibility field. The branded tray always draws the Ceiling icon and ignores this flag. Leave it unchanged. |
 | `show_as_used` | boolean | `true` | Show usage as used (`true`) or remaining (`false`). Safe to edit. |
 | `enable_animations` | boolean | `true` | Enable UI animations. Safe to edit. |
 | `reset_time_relative` | boolean | `true` | Show reset times as relative values. Safe to edit. |
 | `show_reset_when_exhausted` | boolean | `false` | Replace exhausted quota text with the concrete reset time. Safe to edit. |
 | `predictive_pace_warning_enabled` | boolean | `false` | Warn when provider pace predicts exhaustion before reset. Opt-in prediction. Safe to edit. |
-| `menu_bar_display_mode` | string | `"detailed"` | `"minimal"`, `"compact"`, or `"detailed"`. Safe to edit. |
+| `menu_bar_display_mode` | string | `"detailed"` | Legacy compatibility field (`"minimal"`, `"compact"`, or `"detailed"`). The branded tray ignores this setting. Leave it unchanged. |
 | `show_all_token_accounts_in_menu` | boolean | `false` | Show all token accounts instead of collapsing behind switchers. Safe to edit. |
 | `provider_configs` | object | `{}` | Per-provider configuration map. See below. Safe to edit. |
 | `unrecognized_provider_configs` | object | `{}` | Written by Ceiling, not by you. Holds `provider_configs` entries whose provider id this build does not recognize, so they survive until a build that knows them folds them back in. Leave it unchanged. |

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -229,11 +229,13 @@ pub struct Settings {
     #[serde(default = "default_true")]
     pub switcher_shows_icons: bool,
 
-    /// Prefer the provider closest to its limit in merged menu bar display
+    /// Legacy compatibility field. The branded tray always follows the most
+    /// constrained healthy provider and ignores this flag.
     #[serde(default)]
     pub menu_bar_shows_highest_usage: bool,
 
-    /// Replace bar-only tray display with provider branding plus percent text where supported
+    /// Legacy compatibility field. The branded tray always draws the Ceiling
+    /// icon and ignores this flag.
     #[serde(default)]
     pub menu_bar_shows_percent: bool,
 
@@ -255,7 +257,8 @@ pub struct Settings {
     #[serde(default)]
     pub predictive_pace_warning_enabled: bool,
 
-    /// Menu bar display mode: "minimal", "compact", or "detailed"
+    /// Legacy compatibility field (`"minimal"`, `"compact"`, or `"detailed"`).
+    /// The branded tray ignores this setting.
     pub menu_bar_display_mode: String,
 
     /// Show all token accounts in provider menus instead of collapsing behind switchers


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`SETTINGS_JSON.md` still described `menu_bar_shows_highest_usage`, `menu_bar_shows_percent`, and `menu_bar_display_mode` as **Safe to edit**. Those flags are an SBS-182 leftover: the branded tray hardcodes `prefer_highest = true` and discards the settings when rendering the Ceiling icon (`tray_bridge.rs`).

This documents the three fields as ignored legacy compatibility keys (same pattern as `float_bar_show_cost`) and updates the matching rustdocs so they no longer claim the flags are effective. No Settings UI was added; none exists for these keys.

## Related issue

Cites SBS-1052.

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [x] Documentation
- [x] Other: rustdoc on persisted Settings fields + tray-bridge comment

## Validation

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` (Windows script; not run on this Linux agent)
- [x] Other:
  - Docs/comment-only change. Confirmed the three flags are persisted and bridged but never read for tray or Settings UI behavior (`rg` across `rust/` and `apps/desktop-tauri/src`).
  - No cargo/frontend tests added: no runtime behavior changed.

## UI / tray proof

- [x] Not applicable

No UI or tray pixels changed. The tray already ignores these flags; this only stops the docs from saying they work.

## Notes for reviewers

Fields stay in `settings.json` / `Settings` so existing files still load. This does not remove the dead keys or invent a tray-mode UI.

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-440f22bc-c864-49e7-99b8-30a71a92650b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-440f22bc-c864-49e7-99b8-30a71a92650b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document legacy `menu_bar_*` tray settings as ignored by branded tray
> Marks `menu_bar_shows_highest_usage`, `menu_bar_shows_percent`, and `menu_bar_display_mode` as legacy compatibility fields that the branded tray ignores. Updates doc comments in [tray_bridge.rs](https://github.com/tsouth89/ceiling/pull/382/files#diff-d7b16595a580357635dc552359ae10efea26a833220a5c769fd0aa2c87eac5f2) and [settings.rs](https://github.com/tsouth89/ceiling/pull/382/files#diff-e942ff1cc196680bb9d65bc031007c839badedb1435f2c5ac11ccea8b882055d) and the user-facing [SETTINGS_JSON.md](https://github.com/tsouth89/ceiling/pull/382/files#diff-5a7c7863dd70bcbb9f006d26bd2c08f369082fb9176a9bc30561469aeb5cc1b1) to clarify these fields are no longer used. No functional changes — field types, serde attributes, and defaults are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c08997.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the branded tray icon represents Ceiling globally.
  - Documented that the icon reflects the most constrained healthy provider and shows an error state when all providers fail.
  - Clarified that legacy menu bar display and usage settings are retained for compatibility but ignored by the branded tray.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->