### PR TITLE
Pin TEST_PROVIDER_CATALOG to live ProviderId (SBS-1048)

### DIFF
--- a/apps/desktop-tauri/src/components/providers/providerIcons.test.ts
+++ b/apps/desktop-tauri/src/components/providers/providerIcons.test.ts
@@ -22,7 +22,10 @@ const DARK_CARD = "#1c2026";
 const LIGHT_CARD = "#f5f7fa";
 
 describe("provider icon registry", () => {
-  it("has explicit icon metadata for every provider in the catalog", () => {
+  it("has explicit icon metadata for every live ProviderId (SBS-1048)", () => {
+    // Walks the Rust-generated catalog, not a hand-kept subset. A live
+    // ProviderId without PROVIDER_ICON_REGISTRY must fail Frontend CI.
+    expect(TEST_PROVIDER_CATALOG.map(([id]) => id)).toContain("wayfinder");
     for (const [id] of TEST_PROVIDER_CATALOG) {
       expect(PROVIDER_ICON_REGISTRY[id], id).toBeDefined();
     }

--- a/apps/desktop-tauri/src/test/providerCatalog.test.ts
+++ b/apps/desktop-tauri/src/test/providerCatalog.test.ts
@@ -27,4 +27,9 @@ describe("provider catalog contract (SBS-1048)", () => {
       /pub fn all\(/,
     );
   });
+
+  it("parses provider.rs when the checkout uses CRLF", () => {
+    const crlf = providerSource.replace(/\r\n/g, "\n").replace(/\n/g, "\r\n");
+    expect(liveProviderCatalogFrom(crlf)).toEqual(live);
+  });
 });

--- a/apps/desktop-tauri/src/test/providerCatalog.test.ts
+++ b/apps/desktop-tauri/src/test/providerCatalog.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import providerSource from "../../../../rust/src/core/provider.rs?raw";
+import {
+  TEST_PROVIDER_CATALOG,
+  liveProviderCatalogFrom,
+} from "./providerCatalog";
+
+describe("provider catalog contract (SBS-1048)", () => {
+  const live = liveProviderCatalogFrom(providerSource);
+
+  it("pins TEST_PROVIDER_CATALOG to ProviderId::all", () => {
+    expect(TEST_PROVIDER_CATALOG).toEqual(live);
+  });
+
+  it("includes wayfinder with the live display name", () => {
+    expect(live).toContainEqual(["wayfinder", "Wayfinder"]);
+  });
+
+  it("keeps catalog ids unique and non-empty", () => {
+    const ids = live.map(([id]) => id);
+    expect(ids.every(Boolean)).toBe(true);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("fails closed when ProviderId::all cannot be parsed", () => {
+    expect(() => liveProviderCatalogFrom("enum ProviderId {}")).toThrow(
+      /pub fn all\(/,
+    );
+  });
+});

--- a/apps/desktop-tauri/src/test/providerCatalog.ts
+++ b/apps/desktop-tauri/src/test/providerCatalog.ts
@@ -1,58 +1,64 @@
-export const TEST_PROVIDER_CATALOG: Array<[string, string]> = [
-  ["codex", "Codex"],
-  ["claude", "Claude"],
-  ["cursor", "Cursor"],
-  ["factory", "Factory"],
-  ["gemini", "Gemini"],
-  ["antigravity", "Antigravity"],
-  ["copilot", "Copilot"],
-  ["zai", "z.ai"],
-  ["minimax", "MiniMax"],
-  ["kiro", "Kiro"],
-  ["vertexai", "Vertex AI"],
-  ["augment", "Augment"],
-  ["opencode", "OpenCode"],
-  ["kimi", "Kimi"],
-  ["kimik2", "Kimi K2"],
-  ["amp", "Amp"],
-  ["warp", "Warp"],
-  ["ollama", "Ollama"],
-  ["azureopenai", "Azure OpenAI"],
-  ["t3chat", "T3 Chat"],
-  ["openrouter", "OpenRouter"],
-  ["jetbrains", "JetBrains AI"],
-  ["alibaba", "Alibaba"],
-  ["alibabatokenplan", "Alibaba Token Plan"],
-  ["nanogpt", "NanoGPT"],
-  ["infini", "Infini"],
-  ["perplexity", "Perplexity"],
-  ["abacus", "Abacus AI"],
-  ["mistral", "Mistral"],
-  ["opencodego", "OpenCode Go"],
-  ["kilo", "Kilo"],
-  ["bedrock", "AWS Bedrock"],
-  ["codebuff", "Codebuff"],
-  ["deepseek", "DeepSeek"],
-  ["windsurf", "Windsurf"],
-  ["manus", "Manus"],
-  ["mimo", "Xiaomi MiMo"],
-  ["doubao", "Doubao"],
-  ["commandcode", "Command Code"],
-  ["crof", "Crof"],
-  ["stepfun", "StepFun"],
-  ["venice", "Venice"],
-  ["openaiapi", "OpenAI API"],
-  ["grok", "Grok"],
-  ["elevenlabs", "ElevenLabs"],
-  ["deepgram", "Deepgram"],
-  ["groq", "Groq"],
-  ["llmproxy", "LLM Proxy"],
-  ["chutes", "Chutes"],
-  ["litellm", "LiteLLM"],
-  ["poe", "Poe"],
-  ["devin", "Devin"],
-  ["zed", "Zed"],
-  ["crossmodel", "CrossModel"],
-  ["qoder", "Qoder"],
-  ["sakana", "Sakana AI"],
-];
+import providerSource from "../../../../rust/src/core/provider.rs?raw";
+
+/**
+ * Live `[cli_name, display_name]` pairs from `ProviderId::all()`, in the same
+ * order `provider_catalog_for` emits. Generated from the Rust source of truth
+ * so a new `ProviderId` cannot sit outside Frontend CI (SBS-1048, same class
+ * as SBS-872).
+ */
+export function liveProviderCatalogFrom(
+  src: string,
+): Array<[string, string]> {
+  const variants = providerIdAll(src);
+  const cliNames = providerIdStringMap(src, "cli_name");
+  const displayNames = providerIdStringMap(src, "display_name");
+  return variants.map((variant) => {
+    const id = cliNames.get(variant);
+    const displayName = displayNames.get(variant);
+    if (!id || !displayName) {
+      throw new Error(
+        `ProviderId::${variant} missing cli_name or display_name`,
+      );
+    }
+    return [id, displayName];
+  });
+}
+
+function rustMethod(src: string, name: string): string {
+  const header = `pub fn ${name}(`;
+  const start = src.indexOf(header);
+  if (start < 0) {
+    throw new Error(`${header} not found in provider.rs`);
+  }
+  const from = src.slice(start);
+  const end = from.indexOf("\n    }\n");
+  if (end < 0) {
+    throw new Error(`${name} method body not closed`);
+  }
+  return from.slice(0, end);
+}
+
+function providerIdAll(src: string): string[] {
+  const variants = [...rustMethod(src, "all").matchAll(/ProviderId::(\w+)/g)].map(
+    (match) => match[1],
+  );
+  if (variants.length === 0) {
+    throw new Error("ProviderId::all() listed no variants");
+  }
+  return variants;
+}
+
+function providerIdStringMap(src: string, name: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const match of rustMethod(src, name).matchAll(
+    /ProviderId::(\w+)\s*=>\s*"([^"]*)"/g,
+  )) {
+    map.set(match[1], match[2]);
+  }
+  if (map.size === 0) {
+    throw new Error(`ProviderId::${name} listed no string arms`);
+  }
+  return map;
+}
+
+export const TEST_PROVIDER_CATALOG = liveProviderCatalogFrom(providerSource);

--- a/apps/desktop-tauri/src/test/providerCatalog.ts
+++ b/apps/desktop-tauri/src/test/providerCatalog.ts
@@ -9,6 +9,7 @@ import providerSource from "../../../../rust/src/core/provider.rs?raw";
 export function liveProviderCatalogFrom(
   src: string,
 ): Array<[string, string]> {
+  src = src.replace(/\r\n/g, "\n");
   const variants = providerIdAll(src);
   const cliNames = providerIdStringMap(src, "cli_name");
   const displayNames = providerIdStringMap(src, "display_name");

--- a/apps/desktop-tauri/vite.config.ts
+++ b/apps/desktop-tauri/vite.config.ts
@@ -1,6 +1,10 @@
 /// <reference types="vitest" />
-import { defineConfig } from "vite";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig, searchForWorkspaceRoot } from "vite";
 import react from "@vitejs/plugin-react";
+
+const here = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
@@ -8,6 +12,16 @@ export default defineConfig({
     host: "127.0.0.1",
     port: 1420,
     strictPort: true,
+    fs: {
+      // Vite denies `?raw` imports outside the app root. SBS-1048 pins
+      // TEST_PROVIDER_CATALOG to rust/src/core/provider.rs; keep this
+      // allowlist limited to that crate path plus the usual roots.
+      allow: [
+        here,
+        searchForWorkspaceRoot(here),
+        resolve(here, "../../rust/src/core"),
+      ],
+    },
   },
   clearScreen: false,
   test: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`TEST_PROVIDER_CATALOG` was a hand-kept 56-id fixture, so it omitted live `ProviderId::Wayfinder` (57). `providerIcons.test.ts` only walked that fixture, which meant Frontend CI could not fail when a live provider lacked `PROVIDER_ICON_REGISTRY` — the same class of drift as SBS-872.

This generates the test catalog from `rust/src/core/provider.rs` (`ProviderId::all` + `cli_name` + `display_name`), the same source `provider_catalog_for` uses. The icon registry test now walks that live list, so a missing registry entry fails Frontend CI. Wayfinder is included.

## Related issue

Fixes SBS-1048

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [x] Other: Frontend test catalog / provider icon contract

## Validation

Hosted CI runs the main frontend and Rust checks. Run the relevant local checks
before pushing and list the exact commands/results. If a check is not relevant,
say why.

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1`
- [ ] For full pre-release validation: `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -All -Version <version>`
- [ ] For installer/release changes: `powershell.exe -File scripts\windows-release-build.ps1 -Ref <ref> -SmokeInstall`
- [x] Other:
  - `pnpm --dir apps/desktop-tauri test` — 91 files, 724 tests passed (pre-CRLF follow-up)
  - `pnpm --dir apps/desktop-tauri run build` — locale/css/native-controls + `tsc --noEmit` + vite build passed
  - Negative check: removing the `wayfinder` registry entry fails `providerIcons.test.ts` with `wayfinder: expected undefined to be defined`
  - Follow-up: normalize CRLF before parse so Windows `core.autocrlf` checkouts do not break catalog generation
  - Rust/clippy not re-run: no Rust source changes

## UI / tray proof

- [x] Not applicable

## Notes for reviewers

- `TEST_PROVIDER_CATALOG` order now follows `ProviderId::all()` (Grok sits after Cursor), not the enum declaration order.
- Vite `server.fs.allow` adds `rust/src/core` so tests can `?raw`-import `provider.rs`. The frontend package still avoids `node:fs` (no `@types/node`).
- Parser fails closed if `ProviderId::all` / `cli_name` / `display_name` cannot be read.
- Catalog parse now strips `\r\n` so the LF method closer works on Windows checkouts (Bugbot).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-382d15b5-d117-4ce1-b4c7-e73a323f6f56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-382d15b5-d117-4ce1-b4c7-e73a323f6f56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Generate `TEST_PROVIDER_CATALOG` from live `ProviderId` definitions
> - Replaces the hardcoded `TEST_PROVIDER_CATALOG` with a value derived at import time by parsing `ProviderId::all()`, `cli_name`, and `display_name` from [provider.rs](https://github.com/tsouth89/ceiling/pull/386/files#diff-657309e6b2214c59bc8874a66551b78513e6ee193084d22170b19304ba6b76e8)
> - Adds `liveProviderCatalogFrom` and helper parsers (`rustMethod`, `providerIdAll`, `providerIdStringMap`) that scan the Rust source and throw on missing mappings or unparseable method bodies
> - Adds a contract test suite in [providerCatalog.test.ts](https://github.com/tsouth89/ceiling/pull/386/files#diff-22e57dc3644951d40e66f636a56ff5c8bfbb523daeee1733cdab326948bbc742) asserting the catalog matches the live source, `wayfinder` is present, ids are unique/non-empty, parsing fails closed when `ProviderId::all` is missing, and CRLF is handled
> - Updates [vite.config.ts](https://github.com/tsouth89/ceiling/pull/386/files#diff-9478265535cbf937bb97148ad7157f58d809ad8c7037a3473324f05617f52c1a) `server.fs.allow` to include `../../rust/src/core` so `?raw` imports of the Rust file work in dev/test
> - Risk: tests now fail if `provider.rs` layout changes and the parsers cannot locate `all()`, `cli_name`, or `display_name` method bodies or their sentinel closes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d54c760.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify the provider catalog matches its live Rust source.
  * Confirmed the Wayfinder provider is included and provider identifiers remain valid and unique.
  * Added validation for malformed catalog definitions and different line-ending formats.

* **Chores**
  * Improved development configuration to reliably access application, workspace, and Rust source directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->