### PR TITLE
Announce update status and progress

### DIFF
--- a/apps/desktop-tauri/src/components/UpdateBanner.test.tsx
+++ b/apps/desktop-tauri/src/components/UpdateBanner.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { UpdateStatePayload } from "../types/bridge";
+import UpdateBanner from "./UpdateBanner";
+
+vi.mock("../hooks/useLocale", () => ({
+  useLocale: () => ({ t: (key: string) => key }),
+}));
+
+const handlers = {
+  onCheck: vi.fn(),
+  onDownload: vi.fn(),
+  onApply: vi.fn(),
+  onDismiss: vi.fn(),
+  onOpenRelease: vi.fn(),
+};
+
+function state(
+  status: UpdateStatePayload["status"],
+  overrides: Partial<UpdateStatePayload> = {},
+): UpdateStatePayload {
+  return {
+    status,
+    version: "2.0.0",
+    error: null,
+    progress: null,
+    releaseUrl: null,
+    canDownload: true,
+    canApply: true,
+    lastCheckedAt: null,
+    ...overrides,
+  };
+}
+
+describe("UpdateBanner accessibility", () => {
+  it("announces available and ready states as status updates", () => {
+    const { rerender } = render(
+      <UpdateBanner updateState={state("available")} {...handlers} />,
+    );
+    expect(screen.getByRole("status").textContent).toContain("2.0.0");
+
+    rerender(<UpdateBanner updateState={state("ready")} {...handlers} />);
+    expect(screen.getByRole("status").textContent).toContain(
+      "BannerReadyToInstallSuffix",
+    );
+  });
+
+  it("exposes download progress without changing the status announcement", () => {
+    const { rerender } = render(
+      <UpdateBanner
+        updateState={state("downloading", { progress: 0.42 })}
+        {...handlers}
+      />,
+    );
+    const status = screen.getByRole("status");
+    expect(status.textContent).not.toContain("42%");
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "42",
+    );
+
+    rerender(
+      <UpdateBanner
+        updateState={state("downloading", { progress: 0.73 })}
+        {...handlers}
+      />,
+    );
+    expect(screen.getByRole("status").textContent).toBe(status.textContent);
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "73",
+    );
+  });
+
+  it("announces update failures as alerts", () => {
+    render(
+      <UpdateBanner
+        updateState={state("error", { error: "network failed" })}
+        {...handlers}
+      />,
+    );
+    expect(screen.getByRole("alert").textContent).toContain("network failed");
+  });
+});

--- a/apps/desktop-tauri/src/components/UpdateBanner.tsx
+++ b/apps/desktop-tauri/src/components/UpdateBanner.tsx
@@ -27,7 +27,7 @@ export default function UpdateBanner({
     <div className={cls}>
       {updateState.status === "available" && (
         <>
-          <span>
+          <span role="status">
             {t("BannerUpdateAvailablePrefix")} <strong>{updateState.version}</strong>
           </span>
           <div className="update-banner__actions">
@@ -62,7 +62,7 @@ export default function UpdateBanner({
 
       {updateState.status === "downloading" && (
         <div className="update-banner__downloading">
-          <span>
+          <span role="status">
             {t("BannerDownloadingPrefix")}
             {updateState.version && (
               <>
@@ -70,11 +70,21 @@ export default function UpdateBanner({
                 <strong>{updateState.version}</strong>
               </>
             )}
-            {updateState.progress != null &&
-              ` — ${Math.round(updateState.progress * 100)}%`}
           </span>
           {updateState.progress != null && (
-            <div className="update-banner__progress">
+            <span aria-hidden="true">
+              {` — ${Math.round(updateState.progress * 100)}%`}
+            </span>
+          )}
+          {updateState.progress != null && (
+            <div
+              className="update-banner__progress"
+              role="progressbar"
+              aria-label={t("BannerDownloadingPrefix")}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={Math.round(updateState.progress * 100)}
+            >
               <div
                 className="update-banner__progress-bar"
                 style={{
@@ -88,7 +98,7 @@ export default function UpdateBanner({
 
       {updateState.status === "ready" && (
         <>
-          <span>
+          <span role="status">
             {t("BannerUpdateAvailablePrefix")}
             {updateState.version && (
               <>
@@ -130,7 +140,7 @@ export default function UpdateBanner({
 
       {updateState.status === "error" && (
         <>
-          <span>
+          <span role="alert">
             {t("BannerUpdateFailedPrefix")}
             {updateState.error && <>: {updateState.error}</>}
           </span>


### PR DESCRIPTION
Fixes #269.

Available, downloading, and ready states now use status semantics. Failures use alert semantics, and download progress exposes numeric progressbar values without repeating the unchanged status text.

Checks:
- `pnpm test -- --run src/components/UpdateBanner.test.tsx`
- `pnpm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI accessibility markup only; no update-install, auth, or data-handling logic changes.
> 
> **Overview**
> Improves screen-reader announcements on the desktop update banner so available/downloading/ready states use `role="status"`, and failures use `role="alert"`.
> 
> Download percent is kept visually but `aria-hidden`, while the progress bar exposes `aria-valuenow` so percent ticks do not re-announce the same status text. Adds tests covering those roles and progress updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef637ba46b9257f3e8a6b2ae2917cdde7bf512f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ARIA status, progressbar, and alert roles to `UpdateBanner`
> - Adds `role="status"` to the primary message span for the available, downloading, and ready states so screen readers announce update status.
> - In the downloading state, moves the inline percentage out of the status message into a separate `aria-hidden` span and adds a `role="progressbar"` container with `aria-valuenow` set to the rounded percent.
> - Adds `role="alert"` to the error message span so errors are announced immediately.
> - Behavioral Change: the visible percentage text is no longer included in the status announcement; only the `progressbar` element conveys progress to assistive tech.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef637ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->