### PR TITLE
Keep account form values after add errors

### DIFF
--- a/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderAccountsBridge } from "../../../types/bridge";
 import { AccountsPanel } from "./AccountsPanel";
@@ -91,5 +91,40 @@ describe("settings AccountsPanel", () => {
     for (const path of container.querySelectorAll("code.accounts-path")) {
       expect(path.textContent?.trim()).not.toBe("");
     }
+  });
+
+  it("keeps account values when adding fails", async () => {
+    tauriMocks.getDirectoryAccounts.mockResolvedValue([provider()]);
+    tauriMocks.addDirectoryAccount.mockRejectedValue(new Error("add failed"));
+    render(<AccountsPanel />);
+
+    const dir = await screen.findByPlaceholderText("C:\\codex-work");
+    const label = screen.getByPlaceholderText("AccountsLabelPlaceholder");
+    fireEvent.change(dir, { target: { value: "C:\\codex-work" } });
+    fireEvent.change(label, { target: { value: "Work" } });
+    fireEvent.click(screen.getByText("AccountsAddButton"));
+
+    await screen.findByText("add failed");
+    expect(dir).toHaveValue("C:\\codex-work");
+    expect(label).toHaveValue("Work");
+  });
+
+  it("clears account values after adding succeeds", async () => {
+    tauriMocks.getDirectoryAccounts.mockResolvedValue([provider()]);
+    tauriMocks.addDirectoryAccount.mockResolvedValue(
+      provider({ followingCli: false }),
+    );
+    render(<AccountsPanel />);
+
+    const dir = await screen.findByPlaceholderText("C:\\codex-work");
+    const label = screen.getByPlaceholderText("AccountsLabelPlaceholder");
+    fireEvent.change(dir, { target: { value: "C:\\codex-work" } });
+    fireEvent.change(label, { target: { value: "Work" } });
+    fireEvent.click(screen.getByText("AccountsAddButton"));
+
+    await waitFor(() => {
+      expect(dir).toHaveValue("");
+      expect(label).toHaveValue("");
+    });
   });
 });

--- a/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/accounts/AccountsPanel.tsx
@@ -65,8 +65,10 @@ export function AccountsPanel() {
     setError(null);
     try {
       applyResult(await op());
+      return true;
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
+      return false;
     } finally {
       setBusy(false);
     }
@@ -96,7 +98,7 @@ export function AccountsPanel() {
 interface ProviderProps {
   provider: ProviderAccountsBridge;
   busy: boolean;
-  onRun: (op: () => Promise<ProviderAccountsBridge>) => Promise<void>;
+  onRun: (op: () => Promise<ProviderAccountsBridge>) => Promise<boolean>;
 }
 
 function ProviderAccounts({ provider, busy, onRun }: ProviderProps) {
@@ -129,14 +131,14 @@ function ProviderAccounts({ provider, busy, onRun }: ProviderProps) {
 
   const handleAdd = async () => {
     if (!dir.trim()) return;
-    await onRun(() =>
+    const added = await onRun(() =>
       addDirectoryAccount(
         provider.providerId,
         dir.trim(),
         label.trim() || null,
       ),
     );
-    resetForm();
+    if (added) resetForm();
   };
 
   const cli = LOGIN_CLI[provider.providerId] ?? provider.providerId;


### PR DESCRIPTION
Fixes #267.

The account form now clears only after a successful add. Rejected adds keep the directory and label so the user can correct and retry.

Tests cover both failure and success.

Checks:
- `pnpm test -- --run src/surfaces/settings/accounts/AccountsPanel.test.tsx`
- `pnpm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI form-reset change in settings with tests; no auth, data, or backend behavior changes.
> 
> **Overview**
> The accounts add form now **clears only after a successful add**. Failed adds keep the directory and label so users can fix the error and retry.
> 
> `run` reports success/failure, and `handleAdd` calls `resetForm` only when the add succeeds. Tests cover both the failure and success paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3340a0242306d687a85f3bded4f9e3654ef280f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep account form values when `onRun` fails in `ProviderAccounts.handleAdd`
> - The `AccountsPanel.run` helper now returns a boolean indicating whether the operation succeeded or failed.
> - `ProviderAccounts.handleAdd` only calls `resetForm()` when `onRun` resolves to `true`.
> - Adds tests in [AccountsPanel.test.tsx](https://github.com/tsouth89/ceiling/pull/391/files#diff-6cced9607e9ae31811c7ccf94edfa27060fe59034f30ecfa2e7d2bba2f7cec97) verifying inputs persist after rejection and clear after resolution.
> - Behavioral Change: `handleAdd` no longer clears the directory and label input fields when `run` encounters an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3340a02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->