### PR TITLE
Drop the Dependabot npm ecosystem for the pnpm workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,9 @@ updates:
     schedule:
       interval: weekly
 
-  - package-ecosystem: npm
-    directory: /apps/desktop-tauri
-    schedule:
-      interval: weekly
-
+  # Frontend dependencies use pnpm, which Dependabot's npm updater cannot
+  # read here: every update run fails against pnpm-lock.yaml. Bump those
+  # dependencies manually instead (e.g. the browserslist security bump).
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
`apps/desktop-tauri` is a pnpm workspace, and Dependabot's npm updater cannot operate against pnpm-lock.yaml: every scheduled run fails (the recurring "npm_and_yarn in /apps/desktop-tauri ... failure" entries on main, most recently for browserslist). Frontend dependency bumps are handled manually instead, like the recent browserslist security bump (#417) which Dependabot never managed to open.

Removes the npm ecosystem block; cargo and github-actions updates are unchanged.

## Validation

Config-only change; no code. Dependabot's next scheduled run should stop emitting the failing npm update job.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove Dependabot npm updater for `/apps/desktop-tauri`
> The frontend workspace uses pnpm, so the Dependabot npm updater cannot process the lockfile. Removes the npm ecosystem entry from [dependabot.yml](https://github.com/tsouth89/ceiling/pull/419/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28) and leaves a comment that frontend dependencies must be bumped manually. The Cargo and GitHub Actions updaters are unchanged.
> - Risk: npm dependency updates for `/apps/desktop-tauri` are no longer automated; manual bumps are now required.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fdec35f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->