### PR TITLE
Do not invent Claude Session 0% when utilization is missing

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
+++ b/apps/desktop-tauri/src-tauri/src/taskbar_widget.rs
@@ -121,13 +121,13 @@ impl<'a> ConstrainingReadout<'a> {
 
 /// Inactive-row ids that mark `primary` as a placeholder, not a reading.
 ///
-/// Match by id only. Sweep: only Cursor writes 0% primary plus an inactive
-/// row for that same window (`cursor-plan` / `cursor-monthly`).
+/// Match by id only. Sweep: Cursor writes 0% primary plus an inactive row
+/// (`cursor-plan` / `cursor-monthly`); Claude does the same for a missing
+/// Session (`claude-session`, SBS-1040).
 fn primary_named_state(snapshot: &crate::commands::ProviderUsageSnapshot) -> Option<&str> {
-    let row = snapshot
-        .inactive_rate_windows
-        .iter()
-        .find(|row| row.id == "cursor-plan" || row.id == "cursor-monthly")?;
+    let row = snapshot.inactive_rate_windows.iter().find(|row| {
+        row.id == "cursor-plan" || row.id == "cursor-monthly" || row.id == "claude-session"
+    })?;
     Some(if row.state == "unavailable" {
         "unavailable"
     } else {
@@ -3714,6 +3714,34 @@ mod tests {
         assert_eq!(with_auto.label, Some("Auto"));
         assert!(with_auto.named_state.is_none());
         assert_eq!(strip_readout_percent(&with_auto, true), Some(42));
+    }
+
+    /// SBS-1040: Claude writes 0% primary when five_hour/utilization is
+    /// missing, plus `claude-session` unavailable. The tile must not paint 0%.
+    #[test]
+    fn claude_strip_omits_percent_when_session_is_unavailable() {
+        let mut snapshot = snap("claude", None, 0.0);
+        snapshot.primary_label = Some("Session (5h)".into());
+        snapshot
+            .inactive_rate_windows
+            .push(crate::commands::InactiveRateWindowSnapshot {
+                id: "claude-session".into(),
+                title: "Session (5h)".into(),
+                description: "No usage reported".into(),
+                state: "unavailable".into(),
+            });
+
+        let readout = constraining_readout(&snapshot);
+        assert_eq!(readout.named_state, Some("unavailable"));
+        assert_eq!(strip_readout_percent(&readout, true), None);
+        assert_eq!(strip_readout_percent(&readout, false), None);
+
+        snapshot.secondary = Some(rate_window(23.0, Some(10_080)));
+        snapshot.secondary_label = Some("Weekly".into());
+        let with_weekly = constraining_readout(&snapshot);
+        assert_eq!(with_weekly.label, Some("Weekly"));
+        assert!(with_weekly.named_state.is_none());
+        assert_eq!(strip_readout_percent(&with_weekly, true), Some(23));
     }
 
     /// SBS-876: omitting the percent is only half the job. Without a label the

--- a/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
@@ -865,6 +865,37 @@ describe("capacityPresentation", () => {
       ).toBe(false);
     });
 
+    it("does not treat a missing Claude session as a 0% hero (SBS-1040)", () => {
+      const snap = provider({
+        providerId: "claude",
+        displayName: "Claude",
+        primary: window(0),
+        primaryLabel: "Session (5h)",
+        secondary: window(23),
+        secondaryLabel: "Weekly",
+        inactiveRateWindows: [
+          {
+            id: "claude-session",
+            title: "Session (5h)",
+            description: "No usage reported",
+            state: "unavailable",
+          },
+        ],
+      });
+      expect(primaryNamedState(snap)).toBe("unavailable");
+      expect(glanceMeters(snap).primary).toBeNull();
+      expect(glanceMeters(snap).companions.map((meter) => meter.label)).toEqual([
+        "Weekly",
+      ]);
+      expect(
+        allMeasuredWindows(snap).some(
+          (measured) =>
+            measured.window.usedPercent === 0 &&
+            measured.label.toLowerCase().includes("session"),
+        ),
+      ).toBe(false);
+    });
+
     it("still heroes a real 0% plan when no inactive row marks it a placeholder", () => {
       // Unknown is not empty: a genuine 0% reading must stay a 0% hero.
       const snap = provider({

--- a/apps/desktop-tauri/src/lib/capacityPresentation.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.ts
@@ -54,11 +54,16 @@ export const GLANCE_COMPANION_HOT_PERCENT = 70;
  * primary alongside an unavailable Weekly inactive row with a different
  * id (`weekly`); title matching would hide that 51% reading (SBS-876).
  *
- * Sweep: the only writer that emits 0% primary AND an inactive row for
- * that same window is Cursor (`cursor-plan` unavailable, `cursor-monthly`
- * notEnforced in `rust/src/providers/cursor/api.rs`).
+ * Sweep: writers that emit 0% primary AND an inactive row for that same
+ * window — Cursor (`cursor-plan` unavailable, `cursor-monthly` notEnforced)
+ * and Claude (`claude-session` unavailable when five_hour/utilization is
+ * absent, SBS-1040).
  */
-const PRIMARY_PLACEHOLDER_IDS = new Set(["cursor-plan", "cursor-monthly"]);
+const PRIMARY_PLACEHOLDER_IDS = new Set([
+  "cursor-plan",
+  "cursor-monthly",
+  "claude-session",
+]);
 
 export function isPrimaryPlaceholderId(id: string): boolean {
   return PRIMARY_PLACEHOLDER_IDS.has(id);

--- a/rust/src/providers/claude/oauth/mod.rs
+++ b/rust/src/providers/claude/oauth/mod.rs
@@ -729,4 +729,52 @@ mod tests {
         assert!(message.contains("rate limited"));
         assert!(message.contains("credentials were preserved"));
     }
+
+    /// SBS-1040: OAuth used to mint Session (5h) 0% when five_hour was omitted.
+    #[test]
+    fn omitted_five_hour_stays_unknown_not_zero() {
+        let response: OAuthUsageResponse = serde_json::from_str(
+            r#"{"seven_day": {"utilization": 14, "resets_at": "2026-08-30T10:00:00Z"}}"#,
+        )
+        .expect("response parses");
+
+        let usage = ClaudeOAuthFetcher::new().build_usage_snapshot(&response, &test_credentials());
+        let session = usage
+            .inactive_rate_windows
+            .iter()
+            .find(|window| window.id == "claude-session")
+            .expect("omitted five_hour must stay unknown");
+        assert_eq!(session.title, "Session (5h)");
+        assert_eq!(session.state, crate::core::EnforcementState::Unavailable);
+        assert!((usage.secondary.expect("weekly").used_percent - 14.0).abs() < 0.001);
+    }
+
+    /// SBS-1040: a null utilization is not 0%.
+    #[test]
+    fn null_utilization_stays_unknown_not_zero() {
+        let window = UsageWindow {
+            utilization: None,
+            resets_at: Some("2026-08-23T12:00:00Z".to_string()),
+        };
+
+        assert!(
+            ClaudeOAuthFetcher::to_rate_window(&window, Some(300), UtilizationScale::Percent)
+                .is_none(),
+            "absent utilization must not become a 0% Session"
+        );
+
+        let response: OAuthUsageResponse = serde_json::from_str(
+            r#"{"five_hour": {"utilization": null}, "seven_day": {"utilization": 9}}"#,
+        )
+        .expect("response parses");
+        let usage = ClaudeOAuthFetcher::new().build_usage_snapshot(&response, &test_credentials());
+        assert!(
+            usage
+                .inactive_rate_windows
+                .iter()
+                .any(|window| window.id == "claude-session"
+                    && window.state == crate::core::EnforcementState::Unavailable)
+        );
+        assert!((usage.secondary.expect("weekly").used_percent - 9.0).abs() < 0.001);
+    }
 }

--- a/rust/src/providers/claude/usage_api.rs
+++ b/rust/src/providers/claude/usage_api.rs
@@ -3,6 +3,13 @@ use serde::Deserialize;
 use super::UtilizationScale;
 use crate::core::{CostSnapshot, NamedRateWindow, RateWindow, UsageSnapshot};
 
+/// Marks the required primary slot as a placeholder when `five_hour` or its
+/// utilization is absent. Glance surfaces treat this id as unknown, not 0%
+/// (SBS-1040 / SBS-876).
+pub(super) const CLAUDE_SESSION_WINDOW_ID: &str = "claude-session";
+const CLAUDE_SESSION_TITLE: &str = "Session (5h)";
+const NO_SESSION_USAGE_REPORTED: &str = "No usage reported";
+
 /// Usage payload shared by Claude's OAuth and web endpoints.
 ///
 /// The two endpoints expose the same windows with different casing and have
@@ -161,9 +168,20 @@ impl ClaudeUsageResponse {
         let primary = self
             .five_hour
             .as_ref()
-            .and_then(|window| convert(window, Some(300), scale))
-            .unwrap_or_else(|| RateWindow::new(0.0));
-        let mut snapshot = UsageSnapshot::new(primary);
+            .and_then(|window| convert(window, Some(300), scale));
+        // UsageSnapshot still needs a primary slot, but 0% is not a reading.
+        // Mark Session unavailable so glance surfaces treat it as unknown.
+        let session_unknown = primary.is_none();
+        let mut snapshot = UsageSnapshot::new(
+            primary.unwrap_or_else(|| RateWindow::with_details(0.0, Some(300), None, None)),
+        );
+        if session_unknown {
+            snapshot = snapshot.with_unavailable_rate_window(
+                CLAUDE_SESSION_WINDOW_ID,
+                CLAUDE_SESSION_TITLE,
+                NO_SESSION_USAGE_REPORTED,
+            );
+        }
 
         if let Some(window) = self
             .seven_day
@@ -305,6 +323,100 @@ mod tests {
                 .expect("Sonnet model-specific window")
                 .used_percent,
             45.0
+        );
+    }
+
+    fn session_placeholder(usage: &crate::core::UsageSnapshot) -> &crate::core::InactiveRateWindow {
+        usage
+            .inactive_rate_windows
+            .iter()
+            .find(|window| window.id == "claude-session")
+            .expect("Session must stay unknown, not a fabricated 0%")
+    }
+
+    /// SBS-1040: a payload that simply omits `five_hour` used to mint
+    /// Session (5h) 0%. That is not a reading — the window is unknown.
+    #[test]
+    fn missing_five_hour_does_not_invent_a_zero_session() {
+        let response: ClaudeUsageResponse = serde_json::from_str(
+            r#"{
+                "seven_day": {"utilization": 23}
+            }"#,
+        )
+        .expect("response parses");
+
+        let usage = snapshot(&response);
+        let session = session_placeholder(&usage);
+        assert_eq!(session.title, "Session (5h)");
+        assert_eq!(session.state, crate::core::EnforcementState::Unavailable);
+        assert_eq!(usage.secondary.expect("weekly").used_percent, 23.0);
+        assert!(
+            usage
+                .inactive_rate_windows
+                .iter()
+                .any(|window| window.id == "claude-session"),
+            "absent five_hour must not render as a real 0% Session"
+        );
+    }
+
+    /// SBS-1040: `five_hour` present with a null utilization is the same lie.
+    #[test]
+    fn null_five_hour_utilization_does_not_invent_a_zero_session() {
+        let response: ClaudeUsageResponse = serde_json::from_str(
+            r#"{
+                "five_hour": {"utilization": null, "resets_at": "2026-08-23T12:00:00Z"},
+                "seven_day": {"utilization": 23}
+            }"#,
+        )
+        .expect("response parses");
+
+        let usage = snapshot(&response);
+        assert_eq!(
+            session_placeholder(&usage).state,
+            crate::core::EnforcementState::Unavailable
+        );
+        assert_eq!(usage.secondary.expect("weekly").used_percent, 23.0);
+    }
+
+    /// Other windows with a null utilization are omitted, not minted at 0%.
+    #[test]
+    fn null_weekly_utilization_is_omitted_not_zero() {
+        let response: ClaudeUsageResponse = serde_json::from_str(
+            r#"{
+                "five_hour": {"utilization": 12},
+                "seven_day": {"utilization": null}
+            }"#,
+        )
+        .expect("response parses");
+
+        let usage = snapshot(&response);
+        assert_eq!(usage.primary.used_percent, 12.0);
+        assert!(
+            usage.secondary.is_none(),
+            "null weekly utilization must stay unknown"
+        );
+        assert!(
+            usage
+                .inactive_rate_windows
+                .iter()
+                .all(|window| window.id != "claude-session")
+        );
+    }
+
+    /// A reported 0% is a reading. Do not mark that unknown.
+    #[test]
+    fn a_reported_zero_session_stays_a_reading() {
+        let response: ClaudeUsageResponse =
+            serde_json::from_str(r#"{"five_hour": {"utilization": 0}}"#).expect("response parses");
+
+        let usage = snapshot(&response);
+        assert!((usage.primary.used_percent).abs() < f64::EPSILON);
+        assert!(
+            usage
+                .inactive_rate_windows
+                .iter()
+                .all(|window| window.id != "claude-session"),
+            "a reported 0% session is a reading, not unknown"
         );
     }
 }

--- a/rust/src/providers/claude/web_api.rs
+++ b/rust/src/providers/claude/web_api.rs
@@ -296,9 +296,8 @@ impl ClaudeWebApiFetcher {
 
         // Build every common Claude usage lane through one normalized path so
         // OAuth and web cannot silently drop fields the other source renders.
-        let mut snapshot = usage.build_snapshot(|window, minutes, scale| {
-            Some(self.to_rate_window(window, minutes, scale))
-        });
+        let mut snapshot = usage
+            .build_snapshot(|window, minutes, scale| self.to_rate_window(window, minutes, scale));
 
         if let Some(promo) = usage.seven_day_promotional.as_ref() {
             let ends_at = promo
@@ -511,14 +510,16 @@ impl ClaudeWebApiFetcher {
         parse_json_with_body(response, "account").await
     }
 
-    /// Convert a usage window to a RateWindow
+    /// Convert a usage window to a RateWindow.
+    ///
+    /// Missing utilization is unknown, not 0% (SBS-1040).
     fn to_rate_window(
         &self,
         window: &ClaudeUsageWindow,
         window_minutes: Option<u32>,
         scale: UtilizationScale,
-    ) -> RateWindow {
-        let used_percent = scale.to_percent(window.utilization.unwrap_or(0.0));
+    ) -> Option<RateWindow> {
+        let used_percent = scale.to_percent(window.utilization?);
 
         let resets_at = window
             .resets_at
@@ -527,7 +528,12 @@ impl ClaudeWebApiFetcher {
 
         let reset_description = resets_at.map(Self::format_reset_time);
 
-        RateWindow::with_details(used_percent, window_minutes, resets_at, reset_description)
+        Some(RateWindow::with_details(
+            used_percent,
+            window_minutes,
+            resets_at,
+            reset_description,
+        ))
     }
 
     /// Parse ISO8601 date string
@@ -596,11 +602,9 @@ mod tests {
             resets_at: None,
         };
 
-        let rate = ClaudeWebApiFetcher::new().to_rate_window(
-            &window,
-            Some(300),
-            UtilizationScale::Fraction,
-        );
+        let rate = ClaudeWebApiFetcher::new()
+            .to_rate_window(&window, Some(300), UtilizationScale::Fraction)
+            .expect("rate window");
 
         assert!((rate.used_percent - 23.0).abs() < f64::EPSILON);
     }
@@ -612,11 +616,9 @@ mod tests {
             resets_at: None,
         };
 
-        let rate = ClaudeWebApiFetcher::new().to_rate_window(
-            &window,
-            Some(300),
-            UtilizationScale::Percent,
-        );
+        let rate = ClaudeWebApiFetcher::new()
+            .to_rate_window(&window, Some(300), UtilizationScale::Percent)
+            .expect("rate window");
 
         assert!((rate.used_percent - 23.0).abs() < f64::EPSILON);
     }
@@ -824,17 +826,17 @@ mod tests {
         let design = usage
             .seven_day_design
             .as_ref()
-            .map(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
+            .and_then(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
             .expect("design window");
         let promo = usage
             .seven_day_promotional
             .as_ref()
-            .map(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
+            .and_then(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
             .expect("promotional omelette window");
         let routines = usage
             .seven_day_routines
             .as_ref()
-            .map(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
+            .and_then(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
             .expect("routines window");
 
         assert!((design.used_percent - 31.0).abs() < f64::EPSILON);
@@ -880,12 +882,12 @@ mod tests {
         let design = usage
             .seven_day_design
             .as_ref()
-            .map(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
+            .and_then(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
             .expect("design window");
         let routines = usage
             .seven_day_routines
             .as_ref()
-            .map(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
+            .and_then(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
             .expect("routines window");
 
         assert!((design.used_percent - 31.0).abs() < f64::EPSILON);
@@ -912,7 +914,7 @@ mod tests {
         let oauth_apps = usage
             .seven_day_oauth_apps
             .as_ref()
-            .map(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
+            .and_then(|w| fetcher.to_rate_window(w, Some(10080), usage.utilization_scale()))
             .expect("oauth apps window");
         let extra = usage.extra_usage.expect("extra usage");
 
@@ -920,5 +922,71 @@ mod tests {
         assert_eq!(extra.is_enabled, Some(true));
         assert_eq!(extra.monthly_limit, Some(2000.0));
         assert_eq!(extra.used_credits, Some(550.0));
+    }
+
+    fn web_snapshot(usage: &ClaudeUsageResponse) -> crate::core::UsageSnapshot {
+        let fetcher = ClaudeWebApiFetcher::new();
+        usage
+            .build_snapshot(|window, minutes, scale| fetcher.to_rate_window(window, minutes, scale))
+    }
+
+    /// SBS-1040: web used `unwrap_or(0.0)`, so a null utilization became
+    /// Session (5h) 0%. Absent utilization is unknown, not empty.
+    #[test]
+    fn absent_utilization_does_not_become_a_zero_window() {
+        let window = ClaudeUsageWindow {
+            utilization: None,
+            resets_at: Some("2026-08-23T12:00:00Z".to_string()),
+        };
+
+        assert!(
+            ClaudeWebApiFetcher::new()
+                .to_rate_window(&window, Some(300), UtilizationScale::Percent)
+                .is_none(),
+            "null utilization must not fabricate 0%"
+        );
+    }
+
+    #[test]
+    fn omitted_five_hour_stays_unknown_on_the_web_snapshot() {
+        let usage: ClaudeUsageResponse = serde_json::from_str(
+            r#"{
+                "seven_day": { "utilization": 31 }
+            }"#,
+        )
+        .unwrap();
+
+        let snapshot = web_snapshot(&usage);
+        assert!(
+            snapshot
+                .inactive_rate_windows
+                .iter()
+                .any(|window| window.id == "claude-session"
+                    && window.state == crate::core::EnforcementState::Unavailable),
+            "omitted five_hour must stay unknown, not Session 0%"
+        );
+        assert_eq!(snapshot.secondary.expect("weekly").used_percent, 31.0);
+    }
+
+    #[test]
+    fn null_five_hour_utilization_stays_unknown_on_the_web_snapshot() {
+        let usage: ClaudeUsageResponse = serde_json::from_str(
+            r#"{
+                "five_hour": { "utilization": null },
+                "seven_day": { "utilization": 31 }
+            }"#,
+        )
+        .unwrap();
+
+        let snapshot = web_snapshot(&usage);
+        assert!(
+            snapshot
+                .inactive_rate_windows
+                .iter()
+                .any(|window| window.id == "claude-session"
+                    && window.state == crate::core::EnforcementState::Unavailable),
+            "null five_hour utilization must stay unknown, not Session 0%"
+        );
+        assert_eq!(snapshot.secondary.expect("weekly").used_percent, 31.0);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Claude Web and OAuth treated a missing `five_hour` window — or a window whose `utilization` was null — as **Session (5h) 0%**. That is not a reading. Absent utilization is now **unknown**.

- `usage_api.rs` `build_snapshot` no longer unwraps a missing session into `RateWindow::new(0.0)`. The required primary slot stays a 0% placeholder, and an `unavailable` `claude-session` inactive row tells glance surfaces not to paint 0%.
- Web `to_rate_window` now returns `Option<RateWindow>` and drops a window when utilization is missing (same as OAuth). Other windows with a null utilization are omitted instead of minted at 0%.
- Glance/strip placeholder id lists now include `claude-session` (same SBS-876 sweep as `cursor-plan` / `cursor-monthly`).

A reported `utilization: 0` is still a real 0% session.

## Related issue

SBS-1040

## Affected areas

- [x] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [x] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

TDD: the new unit tests were run **before** the production change and failed (6 failures) — missing `five_hour` and null `five_hour.utilization` on OAuth, Web, and shared `build_snapshot`. The reported-`0` case already passed.

After the fix:

- `cargo test --manifest-path rust/Cargo.toml --lib -- providers::claude` — 100 passed
- `cargo test --manifest-path rust/Cargo.toml --lib` — 1159 passed
- `cargo fmt --all` on both manifests
- `pnpm --dir apps/desktop-tauri test` — 721 passed (includes `claude-session` glance case)
- Desktop crate tests (`apps/desktop-tauri/src-tauri`) were not run here: this Linux host lacks `gdk-3.0` / GTK. Windows CI covers `claude_strip_omits_percent_when_session_is_unavailable`.
- `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` fails on two **pre-existing** unused items (`secure_file.rs`, `updater.rs`), not this change.

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1`
- [x] Other: Linux checks listed above.

## UI / tray proof

- [x] Not applicable
Glance/strip behavior is locked by the same named-state tests used for Cursor SBS-876 (`claude-session` unavailable hides the 0% hero; Weekly still shows). No visual capture on this Linux agent.

## Notes for reviewers

- `UsageSnapshot.primary` is still required, so the 0% slot remains. The inactive row + `PRIMARY_PLACEHOLDER_IDS` / `primary_named_state` is what keeps unknown unknown on glance surfaces.
- CLI `/usage` parsing still uses `session_percent.unwrap_or(0.0)` when a weekly figure exists without a session figure. That path was left alone because SBS-1040 is Web/OAuth.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf5ee4f7-b8ce-4c96-abff-e6d44bba545f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf5ee4f7-b8ce-4c96-abff-e6d44bba545f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop inventing 0% Claude Session when `five_hour` utilization is missing
> - `to_rate_window` in [web_api.rs](https://github.com/tsouth89/ceiling/pull/389/files#diff-3d65d11e99197c36779411f5fd37e32198e5cb519098d8c9b8c8b6e070141340) and [usage_api.rs](https://github.com/tsouth89/ceiling/pull/389/files#diff-c56b0445ead97d8e304450e4bbde6d142cd161772b5fa6e61d0cac44e9a529ee) now returns `Option<RateWindow>` and returns `None` when `utilization` is absent, instead of defaulting to 0%.
> - When the primary `five_hour` window is missing or null, `build_snapshot` appends an inactive `claude-session` window in `Unavailable` state with title `Session (5h)` and description `No usage reported`, while still providing a structural 0% primary.
> - `PRIMARY_PLACEHOLDER_IDS` in [capacityPresentation.ts](https://github.com/tsouth89/ceiling/pull/389/files#diff-a77d8b9429a947744bc233d5baf44dbad10f512719c23ab0b984d30d615a8f15) and [taskbar_widget.rs](https://github.com/tsouth89/ceiling/pull/389/files#diff-b65f13a1e42ffec75d1a632dda515e529f4be2aaec7d959c4c1cf53d5d937e4e) now includes `claude-session`, so the UI omits the primary meter and shows a named state instead of 0%.
> - Explicitly reported 0% Session is unchanged and remains a real reading.
> - Behavioral Change: `ClaudeWebApiFetcher.to_rate_window` return type changed from `RateWindow` to `Option<RateWindow>`; the closure in `fetch_with_cookies` was updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bccb11f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->