### PR TITLE
Select latest Codex session by record time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **A leaked `serve.token` is rotated on Windows, not just Unix.** After SBS-953, a world-readable token was replaced on Unix, but Windows still tightened the DACL and reused the same secret. The ACL is now inspected before tightening; if anyone other than the current user, SYSTEM, or Administrators can read the file, the token is replaced. Closes SBS-1043.
 
 ### Fixed
+- **Codex latest-session cost follows transcript time.** Copying or touching an older rollout no longer makes it replace a newer session in local cost summaries. Fixes #271.
 - **MCP `get_status` no longer hides an exhausted Weekly behind a healthy session.** Top-level `remaining_percent` copied only `usage.primary`, so a Claude/Codex 5-hour window with room made the advertised cap-check sink look fine while Weekly was already at 100%. It now uses the same constraining-window ranking as the desktop strip across primary, secondary, and tertiary (exhausted first, then highest used %). Closes SBS-1055.
 - **Remembered window positions no longer drop a sibling when two surfaces save at once.** `window_geometry.json` was updated with an unlocked read-modify-write, so moving Settings while the float bar or Pop Out also wrote could replace the file with a snapshot that had never seen the other key. Geometry persist now holds the same cross-process state lock as settings and credentials. Closes SBS-1024.
 - **`codexbar` with no subcommand now runs `usage`.** CLI.md and `--help` already called usage the default command, but a bare `codexbar` printed an error asking for an explicit subcommand. It now does what those docs said. Closes SBS-1026.
@@ -1559,6 +1560,5 @@ First stable release of Ceiling for Windows.
 - Configurable refresh cadence, manual refresh, and About links.
 - Async off-main log parsing for responsiveness; strict-concurrency build flags enabled.
 - Packaging + signing/notarization scripts (arm64); build scripts convert `.icon` bundle to `.icns`.
-
 
 

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -2182,7 +2182,7 @@ struct CodexReportRollups<'a> {
     hourly: HourlySummaries,
     collect_hourly: bool,
     current_windows: HashMap<String, CostSummary>,
-    latest: Option<(std::time::SystemTime, CostSummary)>,
+    latest: Option<(DateTime<Utc>, PathBuf, CostSummary)>,
     today_sessions: u32,
     seven_day_sessions: u32,
     period_sessions: u32,
@@ -2217,6 +2217,7 @@ impl<'a> CodexReportRollups<'a> {
     /// a caller bug rather than something to filter here.
     fn ingest_parsed(&mut self, path: &Path, records: &[CodexUsageRecord]) {
         let mut file_summary = CostSummary::default();
+        let mut latest_recorded_at = None;
         let mut contributed_today = false;
         let mut contributed_seven_days = false;
         for record in records {
@@ -2232,6 +2233,11 @@ impl<'a> CodexReportRollups<'a> {
                 &self.range.until_key,
             ) {
                 continue;
+            }
+            if let Some(timestamp) = record.timestamp
+                && latest_recorded_at.is_none_or(|seen| timestamp > seen)
+            {
+                latest_recorded_at = Some(timestamp);
             }
             // Always credit caller windows first. A missing daily bucket must not
             // drop custom/reset-window totals (that is what broke Estimated API
@@ -2277,15 +2283,17 @@ impl<'a> CodexReportRollups<'a> {
         self.period_sessions += 1;
         self.today_sessions += u32::from(contributed_today);
         self.seven_day_sessions += u32::from(contributed_seven_days);
-        let modified = fs::metadata(path)
+        let fallback_modified = fs::metadata(path)
             .and_then(|metadata| metadata.modified())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-        if self
-            .latest
-            .as_ref()
-            .is_none_or(|(seen, _)| modified > *seen)
-        {
-            self.latest = Some((modified, file_summary));
+            .ok()
+            .map(DateTime::<Utc>::from)
+            .unwrap_or(DateTime::<Utc>::UNIX_EPOCH);
+        let recorded_at = latest_recorded_at.unwrap_or(fallback_modified);
+        let path = path.to_path_buf();
+        if self.latest.as_ref().is_none_or(|(seen_at, seen_path, _)| {
+            recorded_at > *seen_at || (recorded_at == *seen_at && path > *seen_path)
+        }) {
+            self.latest = Some((recorded_at, path, file_summary));
         }
     }
 
@@ -2294,7 +2302,7 @@ impl<'a> CodexReportRollups<'a> {
             self.daily,
             self.hourly,
             days,
-            self.latest.map(|(_, summary)| summary),
+            self.latest.map(|(_, _, summary)| summary),
             (
                 self.today_sessions,
                 self.seven_day_sessions,
@@ -4124,5 +4132,67 @@ mod tests {
             "derived local day {day} must receive the record"
         );
         assert_eq!(report.hourly_activity.len(), 1);
+    }
+
+    #[test]
+    fn codex_latest_session_uses_record_timestamp_not_file_mtime() {
+        let now = Utc::now();
+        let today = now.with_timezone(&Local).date_naive();
+        let range = CostUsageDayRange::new(today, today);
+        let dir = tempfile::tempdir().unwrap();
+        let newer_path = dir.path().join("newer.jsonl");
+        let older_path = dir.path().join("older.jsonl");
+        std::fs::write(&newer_path, "newer").unwrap();
+        std::fs::write(&older_path, "older touched later").unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(&newer_path)
+            .unwrap()
+            .set_times(
+                std::fs::FileTimes::new().set_modified(
+                    std::time::SystemTime::now() - std::time::Duration::from_secs(3_600),
+                ),
+            )
+            .unwrap();
+
+        let record = |timestamp, input| CodexUsageRecord {
+            timestamp: Some(timestamp),
+            model: "gpt-5.6-sol".to_string(),
+            effort: None,
+            project: None,
+            plan: None,
+            input,
+            cached: 0,
+            output: 1,
+        };
+        let mut rollups = CodexReportRollups::new(1, &range, &[], today, false);
+        rollups.ingest_parsed(&newer_path, &[record(now, 222)]);
+        rollups.ingest_parsed(&older_path, &[record(now - Duration::hours(1), 111)]);
+
+        let latest = rollups.finish(1).latest_session.expect("latest session");
+        assert_eq!(latest.input_tokens, 222);
+    }
+
+    #[test]
+    fn codex_latest_session_ties_are_broken_by_path() {
+        let now = Utc::now();
+        let today = now.with_timezone(&Local).date_naive();
+        let range = CostUsageDayRange::new(today, today);
+        let record = |input| CodexUsageRecord {
+            timestamp: Some(now),
+            model: "gpt-5.6-sol".to_string(),
+            effort: None,
+            project: None,
+            plan: None,
+            input,
+            cached: 0,
+            output: 1,
+        };
+        let mut rollups = CodexReportRollups::new(1, &range, &[], today, false);
+        rollups.ingest_parsed(Path::new("a.jsonl"), &[record(111)]);
+        rollups.ingest_parsed(Path::new("b.jsonl"), &[record(222)]);
+
+        let latest = rollups.finish(1).latest_session.expect("latest session");
+        assert_eq!(latest.input_tokens, 222);
     }
 }


### PR DESCRIPTION
Fixes #271.

Codex latest-session summaries now rank each rollout by its newest included record timestamp. File modification time remains the fallback, and equal timestamps use a stable path tie-break.

Checks:
- `cargo fmt --all -- --check`
- `cargo test --manifest-path rust/Cargo.toml codex_latest_session`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow cost-scanner ranking change with tests; it only affects which session is labeled latest, not totals or auth.
> 
> **Overview**
> Codex local cost summaries now treat the **latest session** as the rollout with the newest transcript timestamp, not the file with the newest mtime. Copying or touching an older rollout no longer displaces a more recent session.
> 
> `CodexReportRollups` ranks by the newest in-range `record.timestamp`, falls back to file mtime when a transcript has no timestamps, and breaks equal times with a stable path comparison. Tests cover both the mtime-vs-record case and the path tie-break.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcbd8ce476e1bd7f000f823fff5c4c8121f714e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Select latest Codex session by transcript record time, not file mtime
> Previously, touching or copying an older rollout file could overwrite a newer session in local cost summaries because selection used the file's modified time. The `latest` field of `CodexReportRollups` now stores `DateTime<Utc>` alongside the source `PathBuf` and `CostSummary`, and `ingest_parsed` picks the most recent `record.timestamp` from the transcript records instead of the filesystem mtime (which becomes a fallback). When two rollouts share the same record timestamp, the lexicographically larger path wins for deterministic ordering.
> - Risk: callers reading `CodexReportRollups.latest` must handle the new tuple shape `(DateTime<Utc>, PathBuf, CostSummary)`; the in-tree consumer in `finish` is already updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dcbd8ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->