### PR TITLE
Honor chart scan cancel on the primary 30-day walk (SBS-1056)

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -2936,12 +2936,13 @@ mod tests {
     }
 
     fn write_claude_chart_transcript(dir: &std::path::Path, name: &str, index: u32) {
-        let ts = (Utc::now() - chrono::Duration::minutes(index as i64)).to_rfc3339();
+        let ts =
+            (Utc::now() - chrono::Duration::minutes(index as i64)).format("%Y-%m-%dT%H:%M:%S%.3fZ");
         std::fs::write(
             dir.join(name),
             format!(
                 r#"{{"type":"assistant","timestamp":"{ts}","requestId":"req-{index}","message":{{"id":"msg-{index}","model":"claude-opus-4-8","usage":{{"input_tokens":10,"output_tokens":100}}}}}}"#
-            ),
+            ) + "\n",
         )
         .expect("write transcript");
     }
@@ -2972,13 +2973,9 @@ mod tests {
             Some(cancel),
         );
         assert!(
-            cancelled
-                .cost_history
-                .iter()
-                .all(|point| point.value == 0.0),
+            cancelled.cost_history.is_empty() && cancelled.local_usage.is_none(),
             "a cancelled scan must not keep paying the corpus"
         );
-        assert!(cancelled.local_usage.is_none());
 
         let full = build_provider_chart_data_with_cancel(
             "claude".into(),

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -9,7 +9,8 @@ use chrono::{DateTime, Datelike, Local, LocalResult, NaiveDate, TimeZone, Timeli
 use codexbar::core::OpenAIDashboardCacheStore;
 use codexbar::cost_scanner::{
     CostScanner, CostSummary, CostUsageReport, CurrentUsageWindow, get_cost_usage_report,
-    get_cost_usage_report_hourly, get_cost_usage_report_scoped, get_cost_usage_report_with_windows,
+    get_cost_usage_report_hourly, get_cost_usage_report_scoped_with_cancel,
+    get_cost_usage_report_with_windows,
 };
 use codexbar::locale::{self, LocaleKey};
 use serde::{Deserialize, Serialize};
@@ -568,6 +569,7 @@ pub async fn get_provider_chart_data(
     let fallback_provider_id = provider_id.clone();
     let fallback_scope = account_scope.kind();
     let cancel = register_chart_scan(&provider_id);
+    let cancel_watch = cancel.clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
         build_provider_chart_data_with_cancel(
             provider_id,
@@ -584,7 +586,10 @@ pub async fn get_provider_chart_data(
         tracing::warn!("Provider chart data worker failed: {}", err);
         ProviderChartData::empty_with_scope(fallback_provider_id, fallback_scope)
     });
-    store_chart_data(cache_key, result.clone());
+    // A superseded scan must not write a partial/empty payload over a newer one.
+    if !cancel_watch.load(Ordering::Relaxed) {
+        store_chart_data(cache_key, result.clone());
+    }
     result
 }
 
@@ -1792,15 +1797,35 @@ fn build_provider_chart_data_with_cancel(
     // reset-aligned windows so one pass over the logs serves both.
     let (comparison_specs, comparison_windows) = comparison_period_specs(Utc::now());
     usage_windows.extend(comparison_windows);
+    if cancel
+        .as_deref()
+        .is_some_and(|flag| flag.load(Ordering::Relaxed))
+    {
+        return ProviderChartData::empty_with_scope(provider_id, account_scope.kind());
+    }
     let report = match &account_scope {
-        ChartAccountScope::MachineWide => {
-            get_cost_usage_report_scoped(&provider_id, 30, &usage_windows, None)
-        }
-        ChartAccountScope::Account { config_dir, .. } => {
-            get_cost_usage_report_scoped(&provider_id, 30, &usage_windows, Some(config_dir.clone()))
-        }
+        ChartAccountScope::MachineWide => get_cost_usage_report_scoped_with_cancel(
+            &provider_id,
+            30,
+            &usage_windows,
+            None,
+            cancel.as_deref(),
+        ),
+        ChartAccountScope::Account { config_dir, .. } => get_cost_usage_report_scoped_with_cancel(
+            &provider_id,
+            30,
+            &usage_windows,
+            Some(config_dir.clone()),
+            cancel.as_deref(),
+        ),
         ChartAccountScope::UnresolvedAccount { .. } => None,
     };
+    if cancel
+        .as_deref()
+        .is_some_and(|flag| flag.load(Ordering::Relaxed))
+    {
+        return ProviderChartData::empty_with_scope(provider_id, account_scope.kind());
+    }
     let cost_history: Vec<DailyCostPoint> = report
         .as_ref()
         .map(|report| {
@@ -1831,7 +1856,10 @@ fn build_provider_chart_data_with_cancel(
                 &comparison_specs,
             )
         });
-        if scoped_summary.is_some() || account_scope != ChartAccountScope::MachineWide {
+        // An empty MachineWide report already walked the same corpus. A second
+        // 30+1 scan just repeats that cost (SBS-1056). Fall back only when the
+        // provider has no report path at all.
+        if report.is_some() || account_scope != ChartAccountScope::MachineWide {
             scoped_summary
         } else {
             load_local_usage_summary_cached(&provider_id, cancel.as_deref())
@@ -2241,11 +2269,7 @@ fn scan_local_cost(
     match provider_id {
         "codex" => Some(scanner.scan_codex_with_cancel(cancel)),
         "claude" => Some(scanner.scan_claude_with_cancel(cancel)),
-        // Grok has no cancel-aware summary path yet; use the full report scan.
-        "grok" => {
-            let _ = (scanner, cancel);
-            codexbar::cost_scanner::get_cost_usage_report("grok", days).map(|r| r.thirty_days)
-        }
+        "grok" => Some(scanner.scan_grok_with_cancel(cancel)),
         _ => None,
     }
 }
@@ -2452,6 +2476,7 @@ fn load_openai_dashboard_chart_data(
 
 #[cfg(test)]
 mod tests {
+    use super::build_provider_chart_data_with_cancel;
     use super::{
         ACTIVITY_HEATMAP_DAYS, ActivityHourPoint, CHART_CACHE_MAX_ENTRIES,
         CHART_CACHE_MAX_ENTRY_AGE, CHART_CACHE_VERSION, CachedProviderChartData, ChartAccountScope,
@@ -2476,6 +2501,8 @@ mod tests {
     use codexbar::settings::Language;
     use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
     use std::time::{Duration, Instant};
 
     fn cache_entry(refreshed_at_ms: i64) -> CachedProviderChartData {
@@ -2906,6 +2933,66 @@ mod tests {
         );
 
         assert_ne!(personal, work);
+    }
+
+    fn write_claude_chart_transcript(dir: &std::path::Path, name: &str, index: u32) {
+        let ts = (Utc::now() - chrono::Duration::minutes(index as i64)).to_rfc3339();
+        std::fs::write(
+            dir.join(name),
+            format!(
+                r#"{{"type":"assistant","timestamp":"{ts}","requestId":"req-{index}","message":{{"id":"msg-{index}","model":"claude-opus-4-8","usage":{{"input_tokens":10,"output_tokens":100}}}}}}"#
+            ),
+        )
+        .expect("write transcript");
+    }
+
+    /// SBS-1056: cancel must abort the primary 30-day report walk, not only the
+    /// post-scan local_usage fallback.
+    #[test]
+    fn cancelled_chart_scan_does_not_walk_the_primary_corpus() {
+        let home = tempfile::tempdir().expect("temp home");
+        let project = home.path().join("projects").join("p");
+        std::fs::create_dir_all(&project).expect("projects dir");
+        write_claude_chart_transcript(&project, "one.jsonl", 1);
+        write_claude_chart_transcript(&project, "two.jsonl", 2);
+        write_claude_chart_transcript(&project, "three.jsonl", 3);
+        let scope = ChartAccountScope::Account {
+            account_id: "acct".into(),
+            config_dir: home.path().to_path_buf(),
+        };
+
+        let cancel = Arc::new(AtomicBool::new(true));
+        let cancelled = build_provider_chart_data_with_cancel(
+            "claude".into(),
+            None,
+            None,
+            None,
+            scope.clone(),
+            Vec::new(),
+            Some(cancel),
+        );
+        assert!(
+            cancelled
+                .cost_history
+                .iter()
+                .all(|point| point.value == 0.0),
+            "a cancelled scan must not keep paying the corpus"
+        );
+        assert!(cancelled.local_usage.is_none());
+
+        let full = build_provider_chart_data_with_cancel(
+            "claude".into(),
+            None,
+            None,
+            None,
+            scope,
+            Vec::new(),
+            None,
+        );
+        assert!(
+            full.local_usage.is_some(),
+            "the same corpus must be visible when the scan is not cancelled"
+        );
     }
 
     #[test]

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -3596,26 +3596,30 @@ mod tests {
         path
     }
 
-    /// SBS-1056: cancel must stop a multi-file Claude walk after the file that
-    /// saw the flag, not finish the rest of the corpus.
+    /// SBS-1056: the report walk hands this same flag into `parse_batch`.
+    /// Cancel after the first file must not parse the rest of the chunk.
     #[test]
-    fn a_claude_file_walk_stops_when_cancelled_mid_scan() {
+    fn parse_batch_stops_when_cancelled_mid_scan() {
         let dir = tempfile::tempdir().unwrap();
         let files = [
             write_claude_transcript(dir.path(), "a.jsonl", 1),
             write_claude_transcript(dir.path(), "b.jsonl", 2),
             write_claude_transcript(dir.path(), "c.jsonl", 3),
         ];
-        let cutoff = Utc::now() - Duration::days(2);
         let cancel = AtomicBool::new(false);
-        let mut seen = 0;
-        for_each_claude_file(&files, &cutoff, Some(&cancel), |_, _| {
-            seen += 1;
-            cancel.store(true, Ordering::Relaxed);
-        });
+        let parsed = parse_batch(
+            &files,
+            1,
+            &|_path| {
+                cancel.store(true, Ordering::Relaxed);
+                1u32
+            },
+            Some(&cancel),
+        );
         assert_eq!(
-            seen, 1,
-            "cancellation after the first file must not visit the rest"
+            parsed.len(),
+            1,
+            "cancellation after the first file must not parse the rest"
         );
     }
 

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -799,7 +799,12 @@ impl CostScanner {
     /// figure Charts already shows. SBS-934: `codexbar cost` and serve `/cost`
     /// must call this instead of treating Grok as unsupported.
     pub fn scan_grok(&self) -> CostSummary {
-        scan_grok_report(self, self.days, &[]).thirty_days
+        self.scan_grok_with_cancel(None)
+    }
+
+    /// Scan Grok local logs, stopping early when the caller cancels the scan.
+    pub fn scan_grok_with_cancel(&self, cancel: Option<&AtomicBool>) -> CostSummary {
+        scan_grok_report(self, self.days, &[], cancel).thirty_days
     }
 
     /// True when local session logs can be priced for this provider.
@@ -1938,9 +1943,9 @@ pub fn get_cost_usage_report_hourly(provider: &str, days: u32) -> Option<CostUsa
     let days = days.max(1);
     let scanner = CostScanner::new(days).with_hourly_activity();
     match provider {
-        "codex" => Some(scan_codex_report(&scanner, days, &[])),
-        "claude" => Some(scan_claude_report(&scanner, days, &[])),
-        "grok" => Some(scan_grok_report(&scanner, days, &[])),
+        "codex" => Some(scan_codex_report(&scanner, days, &[], None)),
+        "claude" => Some(scan_claude_report(&scanner, days, &[], None)),
+        "grok" => Some(scan_grok_report(&scanner, days, &[], None)),
         _ => None,
     }
 }
@@ -1962,15 +1967,28 @@ pub fn get_cost_usage_report_scoped(
     current_windows: &[CurrentUsageWindow],
     scoped_home: Option<PathBuf>,
 ) -> Option<CostUsageReport> {
+    get_cost_usage_report_scoped_with_cancel(provider, days, current_windows, scoped_home, None)
+}
+
+/// As [`get_cost_usage_report_scoped`], but stops the transcript walk when
+/// `cancel` is set. Charts register a flag so navigate-away / a newer scan
+/// does not keep paying the full 30-day corpus (SBS-1056).
+pub fn get_cost_usage_report_scoped_with_cancel(
+    provider: &str,
+    days: u32,
+    current_windows: &[CurrentUsageWindow],
+    scoped_home: Option<PathBuf>,
+    cancel: Option<&AtomicBool>,
+) -> Option<CostUsageReport> {
     let days = days.max(1);
     let scanner = match scoped_home {
         Some(home) => CostScanner::scoped_to(days, home),
         None => CostScanner::new(days),
     };
     match provider {
-        "codex" => Some(scan_codex_report(&scanner, days, current_windows)),
-        "claude" => Some(scan_claude_report(&scanner, days, current_windows)),
-        "grok" => Some(scan_grok_report(&scanner, days, current_windows)),
+        "codex" => Some(scan_codex_report(&scanner, days, current_windows, cancel)),
+        "claude" => Some(scan_claude_report(&scanner, days, current_windows, cancel)),
+        "grok" => Some(scan_grok_report(&scanner, days, current_windows, cancel)),
         _ => None,
     }
 }
@@ -2310,6 +2328,7 @@ fn scan_codex_report(
     scanner: &CostScanner,
     days: u32,
     windows: &[CurrentUsageWindow],
+    cancel: Option<&AtomicBool>,
 ) -> CostUsageReport {
     let today = Local::now().date_naive();
     let start = codex_period_start(today, days);
@@ -2322,15 +2341,31 @@ fn scan_codex_report(
     let mut seen = HashSet::new();
     let mut files = Vec::new();
     for sessions_dir in scanner.get_codex_sessions_dirs() {
-        files.extend(codex_session_files(&sessions_dir, &range, &mut seen, None));
+        if is_cancelled(cancel) {
+            break;
+        }
+        files.extend(codex_session_files(
+            &sessions_dir,
+            &range,
+            &mut seen,
+            cancel,
+        ));
     }
     // The archive is a flat dir, so gate on the rollout's filename date rather
     // than walking a date tree that does not exist there.
     for archived_dir in scanner.get_codex_archived_dirs() {
-        files.extend(codex_archived_files(&archived_dir, &range, &mut seen, None));
+        if is_cancelled(cancel) {
+            break;
+        }
+        files.extend(codex_archived_files(
+            &archived_dir,
+            &range,
+            &mut seen,
+            cancel,
+        ));
     }
 
-    for_each_codex_file(&files, None, |path, records| {
+    for_each_codex_file(&files, cancel, |path, records| {
         rollups.ingest_parsed(path, records);
     });
 
@@ -2438,6 +2473,7 @@ fn scan_grok_report(
     scanner: &CostScanner,
     days: u32,
     windows: &[CurrentUsageWindow],
+    cancel: Option<&AtomicBool>,
 ) -> CostUsageReport {
     let mut daily = empty_daily_summaries(days);
     let mut hourly = HourlySummaries::new();
@@ -2462,9 +2498,12 @@ fn scan_grok_report(
     let mut period_sessions = 0;
 
     for session_dir in discover_grok_session_dirs(&sessions_root) {
+        if is_cancelled(cancel) {
+            break;
+        }
         let meta = load_session_meta(&session_dir);
         let updates = session_dir.join("updates.jsonl");
-        let records = parse_grok_updates_file(&updates, &meta, cutoff);
+        let records = parse_grok_updates_file(&updates, &meta, cutoff, cancel);
         if records.is_empty() {
             continue;
         }
@@ -2543,6 +2582,7 @@ fn scan_claude_report(
     scanner: &CostScanner,
     days: u32,
     windows: &[CurrentUsageWindow],
+    cancel: Option<&AtomicBool>,
 ) -> CostUsageReport {
     let projects_dirs = scanner.get_claude_projects_dirs();
     let mut daily = empty_daily_summaries(days);
@@ -2558,7 +2598,10 @@ fn scan_claude_report(
     // Union files across ambient + every configured Claude account home.
     let mut files = Vec::new();
     for projects_dir in projects_dirs.iter().filter(|dir| dir.exists()) {
-        files.extend(scanner.claude_files_since(projects_dir, &cutoff, None));
+        if is_cancelled(cancel) {
+            break;
+        }
+        files.extend(scanner.claude_files_since(projects_dir, &cutoff, cancel));
     }
     files.sort();
     files.dedup();
@@ -2573,7 +2616,7 @@ fn scan_claude_report(
     let mut seven_day_sessions = 0;
     let mut period_sessions = 0;
 
-    for_each_claude_file(&files, &cutoff, None, |path, records| {
+    for_each_claude_file(&files, &cutoff, cancel, |path, records| {
         let mut file_summary = CostSummary::default();
         let mut latest_recorded_at: Option<DateTime<Utc>> = None;
         let mut contributed_today = false;
@@ -2859,11 +2902,13 @@ mod tests {
             &CostScanner::scoped_to(2, personal.path().to_path_buf()),
             2,
             &[],
+            None,
         );
         let work_report = scan_codex_report(
             &CostScanner::scoped_to(2, work.path().to_path_buf()),
             2,
             &[],
+            None,
         );
 
         // Each account sees only its own logs, not the other's, and not the sum.
@@ -2926,6 +2971,7 @@ mod tests {
             &CostScanner::with_ambient_and_account_homes(2, ambient.clone(), Vec::new()),
             2,
             &[],
+            None,
         );
         assert_eq!(ambient_only.thirty_days.input_tokens, 1000);
 
@@ -2938,6 +2984,7 @@ mod tests {
             ),
             2,
             &[],
+            None,
         );
         assert_eq!(
             both.thirty_days.input_tokens, 8000,
@@ -2954,6 +3001,7 @@ mod tests {
             ),
             2,
             &[],
+            None,
         );
         assert_eq!(
             with_dup_home.thirty_days.input_tokens, 8000,
@@ -2996,6 +3044,7 @@ mod tests {
             ),
             2,
             &[],
+            None,
         );
         assert_eq!(
             report.thirty_days.input_tokens, 1000,
@@ -3034,6 +3083,7 @@ mod tests {
             &CostScanner::with_ambient_and_account_homes(2, tmp.path().to_path_buf(), Vec::new()),
             2,
             &[],
+            None,
         );
 
         assert_eq!(
@@ -3269,8 +3319,8 @@ mod tests {
         let standard =
             CostScanner::with_codex_speed(2, Some("standard")).with_ambient_home(ambient.clone());
         let fast = CostScanner::with_codex_speed(2, Some("fast")).with_ambient_home(ambient);
-        let std_report = scan_codex_report(&standard, 2, &windows);
-        let fast_report = scan_codex_report(&fast, 2, &windows);
+        let std_report = scan_codex_report(&standard, 2, &windows, None);
+        let fast_report = scan_codex_report(&fast, 2, &windows, None);
 
         let std_window = std_report
             .current_windows
@@ -3538,6 +3588,143 @@ mod tests {
         unique.dedup();
         assert_eq!(dedup_keys.len(), unique.len(), "no record read twice");
         assert_eq!(unique.len(), 3, "every record accounted for exactly once");
+    }
+
+    fn write_claude_transcript(dir: &Path, name: &str, index: u32) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, format!("{}\n", claude_event_line(index, 100))).unwrap();
+        path
+    }
+
+    /// SBS-1056: cancel must stop a multi-file Claude walk after the file that
+    /// saw the flag, not finish the rest of the corpus.
+    #[test]
+    fn a_claude_file_walk_stops_when_cancelled_mid_scan() {
+        let dir = tempfile::tempdir().unwrap();
+        let files = [
+            write_claude_transcript(dir.path(), "a.jsonl", 1),
+            write_claude_transcript(dir.path(), "b.jsonl", 2),
+            write_claude_transcript(dir.path(), "c.jsonl", 3),
+        ];
+        let cutoff = Utc::now() - Duration::days(2);
+        let cancel = AtomicBool::new(false);
+        let mut seen = 0;
+        for_each_claude_file(&files, &cutoff, Some(&cancel), |_, _| {
+            seen += 1;
+            cancel.store(true, Ordering::Relaxed);
+        });
+        assert_eq!(
+            seen, 1,
+            "cancellation after the first file must not visit the rest"
+        );
+    }
+
+    /// SBS-1056: the chart 30-day report used to pass `None` into the walk.
+    #[test]
+    fn a_cancelled_claude_report_does_not_read_the_corpus() {
+        let home = tempfile::tempdir().unwrap();
+        let project = home.path().join("projects").join("p");
+        std::fs::create_dir_all(&project).unwrap();
+        write_claude_transcript(&project, "one.jsonl", 1);
+        write_claude_transcript(&project, "two.jsonl", 2);
+        write_claude_transcript(&project, "three.jsonl", 3);
+
+        let cancel = AtomicBool::new(true);
+        let cancelled = get_cost_usage_report_scoped_with_cancel(
+            "claude",
+            30,
+            &[],
+            Some(home.path().to_path_buf()),
+            Some(&cancel),
+        )
+        .expect("claude is supported");
+        assert_eq!(
+            cancelled.thirty_days.sessions_count, 0,
+            "an already-cancelled report must not parse transcripts"
+        );
+
+        let full = get_cost_usage_report_scoped("claude", 30, &[], Some(home.path().to_path_buf()))
+            .expect("claude is supported");
+        assert_eq!(full.thirty_days.sessions_count, 3);
+    }
+
+    #[test]
+    fn a_cancelled_codex_report_does_not_read_the_corpus() {
+        let today = Local::now().date_naive();
+        let home = tempfile::tempdir().unwrap();
+        let day_dir = home
+            .path()
+            .join("sessions")
+            .join(today.format("%Y").to_string())
+            .join(today.format("%m").to_string())
+            .join(today.format("%d").to_string());
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let ts = (Utc::now() - Duration::hours(1))
+            .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+            .to_string();
+        std::fs::write(
+            day_dir.join(format!(
+                "rollout-{}-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jsonl",
+                today.format("%Y-%m-%d")
+            )),
+            format!(
+                r#"{{"timestamp":"{ts}","type":"event_msg","payload":{{"type":"token_count","info":{{"last_token_usage":{{"input_tokens":1000,"cached_input_tokens":0,"output_tokens":0}}}}}}}}"#
+            ),
+        )
+        .unwrap();
+
+        let cancel = AtomicBool::new(true);
+        let cancelled = get_cost_usage_report_scoped_with_cancel(
+            "codex",
+            2,
+            &[],
+            Some(home.path().to_path_buf()),
+            Some(&cancel),
+        )
+        .expect("codex is supported");
+        assert_eq!(cancelled.thirty_days.sessions_count, 0);
+        assert_eq!(cancelled.thirty_days.input_tokens, 0);
+
+        let full = get_cost_usage_report_scoped("codex", 2, &[], Some(home.path().to_path_buf()))
+            .expect("codex is supported");
+        assert_eq!(full.thirty_days.sessions_count, 1);
+        assert_eq!(full.thirty_days.input_tokens, 1000);
+    }
+
+    #[test]
+    fn a_cancelled_grok_report_does_not_read_the_corpus() {
+        let home = tempfile::tempdir().unwrap();
+        let session = home
+            .path()
+            .join("sessions")
+            .join("proj")
+            .join("019f-session");
+        std::fs::create_dir_all(&session).unwrap();
+        let now = Utc::now();
+        let ts = now.timestamp() as f64;
+        let ms = now.timestamp_millis();
+        std::fs::write(
+            session.join("updates.jsonl"),
+            format!(
+                r#"{{"timestamp":{ts},"method":"_x.ai/session/update","params":{{"sessionId":"s1","_meta":{{"eventId":"e1","agentTimestampMs":{ms}}},"update":{{"sessionUpdate":"turn_completed","prompt_id":"p1","usage":{{"inputTokens":1000,"outputTokens":100,"cachedReadTokens":0,"reasoningTokens":0,"modelCalls":1,"costUsdTicks":10000000000,"modelUsage":{{"grok-4.5-build":{{"inputTokens":1000,"outputTokens":100,"cachedReadTokens":0,"reasoningTokens":0,"modelCalls":1,"costUsdTicks":10000000000}}}}}}}}}}}}"#
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            session.join("summary.json"),
+            r#"{"info":{"cwd":"/tmp/ceiling"},"current_model_id":"grok-4.5"}"#,
+        )
+        .unwrap();
+
+        let scanner = CostScanner::new(7).with_ambient_home(home.path().to_path_buf());
+        let cancel = AtomicBool::new(true);
+        let cancelled = scan_grok_report(&scanner, 7, &[], Some(&cancel));
+        assert_eq!(cancelled.thirty_days.sessions_count, 0);
+        assert_eq!(cancelled.thirty_days.input_tokens, 0);
+
+        let full = scanner.scan_grok();
+        assert_eq!(full.sessions_count, 1);
+        assert_eq!(full.input_tokens, 1000);
     }
 
     #[test]
@@ -3827,6 +4014,7 @@ mod tests {
             &CostScanner::new(7).with_ambient_home(home.path().to_path_buf()),
             7,
             &[],
+            None,
         );
 
         assert_eq!(report.thirty_days.sessions_count, 1);
@@ -3886,6 +4074,7 @@ mod tests {
             &CostScanner::new(7).with_ambient_home(home.path().to_path_buf()),
             7,
             &[],
+            None,
         );
 
         assert_eq!(mixed.thirty_days.input_tokens, 51_000);
@@ -3998,6 +4187,7 @@ mod tests {
             &CostScanner::scoped_to(2, home.path().to_path_buf()),
             2,
             &[],
+            None,
         );
         assert!(
             without_hourly.hourly_activity.is_empty(),
@@ -4012,6 +4202,7 @@ mod tests {
             &CostScanner::scoped_to(2, home.path().to_path_buf()).with_hourly_activity(),
             2,
             &[],
+            None,
         );
 
         let expected: Vec<(NaiveDate, u32)> = [earlier, recent]

--- a/rust/src/grok_costs.rs
+++ b/rust/src/grok_costs.rs
@@ -16,6 +16,7 @@ use std::collections::HashSet;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Grok logs store USD cost as integer ticks: `usd = ticks / COST_USD_TICKS_PER_DOLLAR`.
 pub const COST_USD_TICKS_PER_DOLLAR: u64 = 10_000_000_000;
@@ -197,6 +198,7 @@ pub fn parse_grok_updates_file(
     path: &Path,
     meta: &SessionMeta,
     cutoff: DateTime<Utc>,
+    cancel: Option<&AtomicBool>,
 ) -> Vec<GrokUsageRecord> {
     let Ok(file) = File::open(path) else {
         return Vec::new();
@@ -209,6 +211,9 @@ pub fn parse_grok_updates_file(
     let mut subagent_keys: Vec<String> = Vec::new();
 
     for line in reader.lines().map_while(Result::ok) {
+        if cancel.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+            break;
+        }
         // Cheap prefilter: most lines are tool chatter.
         if !line.contains("turn_completed")
             && !line.contains("subagent_finished")
@@ -272,7 +277,7 @@ pub fn parse_grok_updates_file(
         }
     }
 
-    if !usage_records.is_empty() {
+    if !usage_records.is_empty() || cancel.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
         return usage_records;
     }
 
@@ -605,7 +610,7 @@ mod tests {
         assert_eq!(meta.effort.as_deref(), Some("high"));
 
         let cutoff = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
-        let records = parse_grok_updates_file(&session.join("updates.jsonl"), &meta, cutoff);
+        let records = parse_grok_updates_file(&session.join("updates.jsonl"), &meta, cutoff, None);
         assert_eq!(records.len(), 1);
         let r = &records[0];
         assert_eq!(r.model, "grok-4.5-build");
@@ -696,7 +701,7 @@ mod tests {
         let meta = load_session_meta(&session);
         assert_eq!(meta.project.as_deref(), Some("toolport"));
         let cutoff = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
-        let records = parse_grok_updates_file(&session.join("updates.jsonl"), &meta, cutoff);
+        let records = parse_grok_updates_file(&session.join("updates.jsonl"), &meta, cutoff, None);
         assert_eq!(records.len(), 2);
         assert!(records.iter().all(|r| r.partial));
         assert!(
@@ -730,7 +735,7 @@ mod tests {
         write_session(&session, &updates, summary);
         let meta = load_session_meta(&session);
         let cutoff = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
-        let records = parse_grok_updates_file(&session.join("updates.jsonl"), &meta, cutoff);
+        let records = parse_grok_updates_file(&session.join("updates.jsonl"), &meta, cutoff, None);
         assert_eq!(records.len(), 1);
         assert!(records[0].partial);
         assert_eq!(records[0].input, 75_000);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Chart scans registered a cancel flag but only checked it after `get_cost_usage_report_scoped` finished the 30-day transcript walk. Navigate-away and a newer scan for the same provider still paid the full corpus. Grok’s `scan_local_cost` ignored cancel entirely (`let _ = cancel`). An empty MachineWide report then ran a second 30+1 `local_usage` scan over the same files.

This wires cancel through the primary Codex/Claude/Grok report scanners and `get_cost_usage_report_scoped_with_cancel`, honors it in `scan_grok_with_cancel`, and skips the MachineWide fallback when a report (even empty) already walked the corpus. A superseded scan no longer writes a partial/empty payload into the chart cache.

## Related issue

SBS-1056

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [x] Provider-specific behavior
- [ ] Installer / release packaging
- [x] Startup / background behavior
- [ ] Documentation
- [x] Other: Charts local cost/transcript scan cancellation

## Validation

Hosted CI runs the main frontend and Rust checks. Local checks after this revision:

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` (Linux agent; script is PowerShell/Windows)
- [ ] For full pre-release validation: not applicable
- [ ] For installer/release changes: not applicable
- [x] Other:
  - `cargo test --manifest-path rust/Cargo.toml` — pass
  - `cargo test --manifest-path rust/Cargo.toml --lib cancelled` — pass
  - `cargo fmt` on both Rust manifests
  - Hosted CI on `c9a30bc1` — all 10 checks passed (Frontend, Rust / shared, Rust / desktop)

## UI / tray proof

- [x] Not applicable
- [ ] Visual proof attached
- [ ] Visual proof was not practical; manual validation and explanation attached

Backend scan-cancellation only; no visual change.

## Notes for reviewers

- Cancel now reaches `scan_codex_report` / `scan_claude_report` / `scan_grok_report` and Grok `updates.jsonl` line reads.
- Empty MachineWide reports no longer stack a second 30+1 scan. The fallback remains only when the provider has no report path.
- Tests cover mid-scan `parse_batch` cancel plus cancelled Claude/Codex/Grok report walks and a cancelled chart build against a fixture corpus.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-193fc822-2e27-40c4-b637-61a705d6c067?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-193fc822-2e27-40c4-b637-61a705d6c067&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Honor cancellation flag during primary 30-day chart scan across all providers
> - Adds `get_cost_usage_report_scoped_with_cancel` in [cost_scanner.rs](https://github.com/tsouth89/ceiling/pull/390/files#diff-bc7d350083eb010be1a8c98f6e01a43aefe35e00cc24d09331934e936017a785) and threads an optional `Arc<AtomicBool>` cancel flag through `scan_codex_report`, `scan_claude_report`, `scan_grok_report`, and `parse_grok_updates_file` so each provider can abort file discovery and parsing early.
> - `build_provider_chart_data_with_cancel` in [chart.rs](https://github.com/tsouth89/ceiling/pull/390/files#diff-dd7afa22800a23cd5d615302c3cea0603e1c29fe1e777943eb5f4e6acd7e2afe) now checks the flag after extending usage windows and after building the report; `get_provider_chart_data` only persists to cache when the flag is unset, preventing a cancelled scan from overwriting newer cached data.
> - Grok's local summary path now uses `scan_grok_with_cancel` instead of delegating to a full report scan.
> - Behavioral Change: `MachineWide` scans now fall back to cached `local_usage` only when the report path is `None` (not when `scoped_summary` is `None`), so a report that yields an empty scoped summary no longer triggers a re-scan fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 847c320.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->