### PR TITLE
Separate provider sidebar controls

### DIFF
--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -2848,7 +2848,7 @@ body:has(.taskbar-flyout-frame) #root {
   gap: 8px;
   padding: 8px 16px 8px 10px;
   border-radius: 8px;
-  cursor: pointer;
+  cursor: default;
   user-select: none;
   border: 1px solid transparent;
   transition: background 120ms ease, border-color 120ms ease, transform 120ms ease;
@@ -2859,9 +2859,25 @@ body:has(.taskbar-flyout-frame) #root {
   background: var(--provider-row-bg-hover);
 }
 
-.providers-sidebar__row:focus-visible {
-  border-color: var(--provider-row-border-selected);
-  box-shadow: 0 0 0 2px rgba(10, 132, 255, 0.25);
+.providers-sidebar__select {
+  display: grid;
+  grid-template-columns: 8px 24px minmax(0, 1fr);
+  grid-column: 1 / 4;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: start;
+  cursor: pointer;
+}
+
+.providers-sidebar__select:focus-visible {
+  outline: 2px solid var(--provider-row-border-selected);
+  outline-offset: 3px;
+  border-radius: 4px;
 }
 
 .providers-sidebar__row--selected {

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProvidersSidebar.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProvidersSidebar.test.tsx
@@ -61,8 +61,9 @@ describe("ProvidersSidebar", () => {
       </LocaleProvider>,
     );
 
-    expect(await screen.findByRole("listbox", { name: "Providers" })).toBeInTheDocument();
-    expect(screen.getAllByRole("option")).toHaveLength(TEST_PROVIDER_CATALOG.length);
+    expect(await screen.findByRole("list", { name: "Providers" })).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(TEST_PROVIDER_CATALOG.length);
+    expect(screen.queryByRole("option")).toBeNull();
     const names = Array.from(
       container.querySelectorAll(".providers-sidebar__name"),
       (node) => node.textContent,
@@ -177,5 +178,41 @@ describe("ProvidersSidebar", () => {
     );
 
     expect(await screen.findByRole("button", { name: "Move up Codex" })).toBeDisabled();
+  });
+
+  it("keeps selection, enable, and reorder as sibling controls", async () => {
+    const onSelect = vi.fn();
+    const onToggleEnabled = vi.fn();
+    const onReorder = vi.fn();
+    render(
+      <LocaleProvider>
+        <ProvidersSidebar
+          providers={rows()}
+          selectedId="codex"
+          searchText=""
+          onSearchTextChange={vi.fn()}
+          onSelect={onSelect}
+          onReorder={onReorder}
+          onToggleEnabled={onToggleEnabled}
+        />
+      </LocaleProvider>,
+    );
+
+    const select = (await screen.findByText("Codex")).closest("button");
+    expect(select).not.toBeNull();
+    const enabled = screen.getByRole("checkbox", { name: "Codex enabled" });
+    const down = screen.getByRole("button", { name: "Move down Codex" });
+    const row = select!.closest("li");
+    expect(row).toContainElement(enabled);
+    expect(row).toContainElement(down);
+    expect(select).not.toContainElement(enabled);
+    expect(select).not.toContainElement(down);
+
+    fireEvent.click(select!);
+    fireEvent.click(enabled);
+    fireEvent.click(down);
+    expect(onSelect).toHaveBeenCalledWith("codex");
+    expect(onToggleEnabled).toHaveBeenCalledWith("codex", false);
+    expect(onReorder).toHaveBeenCalled();
   });
 });

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProvidersSidebar.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProvidersSidebar.tsx
@@ -1,6 +1,5 @@
 import {
   type CSSProperties,
-  type KeyboardEvent as ReactKeyboardEvent,
   type DragEvent as ReactDragEvent,
   useEffect,
   useRef,
@@ -166,18 +165,6 @@ export function ProvidersSidebar({
     setDropTargetId(null);
   };
 
-  const handleKey = (row: ProviderSidebarRow) => (e: ReactKeyboardEvent<HTMLLIElement>) => {
-    if (e.altKey && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
-      e.preventDefault();
-      moveId(row.id, e.key === "ArrowUp" ? -1 : 1);
-      return;
-    }
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      onSelect(row.id);
-    }
-  };
-
   const sidebarRef = useRef<HTMLUListElement>(null);
 
   // Explicit wheel handler — WebView2 on Windows can swallow wheel events
@@ -217,9 +204,8 @@ export function ProvidersSidebar({
       <ul
         ref={sidebarRef}
         className="providers-sidebar"
-        role="listbox"
+        role="list"
         aria-label="Providers"
-        aria-orientation="vertical"
         onWheel={handleWheel}
       >
         {ordered.length === 0 && (
@@ -254,37 +240,39 @@ export function ProvidersSidebar({
             <li
               key={p.id}
               className={cls}
-              role="option"
-              tabIndex={isSelected ? 0 : -1}
-              aria-selected={isSelected}
               draggable={!disabled}
               style={rowStyle}
-              onClick={() => onSelect(p.id)}
-              onKeyDown={handleKey(p)}
               onDragStart={handleDragStart(p.id)}
               onDragOver={handleDragOver(p.id)}
               onDrop={handleDrop(p.id)}
               onDragEnd={handleDragEnd}
             >
-              <span
-                className={`providers-sidebar__status providers-sidebar__status--${p.status}`}
-                title={t(STATUS_TO_KEY[p.status])}
-                aria-label={t(STATUS_TO_KEY[p.status])}
-              />
-              <ProviderIcon providerId={p.id} size={24} />
-              <div className="providers-sidebar__text">
-                <span className="providers-sidebar__name">{p.displayName}</span>
-                <span className="providers-sidebar__subtitle">
-                  <span className="providers-sidebar__subtitle-primary">
-                    {p.subtitlePrimary}
-                  </span>
-                  {p.subtitleSecondary && (
-                    <span className="providers-sidebar__subtitle-secondary">
-                      {p.subtitleSecondary}
+              <button
+                type="button"
+                className="providers-sidebar__select"
+                onClick={() => onSelect(p.id)}
+                aria-current={isSelected ? "true" : undefined}
+              >
+                <span
+                  className={`providers-sidebar__status providers-sidebar__status--${p.status}`}
+                  title={t(STATUS_TO_KEY[p.status])}
+                  aria-label={t(STATUS_TO_KEY[p.status])}
+                />
+                <ProviderIcon providerId={p.id} size={24} />
+                <span className="providers-sidebar__text">
+                  <span className="providers-sidebar__name">{p.displayName}</span>
+                  <span className="providers-sidebar__subtitle">
+                    <span className="providers-sidebar__subtitle-primary">
+                      {p.subtitlePrimary}
                     </span>
-                  )}
+                    {p.subtitleSecondary && (
+                      <span className="providers-sidebar__subtitle-secondary">
+                        {p.subtitleSecondary}
+                      </span>
+                    )}
+                  </span>
                 </span>
-              </div>
+              </button>
               <span
                 className="providers-sidebar__handle"
                 aria-hidden="true"


### PR DESCRIPTION
Fixes #272.

Provider rows are now ordinary list items with separate selection, enable, and reorder controls. This removes nested controls from listbox options and lets each native control keep its keyboard behavior.

Checks:
- `pnpm test -- --run src/surfaces/settings/providers/ProvidersSidebar.test.tsx`
- `pnpm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/accessibility markup change in settings only. No auth, data, or backend behavior is affected.
> 
> **Overview**
> Fixes nested interactive controls in the providers sidebar by treating each row as a normal list item instead of a `listbox` option.
> 
> Selection is now its own button (`providers-sidebar__select`) with `aria-current`. Enable and reorder stay sibling controls so they keep native keyboard behavior. Row-level Enter/Space and Alt+Arrow reorder shortcuts are removed.
> 
> Focus styling moves onto the select button; tests assert list/listitem roles and that select, enable, and reorder fire independently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69c860dd2c8d1c13dc3874b6208a81df0c79097c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move `ProvidersSidebar` selection into inner button and drop listbox ARIA roles
> - Replaces the `listbox`/`option` roles in `ProvidersSidebar` with `list`/`listitem` and moves selection onto an inner `.providers-sidebar__select` button using `aria-current`.
> - Removes the `handleKey` function and `li`-level `onClick`/`onKeyDown`/`tabIndex`/`aria-selected`, dropping Alt+ArrowUp/Down reordering and Enter/Space selection on the list item. Drag-and-drop handlers stay on the `li`.
> - The select button, enable checkbox, and reorder controls are now siblings within the same `listitem`; updated tests assert the new roles and sibling structure.
> - Risk: assistive-tech users and keyboard flows that relied on `listbox`/`option` semantics or Alt+Arrow reordering from `ProvidersSidebar.tsx` will lose that behavior; reordering now depends solely on drag-and-drop.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69c860d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->