### PR TITLE
Rotate a leaked Windows serve.token instead of reusing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Ceiling] Unreleased
 
+### Security
+- **A leaked `serve.token` is rotated on Windows, not just Unix.** After SBS-953, a world-readable token was replaced on Unix, but Windows still tightened the DACL and reused the same secret. The ACL is now inspected before tightening; if anyone other than the current user, SYSTEM, or Administrators can read the file, the token is replaced. Closes SBS-1043.
+
 ### Fixed
 - **Remembered window positions no longer drop a sibling when two surfaces save at once.** `window_geometry.json` was updated with an unlocked read-modify-write, so moving Settings while the float bar or Pop Out also wrote could replace the file with a snapshot that had never seen the other key. Geometry persist now holds the same cross-process state lock as settings and credentials. Closes SBS-1024.
 - **`codexbar` with no subcommand now runs `usage`.** CLI.md and `--help` already called usage the default command, but a bare `codexbar` printed an error asking for an explicit subcommand. It now does what those docs said. Closes SBS-1026.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -135,7 +135,7 @@ Useful options:
 - `--allow-unauthenticated` - skip the per-user bearer token. Any local process can then read usage. Existing scripts that do not send `Authorization` need this flag.
 - `--include-identity` - include account email, organization, login method, and raw provider errors. Those fields are omitted by default.
 
-On first start, Ceiling prints an `Authorization: Bearer …` token and stores it at `<user config dir>/Ceiling/serve.token` (current-user ACL on Windows, mode `0600` elsewhere). Later starts print only the path. `/health` stays unauthenticated. `/usage` and `/cost` require the token unless `--allow-unauthenticated` is set.
+On first start, Ceiling prints an `Authorization: Bearer …` token and stores it at `<user config dir>/Ceiling/serve.token` (current-user ACL on Windows, mode `0600` elsewhere). Later starts print only the path. If an existing token file is readable by other users, Ceiling replaces it with a new token rather than tightening the ACL and reusing the leaked value. `/health` stays unauthenticated. `/usage` and `/cost` require the token unless `--allow-unauthenticated` is set.
 
 Example:
 

--- a/rust/src/cli/serve.rs
+++ b/rust/src/cli/serve.rs
@@ -561,17 +561,14 @@ fn load_or_create_serve_token_at(path: PathBuf) -> io::Result<ServeToken> {
 }
 
 fn read_existing_serve_token(path: PathBuf) -> io::Result<ServeToken> {
-    // Stat before chmod. A token that was world-readable is already leaked;
-    // tightening the mode cannot un-expose it, so treat it as invalid and let
-    // the caller mint a replacement.
-    #[cfg(unix)]
-    {
-        if serve_token_mode_is_too_open(&path)? {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "serve token file is readable by other users",
-            ));
-        }
+    // Inspect ACL/mode before tightening. A token that was readable by other
+    // users is already leaked; chmod / DACL rewrite cannot un-expose it, so
+    // treat it as invalid and let the caller mint a replacement.
+    if serve_token_mode_is_too_open(&path)? {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "serve token file is readable by other users",
+        ));
     }
     let token = std::fs::read_to_string(&path)?;
     let token = token.trim();
@@ -616,24 +613,31 @@ fn create_new_serve_token(path: &Path) -> io::Result<String> {
 }
 
 fn validate_existing_token_file(path: &Path) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        if serve_token_mode_is_too_open(path)? {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                "serve token file is readable by other users",
-            ));
-        }
+    if serve_token_mode_is_too_open(path)? {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "serve token file is readable by other users",
+        ));
     }
-    let _ = path;
     Ok(())
 }
 
-#[cfg(unix)]
 fn serve_token_mode_is_too_open(path: &Path) -> io::Result<bool> {
-    use std::os::unix::fs::PermissionsExt;
-    let mode = std::fs::metadata(path)?.permissions().mode() & 0o777;
-    Ok(mode & 0o077 != 0)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(path)?.permissions().mode() & 0o777;
+        Ok(mode & 0o077 != 0)
+    }
+    #[cfg(windows)]
+    {
+        crate::windows_security::path_dacl_is_readable_by_others(path)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = path;
+        Ok(false)
+    }
 }
 
 fn protect_token_file(path: &std::path::Path) -> io::Result<()> {
@@ -759,6 +763,10 @@ mod tests {
             let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
             assert_eq!(mode, 0o600);
         }
+        #[cfg(windows)]
+        {
+            assert!(!crate::windows_security::path_dacl_is_readable_by_others(&path).unwrap());
+        }
         let _ = std::fs::remove_dir_all(dir);
     }
 
@@ -778,10 +786,12 @@ mod tests {
         let _ = std::fs::remove_dir_all(dir);
     }
 
-    #[cfg(unix)]
+    /// SBS-1043: Windows reused a leaked token after tightening the DACL.
+    /// Unix already rotated (SBS-953); both platforms now treat a too-open
+    /// ACL as invalid and mint a replacement.
+    #[cfg(any(unix, windows))]
     #[test]
     fn rotates_a_world_readable_serve_token_instead_of_reusing_it() {
-        use std::os::unix::fs::PermissionsExt;
         let dir = std::env::temp_dir().join(format!(
             "ceiling-serve-token-open-{}",
             uuid::Uuid::new_v4().simple()
@@ -789,14 +799,30 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("serve.token");
         std::fs::write(&path, "leaked-token\n").unwrap();
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+        #[cfg(windows)]
+        {
+            crate::windows_security::grant_everyone_file_access(&path).unwrap();
+        }
 
         let loaded = load_or_create_serve_token_at(path.clone()).unwrap();
         assert!(loaded.created);
         assert_ne!(loaded.token, "leaked-token");
         assert_eq!(std::fs::read_to_string(&path).unwrap().trim(), loaded.token);
-        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o600);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+        #[cfg(windows)]
+        {
+            assert!(!crate::windows_security::path_dacl_is_readable_by_others(&path).unwrap());
+        }
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/rust/src/windows_security.rs
+++ b/rust/src/windows_security.rs
@@ -222,6 +222,9 @@ pub fn path_dacl_is_readable_by_others(path: &Path) -> io::Result<bool> {
             let mut ace_ptr = std::ptr::null_mut();
             GetAce(dacl, index, &mut ace_ptr)
                 .map_err(|error| windows_error("GetAce failed", error))?;
+            if ace_ptr.is_null() {
+                return Err(io::Error::other("GetAce returned a null ACE"));
+            }
             let ace = &*ace_ptr.cast::<ACCESS_ALLOWED_ACE>();
             if u32::from(ace.Header.AceType) != ACCESS_ALLOWED_ACE_TYPE {
                 continue;

--- a/rust/src/windows_security.rs
+++ b/rust/src/windows_security.rs
@@ -205,9 +205,9 @@ pub fn path_dacl_is_readable_by_others(path: &Path) -> io::Result<bool> {
         GetSecurityDescriptorDacl(descriptor, &mut present, &mut dacl, &mut defaulted)
             .map_err(|error| windows_error("GetSecurityDescriptorDacl failed", error))?;
         // A missing or NULL DACL is "everyone". An empty DACL is deny-all.
-        if !present.as_bool() || dacl.is_null() {
+        let Some(dacl) = dacl.as_ref().filter(|_| present.as_bool()) else {
             return Ok(true);
-        }
+        };
 
         let mut info = ACL_SIZE_INFORMATION::default();
         GetAclInformation(
@@ -222,17 +222,21 @@ pub fn path_dacl_is_readable_by_others(path: &Path) -> io::Result<bool> {
             let mut ace_ptr = std::ptr::null_mut();
             GetAce(dacl, index, &mut ace_ptr)
                 .map_err(|error| windows_error("GetAce failed", error))?;
-            if ace_ptr.is_null() {
+            let Some(ace) = ace_ptr.cast::<ACCESS_ALLOWED_ACE>().as_ref() else {
                 return Err(io::Error::other("GetAce returned a null ACE"));
-            }
-            let ace = &*ace_ptr.cast::<ACCESS_ALLOWED_ACE>();
+            };
             if u32::from(ace.Header.AceType) != ACCESS_ALLOWED_ACE_TYPE {
                 continue;
             }
             if !ace_grants_read(ace.Mask) {
                 continue;
             }
-            let ace_sid = PSID((&ace.SidStart as *const u32).cast_mut().cast());
+            let ace_sid = PSID(
+                std::ptr::from_ref(&ace.SidStart)
+                    .cast::<u32>()
+                    .cast_mut()
+                    .cast(),
+            );
             if EqualSid(ace_sid, user_sid).is_ok()
                 || EqualSid(ace_sid, system.as_psid()).is_ok()
                 || EqualSid(ace_sid, administrators.as_psid()).is_ok()

--- a/rust/src/windows_security.rs
+++ b/rust/src/windows_security.rs
@@ -5,16 +5,21 @@ use std::mem::{size_of, size_of_val};
 use std::os::windows::ffi::OsStrExt;
 use std::path::Path;
 
-use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::Foundation::{BOOL, CloseHandle, GENERIC_ALL, GENERIC_READ, HANDLE};
 use windows::Win32::Security::{
-    ACCESS_ALLOWED_ACE, ACL, ACL_REVISION, AddAccessAllowedAce, DACL_SECURITY_INFORMATION,
-    GetLengthSid, GetTokenInformation, InitializeAcl, InitializeSecurityDescriptor,
-    PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, SE_DACL_PROTECTED,
+    ACCESS_ALLOWED_ACE, ACL, ACL_REVISION, ACL_SIZE_INFORMATION, AclSizeInformation,
+    AddAccessAllowedAce, CreateWellKnownSid, DACL_SECURITY_INFORMATION, EqualSid, GetAce,
+    GetAclInformation, GetFileSecurityW, GetLengthSid, GetSecurityDescriptorDacl,
+    GetTokenInformation, InitializeAcl, InitializeSecurityDescriptor,
+    PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID, SE_DACL_PROTECTED,
     SECURITY_ATTRIBUTES, SECURITY_DESCRIPTOR, SetFileSecurityW, SetSecurityDescriptorControl,
-    SetSecurityDescriptorDacl, TOKEN_QUERY, TOKEN_USER, TokenUser,
+    SetSecurityDescriptorDacl, TOKEN_QUERY, TOKEN_USER, TokenUser, WELL_KNOWN_SID_TYPE,
+    WinBuiltinAdministratorsSid, WinLocalSystemSid,
 };
-use windows::Win32::Storage::FileSystem::FILE_ALL_ACCESS;
-use windows::Win32::System::SystemServices::SECURITY_DESCRIPTOR_REVISION;
+use windows::Win32::Storage::FileSystem::{FILE_ALL_ACCESS, FILE_READ_DATA};
+use windows::Win32::System::SystemServices::{
+    ACCESS_ALLOWED_ACE_TYPE, SECURITY_DESCRIPTOR_REVISION,
+};
 use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 use windows::core::PCWSTR;
 
@@ -152,5 +157,244 @@ pub fn restrict_path_to_current_user(path: &Path) -> io::Result<()> {
         )
         .ok()
         .map_err(|error| windows_error("SetFileSecurityW failed", error))
+    }
+}
+
+/// True when the DACL grants read to someone other than the current user.
+///
+/// SYSTEM and Administrators are ignored the way root is on Unix: they can
+/// read a 0600 file anyway. `Users`, `Everyone`, `Authenticated Users`, or a
+/// specific other account is a leak. Tightening the ACL cannot un-expose that
+/// token, so callers should rotate instead of reuse.
+pub fn path_dacl_is_readable_by_others(path: &Path) -> io::Result<bool> {
+    let (_user_buffer, user_sid) = current_process_user_sid()?;
+    let system = well_known_sid(WinLocalSystemSid)?;
+    let administrators = well_known_sid(WinBuiltinAdministratorsSid)?;
+    let wide_path = wide_path(path);
+    let mut descriptor_bytes = 0u32;
+    unsafe {
+        let _ = GetFileSecurityW(
+            PCWSTR(wide_path.as_ptr()),
+            DACL_SECURITY_INFORMATION.0,
+            PSECURITY_DESCRIPTOR(std::ptr::null_mut()),
+            0,
+            &mut descriptor_bytes,
+        );
+    }
+    if descriptor_bytes == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let descriptor_words = (descriptor_bytes as usize).div_ceil(size_of::<usize>());
+    let mut descriptor_buffer = vec![0usize; descriptor_words];
+    let descriptor = PSECURITY_DESCRIPTOR(descriptor_buffer.as_mut_ptr().cast());
+    unsafe {
+        GetFileSecurityW(
+            PCWSTR(wide_path.as_ptr()),
+            DACL_SECURITY_INFORMATION.0,
+            descriptor,
+            descriptor_bytes,
+            &mut descriptor_bytes,
+        )
+        .ok()
+        .map_err(|error| windows_error("GetFileSecurityW failed", error))?;
+
+        let mut present = BOOL::default();
+        let mut defaulted = BOOL::default();
+        let mut dacl: *mut ACL = std::ptr::null_mut();
+        GetSecurityDescriptorDacl(descriptor, &mut present, &mut dacl, &mut defaulted)
+            .map_err(|error| windows_error("GetSecurityDescriptorDacl failed", error))?;
+        // A missing or NULL DACL is "everyone". An empty DACL is deny-all.
+        if !present.as_bool() || dacl.is_null() {
+            return Ok(true);
+        }
+
+        let mut info = ACL_SIZE_INFORMATION::default();
+        GetAclInformation(
+            dacl,
+            (&mut info as *mut ACL_SIZE_INFORMATION).cast(),
+            size_of::<ACL_SIZE_INFORMATION>() as u32,
+            AclSizeInformation,
+        )
+        .map_err(|error| windows_error("GetAclInformation failed", error))?;
+
+        for index in 0..info.AceCount {
+            let mut ace_ptr = std::ptr::null_mut();
+            GetAce(dacl, index, &mut ace_ptr)
+                .map_err(|error| windows_error("GetAce failed", error))?;
+            let ace = &*ace_ptr.cast::<ACCESS_ALLOWED_ACE>();
+            if u32::from(ace.Header.AceType) != ACCESS_ALLOWED_ACE_TYPE {
+                continue;
+            }
+            if !ace_grants_read(ace.Mask) {
+                continue;
+            }
+            let ace_sid = PSID((&ace.SidStart as *const u32).cast_mut().cast());
+            if EqualSid(ace_sid, user_sid).is_ok()
+                || EqualSid(ace_sid, system.as_psid()).is_ok()
+                || EqualSid(ace_sid, administrators.as_psid()).is_ok()
+            {
+                continue;
+            }
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn ace_grants_read(mask: u32) -> bool {
+    mask & FILE_READ_DATA.0 != 0 || mask & GENERIC_READ.0 != 0 || mask & GENERIC_ALL.0 != 0
+}
+
+fn wide_path(path: &Path) -> Vec<u16> {
+    path.as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+fn current_process_user_sid() -> io::Result<(Vec<usize>, PSID)> {
+    unsafe {
+        let mut token = HANDLE::default();
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token)
+            .map_err(|error| windows_error("OpenProcessToken failed", error))?;
+        let result = token_user_sid(token);
+        let _ = CloseHandle(token);
+        result
+    }
+}
+
+unsafe fn token_user_sid(token: HANDLE) -> io::Result<(Vec<usize>, PSID)> {
+    let mut token_bytes = 0u32;
+    let _ = unsafe { GetTokenInformation(token, TokenUser, None, 0, &mut token_bytes) };
+    if token_bytes < size_of::<TOKEN_USER>() as u32 {
+        return Err(io::Error::other(
+            "GetTokenInformation returned an invalid TOKEN_USER size",
+        ));
+    }
+    let token_words = (token_bytes as usize).div_ceil(size_of::<usize>());
+    let mut token_buffer = vec![0usize; token_words];
+    unsafe {
+        GetTokenInformation(
+            token,
+            TokenUser,
+            Some(token_buffer.as_mut_ptr().cast()),
+            token_bytes,
+            &mut token_bytes,
+        )
+    }
+    .map_err(|error| windows_error("GetTokenInformation failed", error))?;
+    let token_user = unsafe { &*token_buffer.as_ptr().cast::<TOKEN_USER>() };
+    let sid = token_user.User.Sid;
+    Ok((token_buffer, sid))
+}
+
+struct OwnedWellKnownSid {
+    buffer: Vec<u8>,
+}
+
+impl OwnedWellKnownSid {
+    fn as_psid(&self) -> PSID {
+        PSID(self.buffer.as_ptr().cast_mut().cast())
+    }
+}
+
+fn well_known_sid(kind: WELL_KNOWN_SID_TYPE) -> io::Result<OwnedWellKnownSid> {
+    let mut sid_bytes = 0u32;
+    let _ = unsafe { CreateWellKnownSid(kind, None, PSID(std::ptr::null_mut()), &mut sid_bytes) };
+    if sid_bytes == 0 {
+        return Err(io::Error::other("CreateWellKnownSid returned an empty SID"));
+    }
+    let mut buffer = vec![0u8; sid_bytes as usize];
+    unsafe { CreateWellKnownSid(kind, None, PSID(buffer.as_mut_ptr().cast()), &mut sid_bytes) }
+        .map_err(|error| windows_error("CreateWellKnownSid failed", error))?;
+    Ok(OwnedWellKnownSid { buffer })
+}
+
+/// Test helper: stamp a current-user + Everyone DACL so the file is leaked.
+#[cfg(test)]
+pub(crate) fn grant_everyone_file_access(path: &Path) -> io::Result<()> {
+    use windows::Win32::Security::WinWorldSid;
+
+    let (_user_buffer, user_sid) = current_process_user_sid()?;
+    let everyone = well_known_sid(WinWorldSid)?;
+    let user_sid_bytes = unsafe { GetLengthSid(user_sid) } as usize;
+    let everyone_sid_bytes = unsafe { GetLengthSid(everyone.as_psid()) } as usize;
+    if user_sid_bytes == 0 || everyone_sid_bytes == 0 {
+        return Err(io::Error::other("GetLengthSid returned zero"));
+    }
+
+    let ace_sid_offset = size_of_val(&ACCESS_ALLOWED_ACE::default().SidStart);
+    let acl_bytes = size_of::<ACL>() + size_of::<ACCESS_ALLOWED_ACE>() + user_sid_bytes
+        - ace_sid_offset
+        + size_of::<ACCESS_ALLOWED_ACE>()
+        + everyone_sid_bytes
+        - ace_sid_offset;
+    let acl_words = acl_bytes.div_ceil(size_of::<usize>());
+    let mut acl_buffer = vec![0usize; acl_words];
+    let acl = acl_buffer.as_mut_ptr().cast::<ACL>();
+    unsafe {
+        InitializeAcl(acl, acl_bytes as u32, ACL_REVISION)
+            .map_err(|error| windows_error("InitializeAcl failed", error))?;
+        AddAccessAllowedAce(acl, ACL_REVISION, FILE_ALL_ACCESS.0, user_sid)
+            .map_err(|error| windows_error("AddAccessAllowedAce failed", error))?;
+        AddAccessAllowedAce(acl, ACL_REVISION, FILE_ALL_ACCESS.0, everyone.as_psid())
+            .map_err(|error| windows_error("AddAccessAllowedAce failed", error))?;
+    }
+
+    let mut descriptor = SECURITY_DESCRIPTOR::default();
+    let descriptor_ptr = PSECURITY_DESCRIPTOR((&mut descriptor as *mut SECURITY_DESCRIPTOR).cast());
+    unsafe {
+        InitializeSecurityDescriptor(descriptor_ptr, SECURITY_DESCRIPTOR_REVISION)
+            .map_err(|error| windows_error("InitializeSecurityDescriptor failed", error))?;
+        SetSecurityDescriptorDacl(descriptor_ptr, true, Some(acl), false)
+            .map_err(|error| windows_error("SetSecurityDescriptorDacl failed", error))?;
+        SetSecurityDescriptorControl(descriptor_ptr, SE_DACL_PROTECTED, SE_DACL_PROTECTED)
+            .map_err(|error| windows_error("SetSecurityDescriptorControl failed", error))?;
+    }
+
+    let wide = wide_path(path);
+    unsafe {
+        SetFileSecurityW(
+            PCWSTR(wide.as_ptr()),
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            descriptor_ptr,
+        )
+        .ok()
+        .map_err(|error| windows_error("SetFileSecurityW failed", error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inherited_temp_file_is_not_world_readable_after_restrict() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("serve.token");
+        std::fs::write(&path, b"token\n").unwrap();
+        restrict_path_to_current_user(&path).unwrap();
+        assert!(
+            !path_dacl_is_readable_by_others(&path).unwrap(),
+            "current-user-only DACL must not count as leaked"
+        );
+    }
+
+    #[test]
+    fn everyone_ace_is_readable_by_others_until_restricted() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("serve.token");
+        std::fs::write(&path, b"leaked\n").unwrap();
+        grant_everyone_file_access(&path).unwrap();
+        assert!(
+            path_dacl_is_readable_by_others(&path).unwrap(),
+            "Everyone ACE must count as a leaked token file"
+        );
+        restrict_path_to_current_user(&path).unwrap();
+        assert!(
+            !path_dacl_is_readable_by_others(&path).unwrap(),
+            "tightening must drop the Everyone ACE"
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SBS-953 / #335 rotated a world-readable `serve.token` on Unix (inspect mode before chmod; too-open means `InvalidData` and a new token). Windows still read the leaked value, called `restrict_path_to_current_user`, and reused it.

This inspects the DACL **before** tightening. If anyone other than the current user, SYSTEM, or Administrators can read the file, the token is treated as leaked and replaced. Tightening still happens for a private-enough file.

SYSTEM and Administrators are ignored the way root is on Unix: they can read a `0600` file anyway. `Everyone`, `Users`, `Authenticated Users`, or another account is a leak.

## Related issue

Fixes SBS-1043 (incomplete SBS-953 / #335).

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [x] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [x] Documentation
- [x] Other: `serve.token` ACL handling on Windows

## Validation

Hosted CI runs the main frontend and Rust checks. Windows `rust-shared` is the job that actually exercises the new DACL path.

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` — not run here (Linux agent; Windows ACL APIs are the change)
- [ ] For full pre-release validation: `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -All -Version <version>`
- [ ] For installer/release changes: `powershell.exe -File scripts\windows-release-build.ps1 -Ref <ref> -SmokeInstall`
- [x] Other:
  - `cargo test --manifest-path rust/Cargo.toml --lib serve_token` — 3 passed (Unix)
  - `cargo test --manifest-path rust/Cargo.toml --lib -- cli::serve settings::tests::incident_badge` — 17 passed
  - `cargo fmt --all --check --manifest-path rust/Cargo.toml` — clean
  - Hosted CI on `aa3b83e1`: Frontend, Rust / shared, Rust / desktop, CodeQL — all green. Windows `rust-shared` covers the new DACL rotation tests.

## UI / tray proof

- [x] Not applicable

## Notes for reviewers

Focus on `read_existing_serve_token` / `serve_token_mode_is_too_open` / `path_dacl_is_readable_by_others`.

A token that was already tightened by the old Windows path cannot be detected as previously leaked. This only catches files whose DACL is still too open.

`grant_everyone_file_access` is test-only: it stamps a current-user + Everyone DACL so CI can prove rotation instead of reuse.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e83fd816-acc0-4877-95f0-d898921e4553?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e83fd816-acc0-4877-95f0-d898921e4553&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rotate leaked `serve.token` on Windows by inspecting file DACL
> - Makes `serve_token_mode_is_too_open` cross-platform: on Unix it keeps the mode-bit check, on Windows it delegates to a new `windows_security::path_dacl_is_readable_by_others` that enumerates DACL ACEs for read grants to anyone beyond the current user, SYSTEM, or Administrators
> - `read_existing_serve_token` and `validate_existing_token_file` now reject a token file that is readable by other users on all platforms, causing a new token to be minted instead of reusing the leaked one
> - A missing or NULL DACL is treated as readable by others, triggering rotation
> - Risk: `path_dacl_is_readable_by_others` only recognizes the current user, SYSTEM, and Administrators SIDs as safe; any other legitimate group SID (e.g., a service account group) that is granted read will cause the token to be rotated on every serve start on Windows
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa3b83e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->