### PR TITLE
Correct the winget identity in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,17 +60,22 @@
 
 ## Release & Winget Notes
 - Treat Winget updates as a normal release step after GitHub release artifacts are stable.
-- Winget does not track "latest" GitHub releases; every version needs its own immutable manifest folder in
-  `microsoft/winget-pkgs`, for example `manifests/f/Finesssee/Win-CodexBar/0.23.6/`.
+- Ceiling's Winget identity is `tsouth89.Ceiling`, with manifest folders under
+  `microsoft/winget-pkgs/manifests/t/tsouth89/Ceiling/`. Do not confuse it with `Finesssee.Win-CodexBar`,
+  which tracks a different project (`nesszer/Win-CodexBar`) despite the shared lineage.
+- Winget does not track "latest" GitHub releases; every version needs its own immutable manifest folder,
+  for example `manifests/t/tsouth89/Ceiling/1.5.37/`.
 - For routine version bumps, copy the previous approved manifest folder and change only version-specific fields:
-  `PackageVersion`, `InstallerUrl`, `InstallerSha256`, `DisplayName`, `DisplayVersion`, `ReleaseNotes`, and
-  `ReleaseNotesUrl`.
+  `PackageVersion`, `InstallerUrl`, `InstallerSha256`, `DisplayName`, `DisplayVersion`, `ReleaseDate`,
+  `ReleaseNotes`, and `ReleaseNotesUrl`.
 - Keep stable package identity and installer behavior unchanged unless there is a real packaging reason:
   `PackageIdentifier`, `InstallerType`, `Scope`, `ProductCode`, `Publisher`, package URLs, and silent install behavior.
 - Before opening a Winget PR, verify the release installer URL resolves and recompute the SHA-256 from the downloaded
-  asset. On Windows, run `winget validate` when available.
-- The first Winget package submission was approved in `microsoft/winget-pkgs#366653`; the v0.23.5 update was approved
-  in `microsoft/winget-pkgs#366794`. Future updates should be faster, but still expect Microsoft validation/review.
+  asset (the release's `.sha256` sidecar is a convenient cross-check). On Windows, run `winget validate` when available;
+  from Linux note the skip in the PR body.
+- Package history: the package was first approved as `microsoft/winget-pkgs#411757` (1.5.22), and recent updates
+  shipped as `#414311` (1.5.25), `#416061` (1.5.29), and `#423050` (1.5.36). Expect Microsoft validation/review lag
+  on every update.
 
 ## Agent Notes
 - The default desktop app is the Tauri shell in `apps/desktop-tauri/`. The Rust crate owns shared backend logic


### PR DESCRIPTION
The winget section pointed at `Finesssee.Win-CodexBar` manifest paths (`manifests/f/...`, first approval #366653, v0.23.x history), but that identity tracks a different repo (`nesszer/Win-CodexBar`). Ceiling's actual identity is `tsouth89.Ceiling` with folders under `manifests/t/tsouth89/Ceiling/` (first approved as #411757 at 1.5.22; 1.5.36 shipped as #423050, and 1.5.37 is pending as #431068).

Rewrites the section with the correct identity and history so the next release does not chase the wrong manifest folder. Also notes that `winget validate` is Windows-only and the skip should be recorded in the PR body from Linux.

## Validation

Docs-only change; no code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix winget package identity in `AGENTS.md`
> Updates the winget guidance in [AGENTS.md](https://github.com/tsouth89/ceiling/pull/420/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) to identify the package as `tsouth89.Ceiling` with the correct `microsoft/winget-pkgs/manifests/t/tsouth89/Ceiling/` manifest path, and clarifies it is distinct from `Finesssee.Win-CodexBar`. Also updates the example version to 1.5.37, adds `ReleaseDate` to the version-specific fields, documents SHA-256 sidecar verification and the Linux validation limitation, and refreshes the approval history to versions 1.5.22, 1.5.25, 1.5.29, and 1.5.36. Documentation-only change with no runtime impact.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ccbdfa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->