### PR TITLE
Localize empty mini charts

### DIFF
--- a/apps/desktop-tauri/src/components/MiniBarChart.test.tsx
+++ b/apps/desktop-tauri/src/components/MiniBarChart.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SimpleBarChart, StackedBarChart } from "./MiniBarChart";
+
+vi.mock("../hooks/useLocale", () => ({
+  useLocale: () => ({ t: () => "No data" }),
+}));
+
+describe("MiniBarChart empty state", () => {
+  it("names an empty simple chart from its label", () => {
+    render(<SimpleBarChart points={[]} label="Daily cost" />);
+
+    expect(screen.getByRole("img", { name: "Daily cost: No data" })).toBeTruthy();
+  });
+
+  it("gives an unlabeled empty stacked chart a localized name", () => {
+    render(<StackedBarChart points={[]} />);
+
+    expect(screen.getByRole("img", { name: "No data" })).toBeTruthy();
+  });
+});

--- a/apps/desktop-tauri/src/components/MiniBarChart.tsx
+++ b/apps/desktop-tauri/src/components/MiniBarChart.tsx
@@ -4,6 +4,7 @@
  */
 
 import type { DailyCostPoint, DailyUsageBreakdown } from "../types/bridge";
+import { useLocale } from "../hooks/useLocale";
 
 interface BarChartProps {
   points: DailyCostPoint[];
@@ -21,11 +22,17 @@ export function SimpleBarChart({
   label,
   formatValue,
 }: BarChartProps) {
+  const { t } = useLocale();
   if (points.length === 0) {
+    const emptyText = t("MiniChartNoData");
     return (
-      <div className="mini-chart mini-chart--empty">
+      <div
+        className="mini-chart mini-chart--empty"
+        role="img"
+        aria-label={label ? `${label}: ${emptyText}` : emptyText}
+      >
         {label && <span className="mini-chart__label">{label}</span>}
-        <span className="mini-chart__empty-msg">No data</span>
+        <span className="mini-chart__empty-msg">{emptyText}</span>
       </div>
     );
   }
@@ -117,11 +124,17 @@ export function StackedBarChart({
   height = 64,
   label,
 }: StackedBarChartProps) {
+  const { t } = useLocale();
   if (points.length === 0) {
+    const emptyText = t("MiniChartNoData");
     return (
-      <div className="mini-chart mini-chart--empty">
+      <div
+        className="mini-chart mini-chart--empty"
+        role="img"
+        aria-label={label ? `${label}: ${emptyText}` : emptyText}
+      >
         {label && <span className="mini-chart__label">{label}</span>}
-        <span className="mini-chart__empty-msg">No data</span>
+        <span className="mini-chart__empty-msg">{emptyText}</span>
       </div>
     );
   }

--- a/apps/desktop-tauri/src/i18n/keys.ts
+++ b/apps/desktop-tauri/src/i18n/keys.ts
@@ -478,6 +478,7 @@ export const ALL_LOCALE_KEYS = [
   "DetailChartCredits",
   "DetailChartUsageBreakdown",
   "DetailChartEmpty",
+  "MiniChartNoData",
   "DetailUpdatedPrefix",
   "PanelAllProviders",
   "PanelAllProvidersShort",

--- a/rust/src/locale.rs
+++ b/rust/src/locale.rs
@@ -718,6 +718,7 @@ locale_keys! {
     DetailChartCredits,
     DetailChartUsageBreakdown,
     DetailChartEmpty,
+    MiniChartNoData,
     DetailUpdatedPrefix,
     PanelAllProviders,
     PanelAllProvidersShort,

--- a/rust/src/locale/en-US.ftl
+++ b/rust/src/locale/en-US.ftl
@@ -473,6 +473,7 @@ DetailChartCost = Cost (30 days)
 DetailChartCredits = Credits used (30 days)
 DetailChartUsageBreakdown = Usage by service (30 days)
 DetailChartEmpty = No chart data yet.
+MiniChartNoData = No data
 DetailUpdatedPrefix = Updated
 PanelAllProviders = All providers
 PanelAllProvidersShort = All

--- a/rust/src/locale/zh-CN.ftl
+++ b/rust/src/locale/zh-CN.ftl
@@ -473,6 +473,7 @@ DetailChartCost = 费用（30 天）
 DetailChartCredits = 已用额度（30 天）
 DetailChartUsageBreakdown = 按服务的用量（30 天）
 DetailChartEmpty = 暂无图表数据。
+MiniChartNoData = 暂无数据
 DetailUpdatedPrefix = 已更新
 PanelAllProviders = 所有服务商
 PanelAllProvidersShort = 全部


### PR DESCRIPTION
Fixes #82.

Empty mini charts now expose a localized accessible name, including the chart label when available. Both English and Chinese catalogs are updated.

Checks:
- `pnpm test -- --run src/components/MiniBarChart.test.tsx`
- `pnpm run build`
- `cargo test --manifest-path rust/Cargo.toml locale`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small i18n and accessibility tweak to empty chart UI; no auth, data, or chart-rendering logic changes.
> 
> **Overview**
> Empty `SimpleBarChart` and `StackedBarChart` states no longer hardcode “No data”. They use the new `MiniChartNoData` locale key (English and Chinese) and set `role="img"` with an `aria-label` that prefixes the chart label when one is provided.
> 
> Adds a small unit test covering labeled vs unlabeled empty charts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5960ca0e5de5c1523c3a138a516a88d2b9a49f2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Localize empty state in `MiniBarChart` and expose `role='img'
> - Replaces hardcoded "No data" text with the `MiniChartNoData` translation key in `SimpleBarChart` and `StackedBarChart` empty states
> - Adds `role='img'` and an `aria-label` to the empty states. The accessible name uses the localized text, or `'<label>: <text>'` when a chart label exists
> - Registers the `MiniChartNoData` key in the TypeScript and Rust locale systems, with translations for `en-US` and `zh-CN`
> - Behavioral Change: Empty `MiniBarChart` components now expose `role='img'` and an `aria-label` instead of rendering plain text
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5960ca0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->