### PR TITLE
Include directory account_id in observation_scope (SBS-1079)

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/capacity_events.rs
+++ b/apps/desktop-tauri/src-tauri/src/capacity_events.rs
@@ -920,14 +920,22 @@ fn normalize_window_id(value: &str) -> String {
 }
 
 pub(crate) fn observation_scope(snapshot: &ProviderUsageSnapshot) -> String {
-    // Scope by BOTH account identifiers, not either/or: the same email can
+    // Scope by every account identifier, not either/or: the same email can
     // belong to different organizations (e.g. a personal vs a business
     // workspace) with distinct limits, and those must never share a baseline.
+    // Directory seats that share a login email (Codex personal + Team) also
+    // stamp distinct `account_id`s; omitting that id collapsed them (SBS-1079).
     let email = snapshot.account_email.as_deref().unwrap_or("");
     let organization = snapshot.account_organization.as_deref().unwrap_or("");
+    let account_id = snapshot
+        .account_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("");
     let raw = format!(
-        "{}|{}|{}|{}",
-        snapshot.provider_id, snapshot.source_label, email, organization
+        "{}|{}|{}|{}|{}",
+        snapshot.provider_id, snapshot.source_label, email, organization, account_id
     );
     format!("{}:{:016x}", snapshot.provider_id, fnv1a64(raw.as_bytes()))
 }
@@ -1552,6 +1560,84 @@ mod tests {
         );
         other.account_email = Some("other@example.com".into());
         assert!(observer.observe(&other).is_empty());
+    }
+
+    /// Two Codex directory seats can share a login email (personal + Team).
+    /// After #379 they stamp distinct `account_id`s; usage_history, threshold
+    /// toasts, and predictive pace already key on those. Capacity-event
+    /// observation used to hash provider|source|email|org only, so both seats
+    /// shared a baseline (SBS-1079).
+    fn shared_email_directory_seats(
+        at: DateTime<Utc>,
+        used: f64,
+        reset: DateTime<Utc>,
+        account_id: &str,
+    ) -> ProviderUsageSnapshot {
+        let mut seat = snapshot(at, used, reset);
+        seat.account_email = Some("Same@Example.com".into());
+        seat.account_organization = Some("Team".into());
+        seat.account_id = Some(account_id.into());
+        seat
+    }
+
+    #[test]
+    fn observation_scope_separates_directory_seats_that_share_an_email() {
+        let now = Utc::now();
+        let reset = now + Duration::hours(4);
+        let personal = shared_email_directory_seats(now, 90.0, reset, "acct-personal");
+        let work = shared_email_directory_seats(now, 10.0, reset, "acct-work");
+
+        assert_ne!(observation_scope(&personal), observation_scope(&work));
+        assert_eq!(
+            observation_scope(&personal),
+            observation_scope(&shared_email_directory_seats(
+                now + Duration::minutes(1),
+                91.0,
+                reset,
+                "acct-personal",
+            ))
+        );
+    }
+
+    #[test]
+    fn shared_email_directory_seats_do_not_confirm_each_others_resets() {
+        // Without account_id in the scope, the work seat's drop from the
+        // personal baseline looks like a confirmed surprise reset.
+        let start = Utc::now();
+        let old_reset = start + Duration::hours(4);
+        let new_reset = start + Duration::hours(9);
+        let mut observer = CapacityEventObserver::default();
+
+        assert!(
+            observer
+                .observe(&shared_email_directory_seats(
+                    start,
+                    85.0,
+                    old_reset,
+                    "acct-personal",
+                ))
+                .is_empty()
+        );
+        assert!(
+            observer
+                .observe(&shared_email_directory_seats(
+                    start + Duration::minutes(5),
+                    10.0,
+                    new_reset,
+                    "acct-work",
+                ))
+                .is_empty()
+        );
+        let events = observer.observe(&shared_email_directory_seats(
+            start + Duration::minutes(10),
+            12.0,
+            new_reset + Duration::minutes(2),
+            "acct-work",
+        ));
+        assert!(
+            events.is_empty(),
+            "shared-email seats must not share a capacity baseline: {events:?}"
+        );
     }
 
     #[test]

--- a/apps/desktop-tauri/src-tauri/src/enforcement.rs
+++ b/apps/desktop-tauri/src-tauri/src/enforcement.rs
@@ -8,12 +8,13 @@
 //! quietly drop out. Surfaces can then show honest uncertainty instead of
 //! silently losing a limit or fabricating a percentage for it.
 //!
-//! Scope is `provider | data source | account identity` (shared with the
-//! capacity-event observer), so accounts, sources, and providers never bleed
-//! into each other. State is process-local: the first read of each scope after
-//! launch is a fresh baseline that never emits `unavailable`, mirroring the
-//! observer's re-baseline-on-launch behaviour so changes that happened while
-//! Ceiling was closed are not replayed as surprises.
+//! Scope is `provider | data source | account identity` including directory
+//! `account_id` (shared with the capacity-event observer), so accounts,
+//! sources, and providers never bleed into each other. State is process-local:
+//! the first read of each scope after launch is a fresh baseline that never
+//! emits `unavailable`, mirroring the observer's re-baseline-on-launch
+//! behaviour so changes that happened while Ceiling was closed are not
+//! replayed as surprises.
 
 use std::collections::HashMap;
 
@@ -368,6 +369,29 @@ mod tests {
         other_org.secondary_label = None;
         assert!(tracker.annotate(&mut other_org).is_empty());
         assert!(other_org.inactive_rate_windows.is_empty());
+    }
+
+    #[test]
+    fn shared_email_directory_seats_do_not_flag_each_other() {
+        // Codex personal + Team seats share a login email and can share an
+        // organization label; directory `account_id` is what keeps their
+        // enforcement baselines apart (SBS-1079). Without it, the work seat's
+        // first read would inherit the personal seat's expected windows.
+        let mut tracker = EnforcementTracker::new();
+        let mut personal = codex_snapshot();
+        personal.account_email = Some("Same@Example.com".into());
+        personal.account_organization = Some("Team".into());
+        personal.account_id = Some("acct-personal".into());
+        tracker.annotate(&mut personal);
+
+        let mut work = codex_snapshot();
+        work.account_email = Some("Same@Example.com".into());
+        work.account_organization = Some("Team".into());
+        work.account_id = Some("acct-work".into());
+        work.secondary = None;
+        work.secondary_label = None;
+        assert!(tracker.annotate(&mut work).is_empty());
+        assert!(work.inactive_rate_windows.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`observation_scope` (shared by capacity-event observation and enforcement tracking) hashed only `provider|source|email|org`. Codex directory seats that share a login email — personal + Team — therefore shared one baseline. A drop on the Team seat looked like a confirmed surprise reset of the personal seat, and a missing core window on one seat was flagged `unavailable` on the other.

Directory `snapshot.account_id` is now part of that hash, matching isolation already in place for `usage_history`, threshold toasts, and post-SBS-1057 predictive pace.

## Related issue

Fixes SBS-1079 (incomplete SBS-1057).

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [x] Other: capacity-event observer + enforcement tracker scope keys

## Validation

Hosted CI is the main frontend and Rust gate (Windows for Rust jobs).

- [x] New tests fail without the `account_id` field (same hash `codex:f9a966f77f51ccff`, false `SurpriseReset` 85%→10%, false `unavailable` on Weekly) and pass with it
- [x] Local `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` — 620 passed
- [x] Local `cargo test --manifest-path rust/Cargo.toml` — passed
- [x] Local `cargo fmt --all --check` — passed
- [x] Local frontend CI steps: `node --test worker.test.mjs`, version-sync check, `pnpm test`, `pnpm build` — passed
- [x] GitHub CI on this PR — all checks green, including Frontend, Rust / shared, Rust / desktop, Rust aggregator, CodeQL
- [ ] `powershell.exe ... scripts\local-check.ps1` — Windows-only; not run here (covered by hosted Rust jobs)

## UI / tray proof

- [x] Not applicable

## Notes for reviewers

The new tests are the regression: two Codex seats with the same email, org, and source but different directory `account_id`s. Without this change they collide.

Ambient seats (`account_id` empty) still hash with an empty fifth field, so persisted baselines for those seats re-key once after upgrade (first live read is a fresh baseline, same as a new scope). Directory seats that were colliding get distinct keys immediately.

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a1331e1-c338-4610-b49b-5692efc25b00?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a1331e1-c338-4610-b49b-5692efc25b00&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include directory `account_id` in `observation_scope` and enforcement scope
> - Adds trimmed, non-empty `account_id` to the scope hash in [capacity_events.rs](https://github.com/tsouth89/ceiling/pull/407/files#diff-9e42248ff2536d3ab4b6e257fa7c6631912296ad45893a93472b2adc61573c8b) and to the enforcement identity scope in [enforcement.rs](https://github.com/tsouth89/ceiling/pull/407/files#diff-e20de83b4148bffc6089ea1cae0682b3c624fbd52842bbce7f86d1fac1feb228)
> - Prevents directory seats sharing the same provider, source, email, and organization from inheriting each other's capacity-event baselines or expected-window enforcement state
> - Whitespace-only or empty `account_id` values are treated as absent, preserving prior behavior for snapshots without an account ID
> - Adds test fixtures and scenarios verifying distinct account IDs produce distinct scopes and that reset confirmations do not cross-contaminate between seats
> - Risk: any out-of-tree code relying on scope hashes being stable without `account_id` will see different hashes for the same snapshot; in-tree readers in `capacity_events.rs` and `enforcement.rs` are updated
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5c57ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->