### PR TITLE
Add GPT-6 Astra pricing

### DIFF
--- a/rust/src/core/cost_pricing.rs
+++ b/rust/src/core/cost_pricing.rs
@@ -342,6 +342,20 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
         },
     );
 
+    // GPT-6 Astra standard rates. Codex usage of Astra does not incur the
+    // >272K long-context multipliers and Codex does not charge cache writes,
+    // so the short-context rates apply at every context size.
+    m.insert(
+        "gpt-6-astra",
+        CodexPricing {
+            input_cost_per_token: 1e-5,
+            output_cost_per_token: 5e-5,
+            cache_read_input_cost_per_token: 1e-6,
+            display_label: None,
+            long_context: None,
+        },
+    );
+
     m
 });
 
@@ -667,6 +681,10 @@ impl CostUsagePricing {
 
         if trimmed == "gpt-5.6" {
             return "gpt-5.6-sol".to_string();
+        }
+
+        if trimmed == "gpt-6" {
+            return "gpt-6-astra".to_string();
         }
 
         trimmed

--- a/rust/src/core/cost_pricing_tests.rs
+++ b/rust/src/core/cost_pricing_tests.rs
@@ -311,6 +311,36 @@ fn test_normalize_codex_model() {
 }
 
 #[test]
+fn gpt_6_astra_normalizes_variants_and_prices_published_rates() {
+    assert_eq!(
+        CostUsagePricing::normalize_codex_model("gpt-6-astra"),
+        "gpt-6-astra"
+    );
+    assert_eq!(
+        CostUsagePricing::normalize_codex_model("gpt-6-astra-2026-09-04"),
+        "gpt-6-astra"
+    );
+    assert_eq!(
+        CostUsagePricing::normalize_codex_model("gpt-6-astra-codex"),
+        "gpt-6-astra"
+    );
+    assert_eq!(
+        CostUsagePricing::normalize_codex_model("gpt-6"),
+        "gpt-6-astra"
+    );
+
+    // Standard API rates: $10 input / $1 cached input / $50 output per 1M.
+    let full = CostUsagePricing::codex_cost_usd("gpt-6-astra", 1_000_000, 0, 1_000_000);
+    assert_close(full.unwrap(), 60.0);
+    let half_cached = CostUsagePricing::codex_cost_usd("gpt-6-astra", 2_000_000, 1_000_000, 0);
+    assert_close(half_cached.unwrap(), 11.0);
+
+    // Codex does not apply Astra long-context multipliers above 272K.
+    let long_input = CostUsagePricing::codex_cost_usd("gpt-6-astra", 300_000, 0, 0);
+    assert_close(long_input.unwrap(), 3.0);
+}
+
+#[test]
 fn codex_variant_pricing_entries_are_not_collapsed_to_the_base_model() {
     for model in ["gpt-5.1-codex-max", "gpt-5.1-codex-mini"] {
         assert_eq!(CostUsagePricing::normalize_codex_model(model), model);


### PR DESCRIPTION
Fixes #413

GPT-6 Astra tokens scan fine from Codex logs but were missing from the built-in pricing table, so the Charts page showed $0.00 with "0% of tokens priced". This adds the model at OpenAI's published standard rates: $10 input / $1 cached input / $50 output per 1M tokens.

Details:

- Codex usage of Astra does not incur the >272K long-context multipliers and Codex does not charge cache writes, so the entry has no long_context rates (short-context rates apply at every context size).
- Bare `gpt-6` normalizes to `gpt-6-astra`, matching the existing `gpt-5.6` to `gpt-5.6-sol` pattern. Date-suffixed and `-codex` variants already resolve through existing logic.
- Added a regression test covering variant normalization and the published rates.

Commands run: `cargo test --manifest-path rust/Cargo.toml` (1186 passed), `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` (617 passed), `cargo fmt --all`. Clippy is clean for the touched files; the two existing `-D warnings` failures are pre-existing on clean main (Windows-gated code that is dead on Linux).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `gpt-6-astra` pricing and alias `gpt-6` to it in `CODEX_PRICING`
> - Adds a `gpt-6-astra` entry to `CODEX_PRICING` at $10/M input, $50/M output, and $1/M cached-input tokens, with no long-context rate override.
> - `CostUsagePricing::normalize_codex_model` now maps the exact name `gpt-6` to the canonical key `gpt-6-astra`, so the alias and dated/Codex-suffixed Astra variants resolve to the new rates.
> - Adds tests covering canonical, dated, Codex-suffixed, and `gpt-6` alias normalization, plus cached and long-context cost assertions.
> - Behavioral Change: `gpt-6` and Astra variants now resolve to `gpt-6-astra` pricing in `cost_pricing.rs`; review `normalize_codex_model` and the `gpt-6-astra` table entry to confirm rates and alias handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79c1041.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pricing support for the GPT-6 Astra model, including standard input, output, and cached-input rates.
  - Added recognition of the `gpt-6` model alias and related model identifiers.

- **Bug Fixes**
  - Ensured extended input lengths use the correct standard pricing when no long-context rates apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->