### PR TITLE
Document the serve HTTP endpoints

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -148,6 +148,50 @@ TOKEN="$(cat "${XDG_CONFIG_HOME:-$HOME/.config}/Ceiling/serve.token")"
 curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/usage
 ```
 
+### HTTP endpoints
+
+The server binds to `127.0.0.1` only and additionally rejects any request whose `Host` header is not local (`127.0.0.1`, `localhost`, or `[::1]`), so it is not reachable from other machines. It is read-only: every route answers `GET` and no route mutates any state. `/usage` and `/cost` require the bearer token described above unless `--allow-unauthenticated` is set; `/health` never requires it.
+
+| Route | Description |
+|---|---|
+| `GET /health` | Liveness check with the server version. Unauthenticated. |
+| `GET /usage` | Usage snapshot per provider. Optional `provider` query param. |
+| `GET /cost` | Local token-cost scan per provider. Optional `provider` query param. |
+
+The `provider` query parameter accepts a provider CLI name (for example `claude` or `codex`), `both` (Codex and Claude), or `all` (every provider). When omitted, the providers enabled in Settings are queried.
+
+`/usage` and `/cost` return a JSON array with one object per requested provider. A provider that fails to fetch reports an error inside its own array entry — the HTTP status is still `200` — and without `--include-identity` that error text is normalized to `"provider request failed"`. `/cost` reads local session logs and supports only Claude, Codex, and Grok; any other provider's entry has `"supported": false`. The scan window is fixed at 30 days (the `cost` subcommand's `--days` flag does not apply here).
+
+Error responses are JSON of the shape `{ "error": "<message>" }`:
+
+| Status | When |
+|---|---|
+| `400` | Malformed request, missing or duplicate `Host` header, or unknown `provider` value. |
+| `401` | Missing or wrong bearer token on `/usage` or `/cost`. |
+| `403` | Non-local `Host` header. |
+| `404` | Unknown path. |
+| `405` | Any method other than `GET`. |
+| `409` | Default provider selection while no providers are enabled (`"code": "no_enabled_providers"`). |
+| `503` | More than 8 concurrent connections. |
+
+Examples (`$TOKEN` as read in the example above):
+
+```sh
+curl http://127.0.0.1:8080/health
+# {"status":"ok","version":"1.5.36"}
+
+curl -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8080/cost?provider=claude"
+# [{"by_model":{...},"cost":{"currency":"USD","total_usd":42.13},
+#   "days_scanned":30,"provider":"claude","sessions_count":57,
+#   "supported":true,
+#   "tokens":{"cached":345678,"input":1234567,"output":89012}}]
+
+curl -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8080/usage?provider=all"
+# [{"provider":"claude","source":"web","usage":{...},"cost":{...}},
+#  {"provider":"codex","source":"cli","usage":{...},"cost":{...}},
+#  ...]
+```
+
 ## `statusline`
 
 Print one compact usage line for an editor status bar. Cache-only.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -150,7 +150,7 @@ curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/usage
 
 ### HTTP endpoints
 
-The server binds to `127.0.0.1` only and additionally rejects any request whose `Host` header is not local (`127.0.0.1`, `localhost`, or `[::1]`), so it is not reachable from other machines. It is read-only: every route answers `GET` and no route mutates any state. `/usage` and `/cost` require the bearer token described above unless `--allow-unauthenticated` is set; `/health` never requires it.
+The server binds to `127.0.0.1` only and additionally rejects any request whose `Host` header is not local (`127.0.0.1`, `localhost`, or `[::1]`), so it is not reachable from other machines. It is read-only: every route answers `GET` and no route mutates usage or account data (successful `/usage` and `/cost` responses do update the response cache described under `--refresh-interval`). `/usage` and `/cost` require the bearer token described above unless `--allow-unauthenticated` is set; `/health` never requires it.
 
 | Route | Description |
 |---|---|
@@ -162,7 +162,7 @@ The `provider` query parameter accepts a provider CLI name (for example `claude`
 
 `/usage` and `/cost` return a JSON array with one object per requested provider. A provider that fails to fetch reports an error inside its own array entry — the HTTP status is still `200` — and without `--include-identity` that error text is normalized to `"provider request failed"`. `/cost` reads local session logs and supports only Claude, Codex, and Grok; any other provider's entry has `"supported": false`. The scan window is fixed at 30 days (the `cost` subcommand's `--days` flag does not apply here).
 
-Error responses are JSON of the shape `{ "error": "<message>" }`:
+Error responses are JSON of the shape `{ "error": "<message>" }`; the `409` additionally carries a `"code"` field:
 
 | Status | When |
 |---|---|


### PR DESCRIPTION
Closes #83.

Extends the `## serve` section of `docs/CLI.md` with a `### HTTP endpoints` subsection, per your comment on the issue — no separate `docs/SERVE.md`, and nothing else in the section touched.

What it documents:

- The three routes (`GET /health`, `GET /usage`, `GET /cost`) and the `provider` query param, including `both` / `all` and the default of querying the providers enabled in Settings when the param is omitted.
- The full error surface as a table: `400`, `401` (bearer token on `/usage` and `/cost`, `/health` exempt), `403` (non-local `Host`), `404`, `405`, `409` (`no_enabled_providers`), `503` (connection cap).
- Array response semantics: one object per requested provider, per-provider fetch errors reported inside the entry with the HTTP status still `200`, and error text normalized to `"provider request failed"` without `--include-identity`.
- `/cost` scope: Claude, Codex, and Grok; `"supported": false` for the rest; fixed 30-day window (the `cost` subcommand's `--days` flag does not apply).
- The local-only posture: the `127.0.0.1` bind plus the `Host`-header check, and that every route is read-only.
- Three `curl` examples with sample JSON shapes, reusing the `$TOKEN` from the existing example above rather than repeating the token setup.

One note: your heads-up about the `--refresh-interval` prose resolved itself while this was in flight — #398 wired the cache up, so the section is written against current behavior (post-#398/#325, v1.5.36) and doesn't touch the flag descriptions.

How verified (docs-only change, so verification was against the running server):

```
cargo build --manifest-path rust/Cargo.toml -p codexbar
target/debug/codexbar serve --port 8124
```

Then curl-checked every documented behavior against the built 1.5.36 binary: `/health` unauthenticated (response matches the docs example verbatim), `401` for both a missing and a wrong bearer token, `400` on an unknown provider, `403` via a forged `Host: example.com`, `404`, `405`, `/cost?provider=claude` matching the documented shape and key order, and `/cost?provider=grok` returning `"supported": true`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add HTTP endpoints section to `docs/CLI.md`
> Documents the serve HTTP API: routes (`GET /health`, `GET /usage`, `GET /cost`), the `provider` query parameter, and response shapes including per-provider error reporting. Also covers the 30-day scan window limit, supported providers for `/cost`, the standardized JSON error format with status-specific conditions (400, 401, 403, 404, 405, 409, 503), and example curl invocations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8337efa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the local server’s HTTP API.
  * Clarified available read-only routes, authentication, provider selection, response formats, and error handling.
  * Documented localhost binding, Host validation, supported cost providers, concurrency limits, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->