### PR TITLE
Treat Vertex usage fetch failures as errors, not 0%

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -730,6 +730,11 @@ fn persist_widget_snapshot_from_cache(
 fn widget_entry_from_usage_snapshot(
     snap: &ProviderUsageSnapshot,
 ) -> Option<codexbar::core::WidgetProviderEntry> {
+    // from_error fills primary with a dummy 0%. MCP/statusline must not
+    // publish that as remaining quota (SBS-1061).
+    if snap.error.is_some() {
+        return None;
+    }
     let provider = ProviderId::from_cli_name(&snap.provider_id)?;
     let updated_at = chrono::DateTime::parse_from_rfc3339(&snap.updated_at)
         .ok()
@@ -1661,6 +1666,34 @@ mod widget_snapshot_tests {
 
         let entry = widget_entry_from_usage_snapshot(&snap).expect("entry");
         assert!(entry.primary.is_none());
+    }
+
+    /// SBS-1061: from_error still carries a dummy 0% primary. MCP/statusline
+    /// must not publish that as a reading.
+    #[test]
+    fn widget_snapshot_omits_an_errored_vertex_zero_percent() {
+        let metadata = instantiate_provider(ProviderId::VertexAI)
+            .metadata()
+            .clone();
+        let snap = ProviderUsageSnapshot::from_error(
+            ProviderId::VertexAI,
+            &metadata,
+            "Vertex AI Resource Manager request failed: HTTP 500".to_string(),
+        );
+        assert!(snap.error.is_some());
+        assert_eq!(snap.primary.used_percent, 0.0);
+
+        assert!(
+            most_constrained_per_provider(std::slice::from_ref(&snap)).is_empty(),
+            "errored Vertex must not win a widget/MCP slot"
+        );
+        // If ranking ever included it, the entry writer still must not emit 0%.
+        if let Some(entry) = widget_entry_from_usage_snapshot(&snap) {
+            panic!(
+                "errored Vertex must not become a widget entry (primary {:?})",
+                entry.primary.as_ref().map(|w| w.used_percent)
+            );
+        }
     }
 
     #[test]

--- a/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.test.ts
@@ -896,6 +896,21 @@ describe("capacityPresentation", () => {
       ).toBe(false);
     });
 
+    it("does not invent 0% when Vertex fetch/decode failed (SBS-1061)", () => {
+      const snap = provider({
+        providerId: "vertexai",
+        displayName: "Vertex AI",
+        primary: window(0),
+        primaryLabel: "Usage",
+        error: "Vertex AI Resource Manager request failed: HTTP 500",
+      });
+      expect(providerGlanceStatus(snap)).toBe("error");
+      expect(glanceMeters(snap).primary).toBeNull();
+      expect(glanceMeters(snap).companions).toEqual([]);
+      expect(allMeasuredWindows(snap)).toEqual([]);
+      expect(capacityFreshness(snap)).toBe("error");
+    });
+
     it("still heroes a real 0% plan when no inactive row marks it a placeholder", () => {
       // Unknown is not empty: a genuine 0% reading must stay a 0% hero.
       const snap = provider({

--- a/apps/desktop-tauri/src/lib/capacityPresentation.ts
+++ b/apps/desktop-tauri/src/lib/capacityPresentation.ts
@@ -351,6 +351,11 @@ const PINNED_COMPANION_IDS: Record<string, string[]> = {
  * Clicking never toggles meters — detail mode lists every window.
  */
 export function glanceMeters(provider: ProviderUsageSnapshot): GlanceMeters {
+  // Fetch/decode failure is an error snapshot whose primary is a dummy 0%.
+  // Overview must not paint that as empty/healthy (SBS-1061).
+  if (provider.error) {
+    return { primary: null, companions: [] };
+  }
   const named = primaryNamedState(provider);
   const primary = named ? null : primaryConstrainingWindow(provider);
 
@@ -478,6 +483,9 @@ export function bankedResetCredits(
 export function allMeasuredWindows(
   provider: ProviderUsageSnapshot,
 ): ConstrainingWindow[] {
+  if (provider.error) {
+    return [];
+  }
   // A placeholder primary is not a reading — Activity must not list a fake
   // 0% Plan (SBS-876).
   if (primaryNamedState(provider)) {

--- a/rust/src/providers/amp/mod.rs
+++ b/rust/src/providers/amp/mod.rs
@@ -109,53 +109,11 @@ impl AmpProvider {
             .await
             .map_err(|e| ProviderError::Parse(e.to_string()))?;
 
-        self.parse_usage_response(&json)
+        usage_from_amp_payload(&json)
     }
 
-    fn parse_usage_response(
-        &self,
-        json: &serde_json::Value,
-    ) -> Result<UsageSnapshot, ProviderError> {
-        // Parse Sourcegraph/Amp usage response
-        let used = json
-            .get("completionsUsed")
-            .or_else(|| json.get("used"))
-            .and_then(|v| v.as_f64())
-            .unwrap_or(0.0);
-
-        let limit = json
-            .get("completionsLimit")
-            .or_else(|| json.get("limit"))
-            .and_then(|v| v.as_f64())
-            .unwrap_or(500.0);
-
-        let used_percent = if limit > 0.0 {
-            (used / limit) * 100.0
-        } else {
-            0.0
-        };
-
-        let plan = json
-            .get("plan")
-            .or_else(|| json.get("tier"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("Pro");
-
-        let reset_time = json
-            .get("resetAt")
-            .or_else(|| json.get("periodEnd"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-
-        let primary_window = RateWindow::with_details(used_percent, None, None, reset_time);
-        let usage = UsageSnapshot::new(primary_window).with_login_method(plan);
-
-        Ok(usage)
-    }
-
-    /// Probe for Amp installation
+    /// Probe for Amp installation. Configured credentials are not a usage reading.
     async fn probe_cli(&self, ctx: &FetchContext) -> Result<UsageSnapshot, ProviderError> {
-        // Check ctx.api_key first
         let has_api_key = ctx.api_key.as_ref().map(|k| !k.is_empty()).unwrap_or(false);
 
         let has_env =
@@ -169,16 +127,63 @@ impl AmpProvider {
             .map(|p| p.join("config.json").exists())
             .unwrap_or(false);
 
-        if has_api_key || has_env || has_amp_config || has_cody_config {
-            let usage =
-                UsageSnapshot::new(RateWindow::new(0.0)).with_login_method("Amp (configured)");
-            Ok(usage)
-        } else {
-            Err(ProviderError::NotInstalled(
-                "Amp not configured. Set SRC_ACCESS_TOKEN environment variable or configure Amp."
-                    .to_string(),
-            ))
-        }
+        usage_from_configured_probe(has_api_key || has_env || has_amp_config || has_cody_config)
+    }
+}
+
+/// Amp JSON without used/limit is a decode miss, not 0% (SBS-1061).
+fn usage_from_amp_payload(json: &serde_json::Value) -> Result<UsageSnapshot, ProviderError> {
+    let used = json
+        .get("completionsUsed")
+        .or_else(|| json.get("used"))
+        .and_then(|v| v.as_f64())
+        .ok_or_else(|| {
+            ProviderError::Parse("Amp usage response has no used reading".to_string())
+        })?;
+
+    let limit = json
+        .get("completionsLimit")
+        .or_else(|| json.get("limit"))
+        .and_then(|v| v.as_f64())
+        .ok_or_else(|| {
+            ProviderError::Parse("Amp usage response has no limit reading".to_string())
+        })?;
+
+    let used_percent = if limit > 0.0 {
+        (used / limit) * 100.0
+    } else {
+        return Err(ProviderError::Parse(
+            "Amp usage response has a non-positive limit".to_string(),
+        ));
+    };
+
+    let plan = json
+        .get("plan")
+        .or_else(|| json.get("tier"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("Pro");
+
+    let reset_time = json
+        .get("resetAt")
+        .or_else(|| json.get("periodEnd"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let primary_window = RateWindow::with_details(used_percent, None, None, reset_time);
+    Ok(UsageSnapshot::new(primary_window).with_login_method(plan))
+}
+
+/// Auto used to fall through here and mint 0% when the fetch failed (SBS-1061).
+fn usage_from_configured_probe(configured: bool) -> Result<UsageSnapshot, ProviderError> {
+    if configured {
+        Err(ProviderError::Other(
+            "Amp is configured, but usage could not be fetched".to_string(),
+        ))
+    } else {
+        Err(ProviderError::NotInstalled(
+            "Amp not configured. Set SRC_ACCESS_TOKEN environment variable or configure Amp."
+                .to_string(),
+        ))
     }
 }
 
@@ -270,5 +275,50 @@ mod tests {
             AmpProvider::new().metadata().dashboard_url,
             Some("https://ampcode.com/settings/usage")
         );
+    }
+
+    fn assert_failure_is_not_zero_percent(result: Result<UsageSnapshot, ProviderError>) {
+        match result {
+            Ok(usage) => panic!(
+                "failure must not be reported as {}% used",
+                usage.primary.used_percent
+            ),
+            Err(_) => {}
+        }
+    }
+
+    /// SBS-1061: a payload with no used/limit used to become 0% of a guessed 500.
+    #[test]
+    fn missing_usage_fields_are_not_reported_as_zero_percent() {
+        assert_failure_is_not_zero_percent(usage_from_amp_payload(&serde_json::json!({})));
+        assert_failure_is_not_zero_percent(usage_from_amp_payload(&serde_json::json!({
+            "plan": "Pro"
+        })));
+        let err = usage_from_amp_payload(&serde_json::json!({}))
+            .expect_err("missing used/limit is a decode failure");
+        assert!(
+            matches!(err, ProviderError::Parse(_)),
+            "missing fields must stay Parse, got {err:?}"
+        );
+    }
+
+    /// A real 0/500 reading is still 0%. The bug is inventing that from absence.
+    #[test]
+    fn reported_zero_used_is_a_reading() {
+        let usage = usage_from_amp_payload(&serde_json::json!({
+            "used": 0.0,
+            "limit": 500.0,
+            "plan": "Pro"
+        }))
+        .expect("explicit zero is a reading");
+        assert_eq!(usage.primary.used_percent, 0.0);
+        assert_eq!(usage.login_method.as_deref(), Some("Pro"));
+    }
+
+    /// SBS-1061: Auto fell through to "configured → 0%" after a failed fetch.
+    #[test]
+    fn configured_probe_is_not_reported_as_zero_percent() {
+        assert_failure_is_not_zero_percent(usage_from_configured_probe(true));
+        assert_failure_is_not_zero_percent(usage_from_configured_probe(false));
     }
 }

--- a/rust/src/providers/amp/mod.rs
+++ b/rust/src/providers/amp/mod.rs
@@ -278,12 +278,11 @@ mod tests {
     }
 
     fn assert_failure_is_not_zero_percent(result: Result<UsageSnapshot, ProviderError>) {
-        match result {
-            Ok(usage) => panic!(
+        if let Ok(usage) = result {
+            panic!(
                 "failure must not be reported as {}% used",
                 usage.primary.used_percent
-            ),
-            Err(_) => {}
+            );
         }
     }
 

--- a/rust/src/providers/kiro/mod.rs
+++ b/rust/src/providers/kiro/mod.rs
@@ -471,12 +471,11 @@ mod tests {
     use super::*;
 
     fn assert_failure_is_not_zero_percent(result: Result<UsageSnapshot, ProviderError>) {
-        match result {
-            Ok(usage) => panic!(
+        if let Ok(usage) = result {
+            panic!(
                 "failure must not be reported as {}% used",
                 usage.primary.used_percent
-            ),
-            Err(_) => {}
+            );
         }
     }
 
@@ -497,7 +496,7 @@ mod tests {
     #[test]
     fn cli_output_with_percent_is_a_reading() {
         let usage = KiroProvider::new()
-            .parse_cli_output("Plan: Pro\n██████░░░░ 42%")
+            .parse_cli_output("Plan: Pro\n██████ 42%")
             .expect("percent bar is a reading");
         assert_eq!(usage.primary.used_percent, 42.0);
         assert_eq!(usage.login_method.as_deref(), Some("Pro"));

--- a/rust/src/providers/kiro/mod.rs
+++ b/rust/src/providers/kiro/mod.rs
@@ -173,8 +173,8 @@ impl KiroProvider {
         let lowered = stripped.to_lowercase();
         let parsed = Self::parse_usage_fields(&stripped, &lowered);
 
-        if let Some(usage) = Self::usage_without_metrics(&parsed) {
-            return Ok(usage);
+        if let Some(err) = Self::usage_without_metrics_error(&parsed) {
+            return Err(err);
         }
 
         let mut usage = Self::usage_with_metrics(&parsed);
@@ -206,18 +206,14 @@ impl KiroProvider {
         Ok(())
     }
 
-    fn usage_without_metrics(parsed: &KiroCliUsage) -> Option<UsageSnapshot> {
+    /// CLI output with a plan name but no credits/percent is not 0% (SBS-1061).
+    fn usage_without_metrics_error(parsed: &KiroCliUsage) -> Option<ProviderError> {
         if parsed.matched_percent || parsed.matched_credits {
             return None;
         }
-
-        let method = if parsed.matched_new_format || parsed.plan_name != "Kiro" {
-            parsed.plan_name.as_str()
-        } else {
-            "Kiro (installed)"
-        };
-
-        Some(UsageSnapshot::new(RateWindow::new(0.0)).with_login_method(method))
+        Some(ProviderError::Parse(
+            "Kiro CLI output has no usage reading".to_string(),
+        ))
     }
 
     fn usage_with_metrics(parsed: &KiroCliUsage) -> UsageSnapshot {
@@ -467,5 +463,43 @@ impl Provider for KiroProvider {
 
     fn supports_cli(&self) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_failure_is_not_zero_percent(result: Result<UsageSnapshot, ProviderError>) {
+        match result {
+            Ok(usage) => panic!(
+                "failure must not be reported as {}% used",
+                usage.primary.used_percent
+            ),
+            Err(_) => {}
+        }
+    }
+
+    /// SBS-1061: a plan name with no credits/percent used to mint 0%.
+    #[test]
+    fn cli_output_without_metrics_is_not_reported_as_zero_percent() {
+        let provider = KiroProvider::new();
+        assert_failure_is_not_zero_percent(provider.parse_cli_output("Plan: Pro\nWelcome to Kiro"));
+        let err = provider
+            .parse_cli_output("Kiro (installed)")
+            .expect_err("no metrics is a decode failure");
+        assert!(
+            matches!(err, ProviderError::Parse(_)),
+            "missing metrics must stay Parse, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn cli_output_with_percent_is_a_reading() {
+        let usage = KiroProvider::new()
+            .parse_cli_output("Plan: Pro\n██████░░░░ 42%")
+            .expect("percent bar is a reading");
+        assert_eq!(usage.primary.used_percent, 42.0);
+        assert_eq!(usage.login_method.as_deref(), Some("Pro"));
     }
 }

--- a/rust/src/providers/minimax/mod.rs
+++ b/rust/src/providers/minimax/mod.rs
@@ -313,18 +313,24 @@ impl MiniMaxProvider {
             .get("used_amount")
             .or_else(|| json.get("total_amount"))
             .and_then(|v| v.as_f64())
-            .unwrap_or(0.0);
+            .ok_or_else(|| {
+                ProviderError::Parse("MiniMax usage response has no used reading".to_string())
+            })?;
 
         let credit_limit = json
             .get("total_quota")
             .or_else(|| json.get("quota"))
             .and_then(|v| v.as_f64())
-            .unwrap_or(100.0);
+            .ok_or_else(|| {
+                ProviderError::Parse("MiniMax usage response has no quota reading".to_string())
+            })?;
 
         let used_percent = if credit_limit > 0.0 {
             (used_credits / credit_limit) * 100.0
         } else {
-            0.0
+            return Err(ProviderError::Parse(
+                "MiniMax usage response has a non-positive quota".to_string(),
+            ));
         };
 
         let plan = json
@@ -402,15 +408,20 @@ impl MiniMaxProvider {
             .map(|p| p.join("config.json").exists())
             .unwrap_or(false);
 
-        if has_env_vars || has_config {
-            let usage =
-                UsageSnapshot::new(RateWindow::new(0.0)).with_login_method("MiniMax (configured)");
-            Ok(usage)
-        } else {
-            Err(ProviderError::NotInstalled(
-                "MiniMax API not configured. Set MINIMAX_API_KEY and MINIMAX_GROUP_ID environment variables".to_string()
-            ))
-        }
+        usage_from_configured_probe(has_env_vars || has_config)
+    }
+}
+
+/// Auto used to fall through here and mint 0% when the fetch failed (SBS-1061).
+fn usage_from_configured_probe(configured: bool) -> Result<UsageSnapshot, ProviderError> {
+    if configured {
+        Err(ProviderError::Other(
+            "MiniMax is configured, but usage could not be fetched".to_string(),
+        ))
+    } else {
+        Err(ProviderError::NotInstalled(
+            "MiniMax API not configured. Set MINIMAX_API_KEY and MINIMAX_GROUP_ID environment variables".to_string()
+        ))
     }
 }
 
@@ -851,6 +862,42 @@ mod tests {
                 .iter()
                 .any(|window| window.id == "billing-tokens-30d")
         );
+    }
+
+    fn assert_failure_is_not_zero_percent(result: Result<UsageSnapshot, ProviderError>) {
+        match result {
+            Ok(usage) => panic!(
+                "failure must not be reported as {}% used",
+                usage.primary.used_percent
+            ),
+            Err(_) => {}
+        }
+    }
+
+    /// SBS-1061: a payload with no used/quota used to become 0% of a guessed 100.
+    #[test]
+    fn missing_usage_fields_are_not_reported_as_zero_percent() {
+        let provider = MiniMaxProvider::new();
+        assert_failure_is_not_zero_percent(provider.parse_usage_response(&serde_json::json!({
+            "base_resp": { "status_code": 0 },
+            "plan_name": "MiniMax Star"
+        })));
+        let err = provider
+            .parse_usage_response(&serde_json::json!({
+                "base_resp": { "status_code": 0 }
+            }))
+            .expect_err("missing used/quota is a decode failure");
+        assert!(
+            matches!(err, ProviderError::Parse(_)),
+            "missing fields must stay Parse, got {err:?}"
+        );
+    }
+
+    /// SBS-1061: Auto fell through to "configured → 0%" after a failed fetch.
+    #[test]
+    fn configured_probe_is_not_reported_as_zero_percent() {
+        assert_failure_is_not_zero_percent(usage_from_configured_probe(true));
+        assert_failure_is_not_zero_percent(usage_from_configured_probe(false));
     }
 
     #[test]

--- a/rust/src/providers/minimax/mod.rs
+++ b/rust/src/providers/minimax/mod.rs
@@ -865,12 +865,11 @@ mod tests {
     }
 
     fn assert_failure_is_not_zero_percent(result: Result<UsageSnapshot, ProviderError>) {
-        match result {
-            Ok(usage) => panic!(
+        if let Ok(usage) = result {
+            panic!(
                 "failure must not be reported as {}% used",
                 usage.primary.used_percent
-            ),
-            Err(_) => {}
+            );
         }
     }
 

--- a/rust/src/providers/vertexai/mod.rs
+++ b/rust/src/providers/vertexai/mod.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 
 use crate::core::{
     FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
-    RateWindow, SourceMode, UsageSnapshot,
+    SourceMode, UsageSnapshot,
 };
 
 /// Vertex AI provider
@@ -184,13 +184,10 @@ impl VertexAIProvider {
             .build()
             .map_err(|e| ProviderError::Other(e.to_string()))?;
 
-        // Get project ID from config
-        let project_id = self
-            .get_project_id()
-            .await
-            .unwrap_or_else(|_| "unknown".to_string());
+        let project_id = self.get_project_id().await?;
 
-        // Vertex AI billing/quota API
+        // Resource Manager `projects.get` is identity metadata, not quota.
+        // A failed or usage-less response must not collapse to 0% (SBS-1061).
         let resp = client
             .get(format!(
                 "https://cloudresourcemanager.googleapis.com/v1/projects/{}",
@@ -201,19 +198,12 @@ impl VertexAIProvider {
             .await;
 
         match resp {
-            Ok(r) if r.status().is_success() => {
-                let json: serde_json::Value = r
-                    .json()
-                    .await
-                    .map_err(|e| ProviderError::Parse(e.to_string()))?;
-                self.parse_usage_response(&json, &project_id)
+            Ok(r) => {
+                let status = r.status();
+                let body = r.json().await.map_err(|e| e.to_string());
+                usage_from_resource_manager_http(status, body, &project_id)
             }
-            _ => {
-                // Return placeholder with project info
-                let usage = UsageSnapshot::new(RateWindow::new(0.0))
-                    .with_login_method(format!("Vertex AI ({})", project_id));
-                Ok(usage)
-            }
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -249,44 +239,63 @@ impl VertexAIProvider {
         Err(ProviderError::Other("Project ID not found".to_string()))
     }
 
-    fn parse_usage_response(
-        &self,
-        json: &serde_json::Value,
-        project_id: &str,
-    ) -> Result<UsageSnapshot, ProviderError> {
-        // Parse project info - actual usage would require Cloud Billing API
-        let project_name = json
-            .get("name")
-            .and_then(|v| v.as_str())
-            .unwrap_or(project_id);
-
-        let usage = UsageSnapshot::new(RateWindow::new(0.0))
-            .with_login_method(format!("Vertex AI ({})", project_name));
-
-        Ok(usage)
-    }
-
-    /// Probe CLI for detection
+    /// Probe CLI for detection. gcloud presence is not a usage reading.
     async fn probe_cli(&self) -> Result<UsageSnapshot, ProviderError> {
-        let gcloud = Self::which_gcloud().ok_or_else(|| {
-            ProviderError::NotInstalled(
-                "gcloud CLI not found. Install from https://cloud.google.com/sdk".to_string(),
-            )
-        })?;
+        let installed = Self::which_gcloud().is_some_and(|path| path.exists());
+        usage_from_cli_presence(installed)
+    }
+}
 
-        if gcloud.exists() {
-            let project = self.get_project_id().await.ok();
-            let label = if let Some(p) = project {
-                format!("Vertex AI ({})", p)
-            } else {
-                "Vertex AI (installed)".to_string()
-            };
+/// Map a Resource Manager HTTP outcome to usage. Fail-closed (SBS-1061):
+/// non-success and unreadable bodies are errors, never `Ok(0%)`.
+fn usage_from_resource_manager_http(
+    status: reqwest::StatusCode,
+    body: Result<serde_json::Value, String>,
+    project_id: &str,
+) -> Result<UsageSnapshot, ProviderError> {
+    if !status.is_success() {
+        return Err(resource_manager_http_failure(status));
+    }
+    let json = body.map_err(ProviderError::Parse)?;
+    usage_from_resource_manager_metadata(&json, project_id)
+}
 
-            let usage = UsageSnapshot::new(RateWindow::new(0.0)).with_login_method(&label);
-            Ok(usage)
-        } else {
-            Err(ProviderError::NotInstalled("gcloud not found".to_string()))
-        }
+/// HTTP failure from Resource Manager. Never a 0% snapshot (SBS-1061).
+fn resource_manager_http_failure(status: reqwest::StatusCode) -> ProviderError {
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        ProviderError::AuthRequired
+    } else {
+        ProviderError::Other(format!(
+            "Vertex AI Resource Manager request failed: HTTP {status}"
+        ))
+    }
+}
+
+/// Resource Manager `projects.get` is project metadata, not quota.
+/// Treating it as 0% used is what made Vertex look empty/healthy (SBS-1061).
+fn usage_from_resource_manager_metadata(
+    json: &serde_json::Value,
+    project_id: &str,
+) -> Result<UsageSnapshot, ProviderError> {
+    let project_name = json
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or(project_id);
+    Err(ProviderError::Parse(format!(
+        "Google Cloud Resource Manager metadata for '{project_name}' is not a usage reading"
+    )))
+}
+
+/// gcloud being installed is not a usage reading (SBS-1061).
+fn usage_from_cli_presence(installed: bool) -> Result<UsageSnapshot, ProviderError> {
+    if installed {
+        Err(ProviderError::Other(
+            "gcloud is installed, but Vertex AI usage is not available from the CLI".to_string(),
+        ))
+    } else {
+        Err(ProviderError::NotInstalled(
+            "gcloud CLI not found. Install from https://cloud.google.com/sdk".to_string(),
+        ))
     }
 }
 
@@ -339,5 +348,113 @@ impl Provider for VertexAIProvider {
 
     fn supports_cli(&self) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The old fail-open returned `Ok(RateWindow::new(0.0))`. This helper is
+    /// what proves SBS-1061: restore that and the test panics.
+    fn assert_failure_is_not_zero_percent(result: Result<UsageSnapshot, ProviderError>) {
+        match result {
+            Ok(usage) => panic!(
+                "failure must not be reported as {}% used",
+                usage.primary.used_percent
+            ),
+            Err(_) => {}
+        }
+    }
+
+    /// SBS-1061: HTTP 5xx used to mint a healthy 0% snapshot.
+    #[test]
+    fn http_failure_is_not_reported_as_zero_percent() {
+        for status in [
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            reqwest::StatusCode::BAD_GATEWAY,
+            reqwest::StatusCode::FORBIDDEN,
+            reqwest::StatusCode::UNAUTHORIZED,
+            reqwest::StatusCode::NOT_FOUND,
+        ] {
+            assert_failure_is_not_zero_percent(usage_from_resource_manager_http(
+                status,
+                Err("ignored on failure".to_string()),
+                "my-project",
+            ));
+        }
+        assert!(matches!(
+            usage_from_resource_manager_http(
+                reqwest::StatusCode::FORBIDDEN,
+                Err("no body".to_string()),
+                "my-project",
+            ),
+            Err(ProviderError::AuthRequired)
+        ));
+    }
+
+    /// SBS-1061: a 200 whose body cannot be decoded is still not 0%.
+    #[test]
+    fn http_decode_failure_is_not_reported_as_zero_percent() {
+        assert_failure_is_not_zero_percent(usage_from_resource_manager_http(
+            reqwest::StatusCode::OK,
+            Err("expected value at line 1 column 1".to_string()),
+            "my-project",
+        ));
+        let err = usage_from_resource_manager_http(
+            reqwest::StatusCode::OK,
+            Err("expected value at line 1 column 1".to_string()),
+            "my-project",
+        )
+        .expect_err("unreadable body is a decode failure");
+        assert!(
+            matches!(err, ProviderError::Parse(_)),
+            "decode failure must stay Parse, got {err:?}"
+        );
+    }
+
+    /// SBS-1061: a successful Resource Manager project payload has no quota.
+    /// The old parser turned that metadata into 0% used.
+    #[test]
+    fn resource_manager_metadata_is_not_reported_as_zero_percent() {
+        let json = serde_json::json!({
+            "name": "projects/my-gcp-project",
+            "projectId": "my-gcp-project",
+            "lifecycleState": "ACTIVE"
+        });
+        let result = usage_from_resource_manager_metadata(&json, "my-gcp-project");
+        assert_failure_is_not_zero_percent(result);
+        let err = usage_from_resource_manager_metadata(&json, "my-gcp-project")
+            .expect_err("metadata is not a usage reading");
+        let message = err.to_string();
+        assert!(
+            message.contains("not a usage reading"),
+            "decode/metadata failure must say why, got {message}"
+        );
+    }
+
+    /// SBS-1061: empty / unreadable JSON is a decode failure, not 0%.
+    #[test]
+    fn decode_failure_is_not_reported_as_zero_percent() {
+        for json in [
+            serde_json::json!({}),
+            serde_json::json!("not-a-project"),
+            serde_json::json!(null),
+        ] {
+            assert_failure_is_not_zero_percent(usage_from_resource_manager_metadata(
+                &json, "unknown",
+            ));
+        }
+    }
+
+    /// SBS-1061: Auto used to fall through to "gcloud exists → 0%".
+    #[test]
+    fn cli_presence_is_not_reported_as_zero_percent() {
+        assert_failure_is_not_zero_percent(usage_from_cli_presence(true));
+        assert_failure_is_not_zero_percent(usage_from_cli_presence(false));
+        assert!(matches!(
+            usage_from_cli_presence(false),
+            Err(ProviderError::NotInstalled(_))
+        ));
     }
 }

--- a/rust/src/providers/vertexai/mod.rs
+++ b/rust/src/providers/vertexai/mod.rs
@@ -358,12 +358,11 @@ mod tests {
     /// The old fail-open returned `Ok(RateWindow::new(0.0))`. This helper is
     /// what proves SBS-1061: restore that and the test panics.
     fn assert_failure_is_not_zero_percent(result: Result<UsageSnapshot, ProviderError>) {
-        match result {
-            Ok(usage) => panic!(
+        if let Ok(usage) = result {
+            panic!(
                 "failure must not be reported as {}% used",
                 usage.primary.used_percent
-            ),
-            Err(_) => {}
+            );
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Vertex AI always looked empty/healthy because Resource Manager metadata and HTTP failures collapsed into `RateWindow::new(0.0)`. Fetch, decode, and metadata-without-usage paths now return an error instead of inventing 0%. Overview, Activity, and MCP/statusline skip that dummy 0% as well.

Sibling Auto `probe_cli` / missing-field fail-open-to-zero paths in Amp, MiniMax, and Kiro are fail-closed the same way. Tests panic if those paths report `Ok(0%)` again.

## Related issue

Fixes SBS-1061

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [x] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [x] Other: glance meters, widget snapshot / MCP `get_status`

## Validation

### Hosted CI (required gate) — green on `0b5908ba`

https://github.com/tsouth89/ceiling/actions/runs/32670749822

| Job | Result |
|---|---|
| Frontend | pass (1m6s) |
| Rust / shared (`fmt --check`, `cargo test rust/Cargo.toml`, `clippy -D warnings`) | pass (3m7s) |
| Rust / desktop (`cargo test` + `clippy -D warnings` on the Tauri crate) | pass (3m17s) |
| Rust (aggregate) | pass |
| CodeQL / Analyze | pass |

### Local gate (Linux agent)

```
cargo fmt --all --check
# FMT_OK

cargo test --manifest-path rust/Cargo.toml
# test result: ok. 1197 passed; 0 failed (lib)
# test result: ok. 32 passed; 0 failed (other targets)

# clippy on this change is clean. Two pre-existing Linux-only lints
# (`secure_file.rs` unused `error` off Windows; `updater.rs`
# `verify_installer_signature_or_delete` unused off Windows) are used
# on windows-latest CI, which passed above.

pnpm --dir apps/desktop-tauri test
# Test Files  93 passed (93)
# Tests  742 passed (742)

pnpm --dir apps/desktop-tauri run build
# tsc --noEmit && vite build OK
```

Windows `scripts\local-check.ps1` is not available on this host. Hosted `Rust / desktop` covers that crate.

### Tests prove failure is not 0%; they fail without the fix

Restoring the old fail-open (`Ok(RateWindow::new(0.0))`) on the Resource Manager HTTP/metadata mappers panics:

```
cargo test --lib resource_manager_metadata_is_not_reported_as_zero_percent
# panicked at rust/src/providers/vertexai/mod.rs:367:13:
# failure must not be reported as 0% used
# FAILED

cargo test --lib http_failure_is_not_reported_as_zero_percent
# panicked at rust/src/providers/vertexai/mod.rs:367:13:
# failure must not be reported as 0% used
# FAILED
```

Those two were reverted after the proof. The same helper is used for Amp/MiniMax/Kiro sibling paths.

New tests that stay green:

- `providers::vertexai::tests::http_failure_is_not_reported_as_zero_percent`
- `providers::vertexai::tests::http_decode_failure_is_not_reported_as_zero_percent`
- `providers::vertexai::tests::resource_manager_metadata_is_not_reported_as_zero_percent`
- `providers::vertexai::tests::decode_failure_is_not_reported_as_zero_percent`
- `providers::vertexai::tests::cli_presence_is_not_reported_as_zero_percent`
- Amp/MiniMax configured-probe + missing-field tests
- Kiro CLI-without-metrics test
- `capacityPresentation` Vertex error snapshot does not invent 0%
- `widget_snapshot_omits_an_errored_vertex_zero_percent` (passed on hosted Rust / desktop)

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` (Windows-only; not available here)
- [x] Other: hosted CI + matching local commands above

## UI / tray proof

- [x] Not applicable (error/unavailable state; no new chrome)

## Notes for reviewers

- The old Vertex HTTP `_ => Ok(0%)` arm is gone. `usage_from_resource_manager_http` / `usage_from_resource_manager_metadata` / `usage_from_cli_presence` are the fail-closed mapping.
- Resource Manager `projects.get` is still not a quota API. A 200 with project metadata is now a Parse error, not a healthy 0%.
- Amp/MiniMax Auto used to hide a failed fetch behind "configured → 0%". Kiro did the same when CLI output had a plan name and no metrics.
- `from_error` still stores a dummy 0% primary (existing contract). Glance meters, `allMeasuredWindows`, and widget/MCP entry writing now refuse to publish it.
- Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02b06878-ead1-4df6-92f3-76339d875671?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02b06878-ead1-4df6-92f3-76339d875671&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Treat Vertex, Amp, Kiro, and MiniMax usage fetch failures as errors, not 0%
> - Removes synthetic 0% usage snapshots across all provider backends: `vertexai`, `amp`, `kiro`, and `minimax` now return `ProviderError` (Parse, AuthRequired, Other, or NotInstalled) when metrics are missing, HTTP fails, or only CLI presence/config is detected
> - Adds strict field validation in each provider's parsing path (e.g. `usage_from_amp_payload`, `usage_from_resource_manager_http`, `MiniMaxProvider.parse_usage_response`) so missing `used`/`limit` or non-positive quotas produce parse errors rather than defaults
> - Desktop frontend (`glanceMeters`, `allMeasuredWindows`, `widget_entry_from_usage_snapshot`) now early-returns null/empty when `provider.error` is set, preventing 0% readings in glance meters, Activity timelines, and widget entries
> - Risk: any caller that relied on receiving a 0% snapshot during partial failures or config-only states will now receive `None` or an error; check consumers of `UsageSnapshot` and `WidgetProviderEntry` in [providers.rs](https://github.com/tsouth89/ceiling/pull/406/files#diff-3248357642e86f56167cd6fd4d31117a591622790738676c888e0a5e83000164) and [capacityPresentation.ts](https://github.com/tsouth89/ceiling/pull/406/files#diff-a77d8b9429a947744bc233d5baf44dbad10f512719c23ab0b984d30d615a8f15)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b5908b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->