### PR TITLE
Fix Linux-only clippy warnings

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/powertoys.rs
+++ b/apps/desktop-tauri/src-tauri/src/powertoys.rs
@@ -1,4 +1,5 @@
 use std::sync::Mutex;
+#[cfg(windows)]
 use std::time::Duration;
 
 use chrono::Utc;

--- a/rust/src/secure_file.rs
+++ b/rust/src/secure_file.rs
@@ -821,12 +821,12 @@ fn is_sharing_or_access_failure(win32_code: u32) -> bool {
 }
 
 fn keep_replacement_temp(result: &io::Result<()>, dest: &Path) -> bool {
-    let Err(error) = result else {
+    let Err(_error) = result else {
         return false;
     };
     #[cfg(windows)]
     {
-        if let Some(raw) = error.raw_os_error() {
+        if let Some(raw) = _error.raw_os_error() {
             return keep_temp_after_replace_failure(raw as u32, dest.exists());
         }
         !dest.exists()

--- a/rust/src/updater.rs
+++ b/rust/src/updater.rs
@@ -511,6 +511,7 @@ pub fn verify_installer_signature(file_path: &Path) -> Result<(), String> {
     }
 }
 
+#[cfg(windows)]
 fn verify_installer_signature_or_delete(file_path: &Path) -> Result<(), String> {
     match verify_installer_signature(file_path) {
         Ok(()) => Ok(()),


### PR DESCRIPTION
The three warnings that made `cargo clippy --all-targets -- -D warnings` fail on Linux:

- `secure_file.rs` `keep_replacement_temp`: the `error` binding is only read inside the Windows block; renamed to `_error` so the non-Windows build does not warn (the Windows block still reads it, since underscore-prefixed bindings remain usable).
- `updater.rs` `verify_installer_signature_or_delete`: its only production caller is Windows-gated, so the function is dead code on Linux. Gated it `#[cfg(windows)]`; its test was already Windows-only.
- `powertoys.rs`: gated the `std::time::Duration` import; its only use is inside `run_status_pipe`, which is `#[cfg(windows)]`.

The shared crate now passes `clippy -D warnings` on Linux. The desktop crate keeps its pre-existing Linux dead-code warnings for Windows-native modules (taskbar/powertoys structs), which are inherent to the platform-gated design and unchanged; Windows CI remains the clippy gate there.

## Validation

- `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` passes on Linux.
- Shared tests 1,261 passed; desktop tests 629 passed. `cargo fmt --all --check` clean.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Linux-only clippy warnings with Windows-only conditional compilation
> - Guards the `Duration` import in [powertoys.rs](https://github.com/tsouth89/ceiling/pull/418/files#diff-75b47798b63b2f031cfefac8ec161709b0879f44f384c934858a5cea4de9973a) with `#[cfg(windows)]` so it only compiles on Windows targets
> - Wraps the `verify_installer_signature_or_delete` helper in [updater.rs](https://github.com/tsouth89/ceiling/pull/418/files#diff-32effa7ba420767f3b1716c2671216a59b23cb17b65db8d75fb44b1d09abc902) in `#[cfg(windows)]` to exclude it from Linux builds
> - Renames the unused error binding in `keep_replacement_temp` in [secure_file.rs](https://github.com/tsouth89/ceiling/pull/418/files#diff-ad931c0d6c98745631dc7a8420f5f246909a8c5b9f80d9987e7f76df43b3e157) to `_e` and adjusts its Windows-only references
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e926190.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->