### PR TITLE
Document dead refresh_all_providers_on_menu_open (SBS-1070)

### DIFF
--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -220,6 +220,7 @@ export interface SettingsSnapshot {
   enabledProviders: string[];
   providerOrder?: string[];
   refreshIntervalSecs: number;
+  /** Legacy compatibility field; opening a tray/menu surface does not force-refresh. */
   refreshAllProvidersOnMenuOpen: boolean;
   startAtLogin: boolean;
   startMinimized: boolean;

--- a/docs/SETTINGS_JSON.md
+++ b/docs/SETTINGS_JSON.md
@@ -13,7 +13,7 @@ fields marked safe, but Ceiling may overwrite the file when the app exits.
 |---|---|---|---|
 | `enabled_providers` | array of strings | `["claude","codex","cursor","grok"]` | Provider CLI names to monitor. Safe to edit. |
 | `refresh_interval_secs` | number | `300` | `0` means manual refresh only. Safe to edit. |
-| `refresh_all_providers_on_menu_open` | boolean | `false` | Force-refresh when a tray/menu surface opens. Safe to edit. |
+| `refresh_all_providers_on_menu_open` | boolean | `false` | Legacy compatibility field. Nothing reads this flag — opening a tray/menu surface does not force-refresh. Leave it unchanged. |
 | `start_minimized` | boolean | `false` | Start minimized. Safe to edit. |
 | `start_at_login` | boolean | `false` | Start at Windows sign-in. Safe to edit. |
 | `show_notifications` | boolean | `true` | Show usage notifications. Safe to edit. |

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -213,7 +213,8 @@ pub struct Settings {
     /// Refresh interval in seconds (0 = manual only)
     pub refresh_interval_secs: u64,
 
-    /// Force-refresh enabled providers whenever the tray/menu surface opens.
+    /// Legacy compatibility field. Opening a tray/menu surface does not
+    /// force-refresh; nothing reads this flag.
     #[serde(default)]
     pub refresh_all_providers_on_menu_open: bool,
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`SETTINGS_JSON.md` still described `refresh_all_providers_on_menu_open` as **Safe to edit** ("force-refresh when a tray/menu surface opens"). Nothing reads the flag — settings only persist and round-trip it. GeneralTab already asserts the toggle is absent.

This documents the field as an ignored legacy compatibility key (same pattern as SBS-1052 / `float_bar_show_cost` / `menu_bar_*`) and updates the matching rustdoc and TypeScript snapshot comment so they no longer claim the flag is effective. No Settings UI was added; none exists for this key.

## Related issue

Cites SBS-1070.

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [x] Documentation
- [x] Other: rustdoc on persisted Settings field + TypeScript snapshot comment

## Validation

Hosted CI is the real gate. On this revision:

- `CI / Frontend` — passed
- `CI / Rust / shared` — passed (windows-latest)
- `CI / Rust / desktop` — passed (windows-latest)
- `CI / Rust` — passed
- CodeQL (actions / javascript-typescript / rust) — passed

`github-advanced-security` / "Code scanning AI findings" failed with `SessionModelError: You are not licensed to use Copilot`. That is a Copilot Autofind license failure, not a finding in this docs/comment change.

Local Windows `scripts\local-check.ps1` is not run on this Linux agent.

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` (Windows script; not run on this Linux agent)
- [x] Other: see hosted CI above, plus local frontend CI commands, `cargo fmt --all --check`, and `cargo test --manifest-path rust/Cargo.toml` (1185 lib + 32 bin).

## UI / tray proof

- [x] Not applicable

No UI or tray pixels changed. The GeneralTab toggle is already absent; this only stops the docs from saying the flag works.

## Notes for reviewers

The field stays in `settings.json` / `Settings` so existing files still load. This does not remove the dead key or invent a refresh-on-menu-open UI.

Do not merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99c0b5bc-72eb-46d5-80e8-08b645f4e889?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99c0b5bc-72eb-46d5-80e8-08b645f4e889&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document `refresh_all_providers_on_menu_open` as a legacy, unread flag
> Updates doc comments and notes across Rust settings, TypeScript bridge types, and the settings JSON reference to mark `refresh_all_providers_on_menu_open` as a legacy compatibility field that nothing reads. Opening a tray or menu surface does not force-refresh providers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c123700.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->