### PR TITLE
Expose quota state in provider card names

### DIFF
--- a/apps/desktop-tauri/src/components/PlanStatusCard.test.tsx
+++ b/apps/desktop-tauri/src/components/PlanStatusCard.test.tsx
@@ -67,6 +67,65 @@ function provider(
 }
 
 describe("PlanStatusCard", () => {
+  it("includes displayed quota windows in the card button name", () => {
+    render(
+      <PlanStatusCard
+        provider={provider()}
+        resetTimeRelative
+        showAsUsed
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Cursor; Monthly: 62% used; Auto: 90% used",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("includes provider errors in the card button name", () => {
+    render(
+      <PlanStatusCard
+        provider={provider({ error: "Authentication failed" })}
+        resetTimeRelative
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Cursor: Authentication failed",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("includes unavailable windows in the card button name", () => {
+    render(
+      <PlanStatusCard
+        provider={provider({
+          primary: window(0),
+          primaryLabel: "Plan",
+          secondary: null,
+          inactiveRateWindows: [
+            {
+              id: "cursor-plan",
+              title: "Plan",
+              description: "No usage reported",
+              state: "unavailable",
+            },
+          ],
+        })}
+        resetTimeRelative
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Cursor; Plan: unavailable" }),
+    ).toBeInTheDocument();
+  });
+
   it("names each account by email when a provider has two (the reported bug)", () => {
     // Exactly the user's setup: two Codex accounts.
     const { unmount } = render(

--- a/apps/desktop-tauri/src/components/PlanStatusCard.tsx
+++ b/apps/desktop-tauri/src/components/PlanStatusCard.tsx
@@ -225,6 +225,22 @@ export default function PlanStatusCard({
   const notEnforcedSummary = inactiveWindowSummary(provider, "notEnforced");
   const unavailableSummary = inactiveWindowSummary(provider, "unavailable");
   const resetCredits = bankedResetCredits(provider);
+  const meterSummary = [meters.primary, ...meters.companions]
+    .filter((meter): meter is ConstrainingWindow => meter != null)
+    .map((meter) => {
+      const percent = glanceDisplayPercent(meter.window, showAsUsed);
+      const suffix = showAsUsed ? t("PanelUsedSuffix") : t("PanelLeftSuffix");
+      return `${meter.label}: ${percent}% ${suffix}`;
+    });
+  if (notEnforcedSummary) {
+    meterSummary.push(`${notEnforcedSummary}: ${t("NotCurrentlyEnforced")}`);
+  }
+  if (unavailableSummary) {
+    meterSummary.push(`${unavailableSummary}: ${t("WindowUnavailable")}`);
+  }
+  const accessibleLabel = provider.error
+    ? `${provider.displayName}: ${provider.error}`
+    : [provider.displayName, ...meterSummary].join("; ");
 
   const className = [
     "plan-status-card",
@@ -347,7 +363,7 @@ export default function PlanStatusCard({
         className={className}
         style={{ "--plan-brand": brand } as CSSProperties}
         onClick={onSelect}
-        aria-label={provider.displayName}
+        aria-label={accessibleLabel}
         aria-busy={isRefreshing}
       >
         {body}


### PR DESCRIPTION
Fixes #268.

Interactive provider cards now announce the provider plus each displayed quota window. Error and unavailable states are included using the same localized wording shown on the card.

Checks:
- `pnpm test -- --run src/components/PlanStatusCard.test.tsx`
- `pnpm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Accessibility-only label change on existing UI; no auth, data, or business-logic changes.
> 
> **Overview**
> Interactive provider cards no longer use only the provider name as their accessible name. The button `aria-label` now includes each displayed quota window (percent used/left) plus localized not-enforced and unavailable wording, or the provider error when present.
> 
> Tests cover quota windows, auth errors, and unavailable plans so screen readers hear the same state shown on the card.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4dfbdb70b42e3d2977bbeb8b2120266efee0da0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose quota state in `PlanStatusCard` button aria-label
> The interactive plan card button now announces quota details to assistive technology. The new `accessibleLabel` in [PlanStatusCard.tsx](https://github.com/tsouth89/ceiling/pull/395/files#diff-d94a5d8370e2967d322c64921f31c729943b31933d3c7bdbc49fa73c5aa50c7c) starts with the provider display name and appends a `meterSummary` built from primary and companion constraining windows, formatted as `<label>: <percent> <used/left suffix>`.
> - When `provider.error` is set, the aria-label becomes `<displayName>: <error>` instead of the meter summary.
> - Not-currently-enforced and unavailable windows are appended with their localized labels.
> - Tests in [PlanStatusCard.test.tsx](https://github.com/tsouth89/ceiling/pull/395/files#diff-9aa22b9de9ba07b30cc17e383df07080a8e081e8ddae11bee11fd60ab4091184) assert the button accessible name for quota windows, provider errors, and unavailable windows.
> - Risk: the non-interactive article branch's ARIA labeling is unchanged; only the button `aria-label` value changes from `provider.displayName` to the new `accessibleLabel`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4dfbdb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->