### PR TITLE
Size the taskbar flyout to its content

### DIFF
--- a/apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx
+++ b/apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx
@@ -31,6 +31,12 @@ import {
 } from "../lib/providerRow";
 
 const FLYOUT_WIDTH = 344;
+// Mirrors `FLYOUT_INITIAL_HEIGHT` in `shell/flyout_window.rs`. Used only when
+// the section has no layout to measure yet — never as a floor. Everything
+// outside `.taskbar-flyout` is transparent, so a window taller than the section
+// shows the desktop as a bare strip under the footer: header + one Unavailable
+// row + footer measures 163px, which the old `Math.max(174, …)` padded to 174.
+const FLYOUT_FALLBACK_HEIGHT = 174;
 const MAX_VISIBLE_PROVIDERS = 6;
 const MAX_VISIBLE_WINDOWS_PER_PROVIDER = 4;
 
@@ -359,7 +365,8 @@ export default function TaskbarFlyout({ state }: { state: BootstrapState }) {
         frame = null;
       // Windows owns the rounded outer edge; size directly to the content so
       // no transparent or CSS-border gutter can appear around that shape.
-      const height = Math.max(174, Math.ceil(surfaceRef.current?.scrollHeight ?? 174));
+      const measured = Math.ceil(surfaceRef.current?.scrollHeight ?? 0);
+      const height = measured > 0 ? measured : FLYOUT_FALLBACK_HEIGHT;
       void (async () => {
         await getCurrentWindow().setSize(new LogicalSize(FLYOUT_WIDTH, height)).catch(() => {});
         await reanchorTrayPanel().catch(() => {});


### PR DESCRIPTION
While working on the repo my Claude auth got logged out, and I caught this visual bug in the taskbar-widget flyout: a bare strip of desktop showing under the "Open Ceiling" row.

## Summary

The native taskbar-widget flyout (TaskbarFlyout.tsx) sized its window with Math.max(174, section.scrollHeight). Everything outside the .taskbar-flyout section is transparent (html, body, #root and .taskbar-flyout-frame are all background: transparent !important), so whenever the content measured under 174px the extra window height showed the desktop as a bare strip under the "Open Ceiling" row.

The shortest real layout hits it: header (52px) + providers padding (8px) + one Unavailable row (58px) + footer (43px) = 163px — i.e. exactly one provider whose last sync failed, which is what a signed-out Claude looks like. As soon as the row grows meters the content passes 174 and the strip vanishes, which is why it's easy to miss.

This drops the floor and sizes the window to the measured section. 174 stays only as a fallback for the no-layout case (matching FLYOUT_INITIAL_HEIGHT in shell/flyout_window.rs, which is unchanged) and can never inflate a real measurement.

## Related issue

None — caught while working on the repo.

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [x] Other: native taskbar-widget flyout (apps/desktop-tauri/src/surfaces/TaskbarFlyout.tsx) — window sizing only. The TrayPanel surface is untouched (see reviewer notes).

## Validation

- [x] powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -Frontend — Frontend tests: 93 files / 741 tests passed; Frontend build: ✓ built; "Local checks passed."
- [ ] Rust / Tauri Rust tests, format, clippy — not run: the change is a single .tsx file, no Rust touched.
- [ ] For full pre-release validation — not a release.
- [ ] For installer/release changes — no packaging changes.
- [x] Other:
  - npx vitest run src/surfaces/TaskbarFlyout — 13/13; npx tsc --noEmit — clean.
  - Live check in the real app (pnpm tauri dev), reproducing the signed-out state deterministically: CLAUDE_CONFIG_DIR pointed at an empty directory and HTTPS_PROXY=http://127.0.0.1:9 so the Claude sync fails with "Last sync failed". Opened the widget flyout and pixel-scanned the capture: panel rows y49–211, window ends at y211, drop shadow from y212 — no un-tinted strip. Same build with the change stashed via Vite HMR: window 183px outer vs 172px after (Tao adds an 8px invisible bottom border; the panel is 163px in both).

## UI / tray proof

- [ ] Not applicable
- [x] Visual proof attached
- [ ] Visual proof was not practical; manual validation and explanation attached

Before (strip under the footer is the desktop showing through the window):

<img width="480" height="340" alt="flyout-strip-before" src="https://github.com/user-attachments/assets/c1458f09-cf60-4552-8075-65795bbcde46" />


After (window ends at the panel; what's below is the window's drop shadow on the wallpaper):

<img width="480" height="340" alt="flyout-strip-after" src="https://github.com/user-attachments/assets/d6c624d6-a218-44b6-9562-f3b235dc08ac" />


## Notes for reviewers

- The diff is the floor removal plus a named fallback constant; nothing else changes. The fallback only applies when surfaceRef has no layout (scrollHeight is 0 or the ref is null), which doesn't happen after mount — the resize effect already waits for hasLoadedCache || visibleProviders.length > 0, and the window is built .visible(false) and revealed only after the first resize, so there is no visible frame at the fallback size.
- I checked whether TrayPanel has the same problem, since useTrayPanelLayout also floors the window (TRAY_OVERVIEW_MIN_HEIGHT = 200) over a height: auto surface and only the dense / user-sized modes stretch it with min-height: 100vh. It doesn't bite in practice: with one provider in an error state and no update banner the surface measures ~305px (window 311px outer), because the provider-grid row plus the five footer rows are ~200px of fixed chrome on their own. That surface also has no user-facing producer any more — only CODEXBAR_PROOF_MODE=trayPanel enters it. So no change there. If it ever gets a shorter layout, the one-line fix is min-height: 100vh on .menu-surface--tray (folding the dense rule into it); the measure pass already zeroes min-height inline, so it can't inflate the measurement, at the cost of the ResizeObserver re-firing each pass on short content — the same idle loop dense mode runs today.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Size `TaskbarFlyout` component to its measured content
> Updates the resize effect in [TaskbarFlyout.tsx](https://github.com/tsouth89/ceiling/pull/439/files#diff-ddcd8ce2c2d236793141f2b1aad25945e386880bb391eb9c5aee90179b0de1b9) to use the measured scroll height when it is positive. Adds the `FLYOUT_FALLBACK_HEIGHT` constant (174px) and applies it only when the content cannot be measured or has zero height. Removes the previous unconditional 174px minimum height, allowing the flyout to shrink below 174px when content is smaller.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48cd298.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Taskbar flyouts now resize to match their content more precisely.
  * Removed unnecessary extra vertical space when flyout content is shorter than the previous minimum height.
  * Flyouts retain a fallback height while content is still being measured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->